### PR TITLE
Add previous and next day navigation

### DIFF
--- a/fredagskoll-frontend/src/App.css
+++ b/fredagskoll-frontend/src/App.css
@@ -503,6 +503,38 @@
   min-width: 0;
 }
 
+.card-nav {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: start;
+}
+
+.card-nav-button {
+  border: 0;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  padding: 0.72rem 1rem;
+  font-size: 0.88rem;
+  font-weight: 800;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+  transition:
+    background-color 220ms ease,
+    color 220ms ease,
+    filter 220ms ease,
+    transform 220ms ease;
+}
+
+.card-nav-button:hover {
+  filter: brightness(0.96);
+}
+
+.card-nav-button:active {
+  transform: translateY(1px);
+}
+
 .celebration-title {
   font-size: clamp(2.7rem, 4.9vw, 4.85rem);
   max-width: 10.5ch;
@@ -743,6 +775,14 @@
   .celebration-card {
     padding: 1.25rem;
     border-radius: 24px;
+  }
+
+  .card-nav {
+    flex-direction: column;
+  }
+
+  .card-nav-button {
+    width: 100%;
   }
 
   .theme-toggle {

--- a/fredagskoll-frontend/src/App.test.tsx
+++ b/fredagskoll-frontend/src/App.test.tsx
@@ -258,3 +258,29 @@ test('rerolls the excuse when clicking Ny ursäkt', async () => {
 
   randomSpy.mockRestore();
 });
+
+test('steps between days from the center navigation buttons', async () => {
+  await renderAppAt(new Date(2026, 2, 25));
+
+  expect(
+    screen.getByRole('heading', { level: 2, name: /Våffeldagen har tagit över/i })
+  ).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: /Föregående dag/i }));
+
+  await waitFor(() =>
+    expect(screen.getByDisplayValue('2026-03-24')).toBeInTheDocument()
+  );
+  expect(
+    screen.queryByRole('heading', { level: 2, name: /Våffeldagen har tagit över/i })
+  ).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: /Nästa dag/i }));
+
+  await waitFor(() =>
+    expect(screen.getByDisplayValue('2026-03-25')).toBeInTheDocument()
+  );
+  expect(
+    screen.getByRole('heading', { level: 2, name: /Våffeldagen har tagit över/i })
+  ).toBeInTheDocument();
+});

--- a/fredagskoll-frontend/src/App.tsx
+++ b/fredagskoll-frontend/src/App.tsx
@@ -72,6 +72,12 @@ function getDaysUntil(date: Date, target: Date): number {
   return Math.round((target.getTime() - date.getTime()) / millisecondsPerDay);
 }
 
+function addDays(date: Date, days: number): Date {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+}
+
 function getUpcomingHolidayBlurb(holidayName: string, daysUntil: number): string {
   if (daysUntil <= 1) {
     return `${holidayName} väntar imorgon, så veckan är i praktiken redan perforerad.`;
@@ -226,6 +232,10 @@ function App({ initialDate = new Date() }: AppProps) {
     };
   }, [dayStatus.dateLabel]);
 
+  function stepSelectedDate(days: number): void {
+    setSelectedDate(formatForInput(addDays(selectedDateObject, days)));
+  }
+
   return (
     <div className={`App ${darkMode ? 'dark' : ''} theme-${theme}`}>
       <div className="app-backdrop" aria-hidden="true" />
@@ -342,6 +352,22 @@ function App({ initialDate = new Date() }: AppProps) {
         </header>
 
         <main className="app-panel celebration-card">
+          <div className="card-nav" aria-label="Datumnavigering">
+            <button
+              type="button"
+              className="card-nav-button"
+              onClick={() => stepSelectedDate(-1)}
+            >
+              Föregående dag
+            </button>
+            <button
+              type="button"
+              className="card-nav-button"
+              onClick={() => stepSelectedDate(1)}
+            >
+              Nästa dag
+            </button>
+          </div>
           <p className="eyebrow">{kicker}</p>
           <h2 className="celebration-title">{formatTitle(mainTitle)}</h2>
           <div className="blurb-row">


### PR DESCRIPTION
## What changed
- added previous and next day buttons to the top corners of the center card
- wired the buttons into the existing selected-date state used by the date picker
- added a test covering backward and forward date stepping

## Verification
- npm test -- --runInBand --watchAll=false
- npm run build