### PR TITLE
Show selected date in day navigation

### DIFF
--- a/fredagskoll-frontend/src/App.css
+++ b/fredagskoll-frontend/src/App.css
@@ -506,10 +506,20 @@
 }
 
 .card-nav {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   gap: 1rem;
-  align-items: start;
+  align-items: center;
+}
+
+.card-date {
+  margin: 0;
+  text-align: center;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: var(--text);
+  text-transform: lowercase;
 }
 
 .card-nav-button {
@@ -789,11 +799,16 @@
   }
 
   .card-nav {
-    flex-direction: column;
+    grid-template-columns: 1fr;
   }
 
   .card-nav-button {
     width: 100%;
+  }
+
+  .card-date {
+    order: -1;
+    font-size: 0.94rem;
   }
 
   .theme-toggle {

--- a/fredagskoll-frontend/src/App.tsx
+++ b/fredagskoll-frontend/src/App.tsx
@@ -49,6 +49,28 @@ function formatShortSwedishDate(date: Date): string {
   }).format(date);
 }
 
+function getSwedishOrdinalDay(day: number): string {
+  const tens = day % 100;
+  const ones = day % 10;
+
+  if (tens !== 11 && (ones === 1 || ones === 2)) {
+    return `${day}:a`;
+  }
+
+  return `${day}:e`;
+}
+
+function formatCenterDate(date: Date): string {
+  const weekday = new Intl.DateTimeFormat('sv-SE', {
+    weekday: 'long',
+  }).format(date);
+  const month = new Intl.DateTimeFormat('sv-SE', {
+    month: 'long',
+  }).format(date);
+
+  return `${weekday} ${getSwedishOrdinalDay(date.getDate())} ${month}`;
+}
+
 function getRandomItem(options: string[], current?: string): string {
   if (options.length === 0) {
     return ordinaryBlurb;
@@ -169,6 +191,7 @@ function App({ initialDate = new Date() }: AppProps) {
   }, [celebration, dayStatus.dayType, themeDays]);
   const hasThemeDays = visibleThemeDays.length > 0;
   const humanDate = formatForHumans(selectedDateObject);
+  const centerDate = formatCenterDate(selectedDateObject);
   const upcomingHoliday = getUpcomingOfficialHolidayInWeek(selectedDateObject);
   const daysUntilHoliday = upcomingHoliday
     ? getDaysUntil(selectedDateObject, upcomingHoliday.date)
@@ -377,6 +400,7 @@ function App({ initialDate = new Date() }: AppProps) {
             >
               Föregående dag
             </button>
+            <p className="card-date">{centerDate}</p>
             <button
               type="button"
               className="card-nav-button"


### PR DESCRIPTION
## What changed
- added the selected date between Föregående dag and Nästa dag in the center card
- formatted the label as Swedish ordinal date text, for example `måndag 24:e november`
- kept the mobile layout readable by stacking the navigation cleanly

## Verification
- npm run build