### PR TITLE
Fix overflowing celebration titles

### DIFF
--- a/fredagskoll-frontend/src/App.css
+++ b/fredagskoll-frontend/src/App.css
@@ -110,9 +110,11 @@
 .app-grid {
   min-height: 100vh;
   display: grid;
-  grid-template-columns: minmax(280px, 330px) minmax(0, 870px);
-  gap: 3.4rem;
+  grid-template-columns: minmax(280px, 330px) minmax(0, 1fr);
+  gap: clamp(1.5rem, 3vw, 3.4rem);
   padding: 2rem;
+  max-width: 1320px;
+  margin: 0 auto;
   align-items: stretch;
   position: relative;
   z-index: 1;
@@ -542,6 +544,15 @@
   overflow-wrap: normal;
   hyphens: manual;
   text-wrap: pretty;
+}
+
+.celebration-title--longword {
+  font-size: clamp(1.95rem, 3.9vw, 3.2rem);
+  max-width: none;
+  line-height: 0.92;
+  overflow-wrap: normal;
+  word-break: normal;
+  hyphens: manual;
 }
 
 .media-grid {

--- a/fredagskoll-frontend/src/App.tsx
+++ b/fredagskoll-frontend/src/App.tsx
@@ -68,6 +68,12 @@ function formatTitle(title: string): string {
   return title.replaceAll('. ', '.\n');
 }
 
+function hasLongTitleWord(title: string): boolean {
+  return title
+    .split(/\s+/)
+    .some((word) => word.replace(/[^\p{L}\p{N}-]/gu, '').length >= 18);
+}
+
 function hasOrdinaryWeekdayExcuses(date: Date, dayType: DayType): boolean {
   if (dayType !== 'ordinary') {
     return false;
@@ -204,6 +210,7 @@ function App({ initialDate = new Date() }: AppProps) {
     : hasThemeDays
       ? `${visibleThemeDays[0]}. Det får väl räcka.`
       : 'En vanlig dag. Så sorgligt är det.';
+  const hasLongWordTitle = hasLongTitleWord(mainTitle);
 
   useEffect(() => {
     if (!currentBlurbs) {
@@ -379,7 +386,13 @@ function App({ initialDate = new Date() }: AppProps) {
             </button>
           </div>
           <p className="eyebrow">{kicker}</p>
-          <h2 className="celebration-title">{formatTitle(mainTitle)}</h2>
+          <h2
+            className={`celebration-title${
+              hasLongWordTitle ? ' celebration-title--longword' : ''
+            }`}
+          >
+            {formatTitle(mainTitle)}
+          </h2>
           <div className="blurb-row">
             <p className="celebration-blurb">{blurb}</p>
             {currentBlurbs ? (


### PR DESCRIPTION
## What changed
- let the main content column shrink properly within the viewport
- added targeted handling for very long celebration titles like Surströmmingspremiär instead of globally chopping all titles

## Verification
- npm run build