### PR TITLE
Widen ordinary themeday title layout

### DIFF
--- a/fredagskoll-frontend/src/App.css
+++ b/fredagskoll-frontend/src/App.css
@@ -557,7 +557,7 @@
 }
 
 .celebration-title--stacked {
-  max-width: 11.5ch;
+  max-width: 13.5ch;
 }
 
 .celebration-title-subline {


### PR DESCRIPTION
## What changed
- widened the stacked ordinary-themeday title constraint so the heading uses more of the available space to the right

## Verification
- npm run build