### PR TITLE
Add seasonal context and refresh supporting copy

### DIFF
--- a/fredagskoll-frontend/src/App.css
+++ b/fredagskoll-frontend/src/App.css
@@ -311,6 +311,23 @@
   background: rgba(255, 255, 255, 0.05);
 }
 
+.season-card {
+  display: grid;
+  gap: 0.8rem;
+  padding: 1rem;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.34);
+  border: 1px solid var(--panel-border);
+  min-width: 0;
+  transition:
+    background-color 260ms ease,
+    border-color 260ms ease;
+}
+
+.App.dark .season-card {
+  background: rgba(255, 255, 255, 0.05);
+}
+
 .upcoming-card {
   display: grid;
   gap: 0.8rem;
@@ -358,6 +375,66 @@
 .upcoming-list {
   display: grid;
   gap: 0.85rem;
+}
+
+.season-list {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.season-item {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.9rem 0.95rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.4);
+  border: 1px solid var(--panel-border);
+}
+
+.App.dark .season-item {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.season-item-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.season-label,
+.season-meta {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  padding: 0.26rem 0.58rem;
+  border-radius: 999px;
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.season-label {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.season-meta {
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.App.dark .season-meta {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.season-title {
+  margin: 0;
+  font-weight: 800;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
 }
 
 .upcoming-item {

--- a/fredagskoll-frontend/src/App.test.tsx
+++ b/fredagskoll-frontend/src/App.test.tsx
@@ -282,6 +282,30 @@ test('renders upcoming notable dates with major celebrations ahead of random fil
   expect(screen.getAllByText(/Om 3 dagar/i).length).toBeGreaterThan(0);
 });
 
+test('renders bokrean as a seasonal sidebar note during the sale window', async () => {
+  await renderAppAt(new Date(2026, 1, 24));
+
+  expect(screen.getAllByText(/Säsongen pågår/i).length).toBeGreaterThan(0);
+  expect(screen.getByText(/^Bokrean$/i)).toBeInTheDocument();
+  expect(
+    screen.getByText(
+      /Papper, impulsköp och den gamla svenska drömmen om att man plötsligt ska bli en människa som läser mer\./i
+    )
+  ).toBeInTheDocument();
+});
+
+test('renders kräftskivesäsong as a seasonal sidebar note during late summer', async () => {
+  await renderAppAt(new Date(2026, 7, 20));
+
+  expect(screen.getAllByText(/Säsongen pågår/i).length).toBeGreaterThan(0);
+  expect(screen.getByText(/^Kräftskivesäsong$/i)).toBeInTheDocument();
+  expect(
+    screen.getByText(
+      /Pappershattar, dill och ett kollektivt beslut att små kräftor tydligen är en fullgod plan för sensommaren\./i
+    )
+  ).toBeInTheDocument();
+});
+
 test('rerolls the excuse when clicking Ny ursäkt', async () => {
   const randomSpy = jest
     .spyOn(Math, 'random')

--- a/fredagskoll-frontend/src/App.tsx
+++ b/fredagskoll-frontend/src/App.tsx
@@ -26,6 +26,7 @@ import {
 import { formatDaysUntilLabel, getUpcomingHolidayBlurb } from './holidayPresentation';
 import { imageCredits } from './imageCredits';
 import { fetchNameDays } from './nameDays';
+import { getSeasonalNotes } from './seasonalNotes';
 import { buildThemeDayBlurbs, filterThemeDays, joinWithAnd } from './themeDayBlurbs';
 import { getThemeDaysForDate } from './temadagar';
 import { getUpcomingNotables } from './upcomingNotables';
@@ -35,6 +36,17 @@ type AppProps = {
 };
 
 type NameDayState = 'loading' | 'ready' | 'error';
+
+const ordinaryThemeDayCardNotes = [
+  'Det är inte officiellt, men tillräckligt många har uppenbarligen bestämt sig för att göra något av det här datumet.',
+  'Kalendern får arbeta med det material den har, och idag blev det ändå förvånansvärt dugligt.',
+  'Det här är inte statsbärande direkt, men absolut tillräckligt för att spela lite större än datumet först såg ut.',
+  'Ingen regering står bakom det här, men folk har ändå visat den goda smaken att fylla dagen med något märkbart.',
+  'Det är smalt, löst sammanhållet och fullt tillräckligt för att ge datumet någon sorts ryggrad.',
+  'Officiellt är det tunt. Inofficiellt är det ändå nog för att låta dagen slippa total förnedring.',
+  'Någon tog sig tid att ge dagen innehåll, och det vore småaktigt att inte arbeta vidare på det.',
+  'Det här får duga som folkligt initiativ. Inte majestätiskt, men klart bättre än kalendermässig öken.',
+];
 
 function getRandomItem(options: string[], current?: string): string {
   if (options.length === 0) {
@@ -70,6 +82,7 @@ function App({ initialDate = new Date() }: AppProps) {
   const [themeDayTitleEnding, setThemeDayTitleEnding] = useState(
     ordinaryThemeDayTitleEndings[0]
   );
+  const [themeDayCardNote, setThemeDayCardNote] = useState(ordinaryThemeDayCardNotes[0]);
 
   const selectedDateObject = useMemo(
     () => new Date(`${selectedDate}T12:00:00`),
@@ -98,6 +111,10 @@ function App({ initialDate = new Date() }: AppProps) {
     : null;
   const upcomingNotables = useMemo(
     () => getUpcomingNotables(selectedDateObject),
+    [selectedDateObject]
+  );
+  const seasonalNotes = useMemo(
+    () => getSeasonalNotes(selectedDateObject),
     [selectedDateObject]
   );
   const theme = celebration?.theme ?? 'ordinary';
@@ -150,6 +167,15 @@ function App({ initialDate = new Date() }: AppProps) {
 
     setThemeDayTitleEnding(getRandomItem(ordinaryThemeDayTitleEndings));
   }, [selectedDate, themeDayDisplayTitle, celebration]);
+
+  useEffect(() => {
+    if (!hasThemeDays || celebration) {
+      setThemeDayCardNote(ordinaryThemeDayCardNotes[0]);
+      return;
+    }
+
+    setThemeDayCardNote(getRandomItem(ordinaryThemeDayCardNotes));
+  }, [selectedDate, hasThemeDays, celebration]);
 
   useEffect(() => {
     let isCurrent = true;
@@ -255,6 +281,24 @@ function App({ initialDate = new Date() }: AppProps) {
                 {formatDaysUntilLabel(daysUntilHoliday)} till{' '}
                 {formatShortSwedishDate(upcomingHoliday.date)}.
               </p>
+            </div>
+          ) : null}
+
+          {seasonalNotes.length > 0 ? (
+            <div className="season-card">
+              <p className="eyebrow">Säsongen pågår</p>
+              <div className="season-list">
+                {seasonalNotes.map((item) => (
+                  <article key={item.id} className="season-item">
+                    <div className="season-item-top">
+                      <span className="season-label">{item.label}</span>
+                      <span className="season-meta">{item.meta}</span>
+                    </div>
+                    <p className="season-title">{item.title}</p>
+                    <p className="nameday-text">{item.note}</p>
+                  </article>
+                ))}
+              </div>
             </div>
           ) : null}
 
@@ -417,7 +461,7 @@ function App({ initialDate = new Date() }: AppProps) {
               </span>
               <p>
                 {hasThemeDays
-                  ? `Temadagsmotorn hittade ${joinWithAnd(visibleThemeDays)}. Det är inte officiellt, men det räcker gott för att börja improvisera.`
+                  ? `Temadagsmotorn hittade ${joinWithAnd(visibleThemeDays)}. ${themeDayCardNote}`
                   : 'Datumet har kollats. Systemet fann ingen semla, ingen sill, ingen bullplikt och ingen kollektiv ursäkt för att tappa fokus.'}
               </p>
               {hasThemeDays ? (

--- a/fredagskoll-frontend/src/seasonalNotes.test.ts
+++ b/fredagskoll-frontend/src/seasonalNotes.test.ts
@@ -1,0 +1,33 @@
+import { getSeasonalNotes } from './seasonalNotes';
+
+test('shows bokrean during the late-february sale window', () => {
+  const notes = getSeasonalNotes(new Date(2026, 1, 24));
+
+  expect(notes).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        id: 'bokrean',
+        title: 'Bokrean',
+      }),
+    ])
+  );
+});
+
+test('shows kräftskivesäsong during late summer', () => {
+  const notes = getSeasonalNotes(new Date(2026, 7, 20));
+
+  expect(notes).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        id: 'kraftskiva',
+        title: 'Kräftskivesäsong',
+      }),
+    ])
+  );
+});
+
+test('does not show seasonal notes outside their windows', () => {
+  const notes = getSeasonalNotes(new Date(2026, 5, 10));
+
+  expect(notes).toHaveLength(0);
+});

--- a/fredagskoll-frontend/src/seasonalNotes.ts
+++ b/fredagskoll-frontend/src/seasonalNotes.ts
@@ -1,0 +1,160 @@
+import { getFettisdag } from './dayLogic';
+
+export interface SeasonalNote {
+  id: string;
+  label: string;
+  title: string;
+  note: string;
+  meta: string;
+}
+
+type SeasonalWindow = SeasonalNote & {
+  start: Date;
+  end: Date;
+  priority: number;
+};
+
+function toDateOnly(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function addDays(date: Date, days: number): Date {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return toDateOnly(result);
+}
+
+function isWithinRange(date: Date, start: Date, end: Date): boolean {
+  const value = toDateOnly(date).getTime();
+  return value >= toDateOnly(start).getTime() && value <= toDateOnly(end).getTime();
+}
+
+function formatShortDate(date: Date): string {
+  return new Intl.DateTimeFormat('sv-SE', {
+    day: 'numeric',
+    month: 'long',
+  }).format(date);
+}
+
+function getLastWeekdayOfMonth(year: number, month: number, weekday: number): Date {
+  const date = new Date(year, month + 1, 0);
+
+  while (date.getDay() !== weekday) {
+    date.setDate(date.getDate() - 1);
+  }
+
+  return toDateOnly(date);
+}
+
+function buildSeasonalWindows(year: number): SeasonalWindow[] {
+  const fettisdag = getFettisdag(year);
+  const bokreanStart = getLastWeekdayOfMonth(year, 1, 2);
+  const bokreanEnd = addDays(bokreanStart, 13);
+  const blackWeekStart = new Date(year, 10, 23);
+  const blackWeekEnd = new Date(year, 10, 30);
+
+  return [
+    {
+      id: 'semmelsasongen',
+      label: 'Säsong',
+      title: 'Semmelsäsongen',
+      note: 'Bagerihyllorna har tappat all återhållsamhet och hela landet låtsas att grädde är en rimlig vinterstrategi.',
+      meta: `${formatShortDate(new Date(year, 0, 2))}-${formatShortDate(fettisdag)}`,
+      start: new Date(year, 0, 2),
+      end: fettisdag,
+      priority: 90,
+    },
+    {
+      id: 'bokrean',
+      label: 'Säsong',
+      title: 'Bokrean',
+      note: 'Papper, impulsköp och den gamla svenska drömmen om att man plötsligt ska bli en människa som läser mer.',
+      meta: `${formatShortDate(bokreanStart)}-${formatShortDate(bokreanEnd)}`,
+      start: bokreanStart,
+      end: bokreanEnd,
+      priority: 100,
+    },
+    {
+      id: 'prideveckor',
+      label: 'Säsong',
+      title: 'Pride-veckor',
+      note: 'Regnbågar, gemenskap och ett ovanligt välgrundat motstånd mot att vara tråkig i onödan.',
+      meta: `${formatShortDate(new Date(year, 6, 20))}-${formatShortDate(new Date(year, 7, 10))}`,
+      start: new Date(year, 6, 20),
+      end: new Date(year, 7, 10),
+      priority: 60,
+    },
+    {
+      id: 'kraftskiva',
+      label: 'Säsong',
+      title: 'Kräftskivesäsong',
+      note: 'Pappershattar, dill och ett kollektivt beslut att små kräftor tydligen är en fullgod plan för sensommaren.',
+      meta: `${formatShortDate(new Date(year, 7, 1))}-${formatShortDate(new Date(year, 8, 15))}`,
+      start: new Date(year, 7, 1),
+      end: new Date(year, 8, 15),
+      priority: 85,
+    },
+    {
+      id: 'halloween',
+      label: 'Säsong',
+      title: 'Halloween-säsong',
+      note: 'Pumpor, smågodis och ett märkligt folkligt samförstånd om att plastspindlar höjer stämningen.',
+      meta: `${formatShortDate(new Date(year, 9, 24))}-${formatShortDate(new Date(year, 10, 2))}`,
+      start: new Date(year, 9, 24),
+      end: new Date(year, 10, 2),
+      priority: 70,
+    },
+    {
+      id: 'black-week',
+      label: 'Säsong',
+      title: 'Black Week',
+      note: 'Kampanjmailer, tillfällig panik och hela handeln i ett tillstånd av svartprissatt intensitet.',
+      meta: `${formatShortDate(blackWeekStart)}-${formatShortDate(blackWeekEnd)}`,
+      start: blackWeekStart,
+      end: blackWeekEnd,
+      priority: 75,
+    },
+    {
+      id: 'julbord',
+      label: 'Säsong',
+      title: 'Julbordssäsong',
+      note: 'Sill, skinka och den årliga svenska förmågan att förvandla buffé till moralisk plikt.',
+      meta: `${formatShortDate(new Date(year, 10, 15))}-${formatShortDate(new Date(year, 11, 24))}`,
+      start: new Date(year, 10, 15),
+      end: new Date(year, 11, 24),
+      priority: 95,
+    },
+    {
+      id: 'julmarknad',
+      label: 'Säsong',
+      title: 'Julmarknadssäsong',
+      note: 'Glögg, granris och små trästånd som försöker sälja värdighet i stearinbelyst tappning.',
+      meta: `${formatShortDate(new Date(year, 10, 20))}-${formatShortDate(new Date(year, 11, 23))}`,
+      start: new Date(year, 10, 20),
+      end: new Date(year, 11, 23),
+      priority: 80,
+    },
+  ];
+}
+
+export function getSeasonalNotes(inputDate: Date, maxItems = 2): SeasonalNote[] {
+  const date = toDateOnly(inputDate);
+  const windows = buildSeasonalWindows(date.getFullYear())
+    .filter((item) => isWithinRange(date, item.start, item.end))
+    .sort((left, right) => {
+      if (right.priority !== left.priority) {
+        return right.priority - left.priority;
+      }
+
+      return left.start.getTime() - right.start.getTime();
+    })
+    .slice(0, maxItems);
+
+  return windows.map(({ id, label, title, note, meta }) => ({
+    id,
+    label,
+    title,
+    note,
+    meta,
+  }));
+}

--- a/fredagskoll-frontend/src/upcomingNotables.test.ts
+++ b/fredagskoll-frontend/src/upcomingNotables.test.ts
@@ -24,4 +24,17 @@ test('falls back to themedays when no larger celebration is near', () => {
     title: 'Internationella konsumentdagen',
     daysUntil: 1,
   });
+  expect(items[0].note).not.toMatch(
+    /Det är inte officiellt, men det är mer än kalendern brukar bjuda på\./i
+  );
+});
+
+test('does not reuse the same celebration extra-note phrasing every time', () => {
+  const items = getUpcomingNotables(new Date(2026, 3, 27), 4, 10);
+
+  expect(items[0]).toMatchObject({
+    kind: 'celebration',
+    title: 'Valborg',
+  });
+  expect(items[0].note).not.toMatch(/Dessutom pågår .* i kulissen\./i);
 });

--- a/fredagskoll-frontend/src/upcomingNotables.ts
+++ b/fredagskoll-frontend/src/upcomingNotables.ts
@@ -56,35 +56,114 @@ function getCelebrationDisplayName(dayType: Exclude<DayType, 'ordinary'>): strin
   return celebrations[dayType].title.split('.')[0];
 }
 
+function pickCopyVariant(seed: string, options: string[]): string {
+  const value = seed.split('').reduce((sum, character) => sum + character.charCodeAt(0), 0);
+  return options[value % options.length];
+}
+
+function getWaitsPhrase(daysUntil: number): string {
+  return daysUntil === 1 ? 'väntar i morgon' : `väntar om ${daysUntil} dagar`;
+}
+
+function getArrivesPhrase(daysUntil: number): string {
+  return daysUntil === 1 ? 'dyker upp i morgon' : `dyker upp om ${daysUntil} dagar`;
+}
+
+function getComesPhrase(daysUntil: number): string {
+  return daysUntil === 1 ? 'kommer i morgon' : `kommer om ${daysUntil} dagar`;
+}
+
+function getLiesAheadPhrase(daysUntil: number): string {
+  return daysUntil === 1 ? 'ligger i morgon' : `ligger ${daysUntil} dagar bort`;
+}
+
 function getUpcomingNote(
   kind: UpcomingNotableKind,
   title: string,
   daysUntil: number,
   extras: string[]
 ): string {
-  const timing = daysUntil === 1 ? 'i morgon' : `om ${daysUntil} dagar`;
+  const waitsPhrase = getWaitsPhrase(daysUntil);
+  const arrivesPhrase = getArrivesPhrase(daysUntil);
+  const comesPhrase = getComesPhrase(daysUntil);
+  const liesAheadPhrase = getLiesAheadPhrase(daysUntil);
 
   if (kind === 'holiday') {
     if (extras.length > 0) {
-      return `${title} dyker upp ${timing}, och ${joinWithAnd(
-        extras
-      ).toLowerCase()} skramlar med på köpet.`;
+      return pickCopyVariant(`${title}-${daysUntil}-holiday-extras`, [
+        `${title} ${arrivesPhrase}, och ${joinWithAnd(
+          extras
+        ).toLowerCase()} skramlar med på köpet.`,
+        `${title} ${waitsPhrase}. Som bonus har även ${joinWithAnd(
+          extras
+        ).toLowerCase()} lyckats klämma sig in i samma datum.`,
+        `${title} ${comesPhrase}, och ${joinWithAnd(
+          extras
+        ).toLowerCase()} hänger på som ett märkligt litet förband.`,
+        `${title} ${liesAheadPhrase}. Samtidigt vägrar ${joinWithAnd(
+          extras
+        ).toLowerCase()} att hålla en låg profil.`,
+      ]);
     }
 
-    return `${title} dyker upp ${timing}, så veckan har åtminstone ett officiellt alibi på väg.`;
+    return `${title} ${arrivesPhrase}, så veckan har åtminstone ett officiellt alibi på väg.`;
   }
 
   if (kind === 'celebration') {
     if (extras.length > 0) {
-      return `${title} väntar ${timing}. Dessutom pågår ${joinWithAnd(
-        extras
-      ).toLowerCase()} i kulissen.`;
+      return pickCopyVariant(`${title}-${daysUntil}-celebration-extras`, [
+        `${title} ${waitsPhrase}. Samtidigt smyger ${joinWithAnd(
+          extras
+        ).toLowerCase()} runt i bakgrunden och vill också bli sedd.`,
+        `${title} ${arrivesPhrase}, och ${joinWithAnd(
+          extras
+        ).toLowerCase()} tänker tydligen inte stå tyst bredvid.`,
+        `${title} ${comesPhrase}. Som vanligt räckte inte det, så ${joinWithAnd(
+          extras
+        ).toLowerCase()} har också lagt sig i.`,
+        `${title} ${liesAheadPhrase}, medan ${joinWithAnd(
+          extras
+        ).toLowerCase()} fladdrar runt som bonusmaterial ingen bett om men ändå får.`,
+        `${title} ${waitsPhrase}, och ${joinWithAnd(
+          extras
+        ).toLowerCase()} står redan där och fingrar på ridån.`,
+        `${title} ${comesPhrase}. Dessutom har ${joinWithAnd(
+          extras
+        ).toLowerCase()} bestämt sig för att dela strålkastaren.`,
+      ]);
     }
 
-    return `${title} väntar ${timing}, vilket ändå är bättre än att blicka rakt in i rå vardag.`;
+    return pickCopyVariant(`${title}-${daysUntil}-celebration`, [
+      `${title} ${waitsPhrase}, vilket ändå är bättre än att blicka rakt in i rå vardag.`,
+      `${title} ${arrivesPhrase}, och veckan får därmed något som åtminstone liknar personlighet.`,
+      `${title} ${comesPhrase}. Det är inte storslaget kanske, men det slår absolut kalendermässigt dödläge.`,
+      `${title} ${liesAheadPhrase}, vilket räcker för att hela veckan ska kännas marginellt mindre grå.`,
+    ]);
   }
 
-  return `${title} väntar ${timing}. Det är inte officiellt, men det är mer än kalendern brukar bjuda på.`;
+  if (extras.length > 0) {
+    return pickCopyVariant(`${title}-${daysUntil}-extras`, [
+      `${title} ${waitsPhrase}, och ${joinWithAnd(extras).toLowerCase()} klamrar sig också fast vid datumet.`,
+      `${title} ${arrivesPhrase}. Dessutom lyckades ${joinWithAnd(
+        extras
+      ).toLowerCase()} få plats i samma lilla kalenderspricka.`,
+      `${title} ${liesAheadPhrase}, och ${joinWithAnd(
+        extras
+      ).toLowerCase()} tänker tydligen inte lämna scenen ensam.`,
+      `${title} ${comesPhrase}. Som om det inte räckte så hasar även ${joinWithAnd(
+        extras
+      ).toLowerCase()} in från sidan.`,
+    ]);
+  }
+
+  return pickCopyVariant(`${title}-${daysUntil}`, [
+    `${title} ${waitsPhrase}. Kalendern försöker åtminstone se mindre livlös ut än vanligt.`,
+    `${title} ${arrivesPhrase}, vilket är oväntat mycket personlighet för ett helt vanligt datum.`,
+    `${title} ${waitsPhrase}. Det är exakt den sortens smala värdighet man får arbeta med ibland.`,
+    `${title} ${comesPhrase}, och det är ändå mer kultur än veckan först gav sken av.`,
+    `${title} ${liesAheadPhrase}. Smalt, ja, men fortfarande märkbart bättre än total kalendertorka.`,
+    `${title} ${waitsPhrase}. Någon tog sig tid att ge datumet en egen liten nisch, och det får man respektera.`,
+  ]);
 }
 
 export function getUpcomingNotables(


### PR DESCRIPTION
## Summary
- add a compact seasonal context layer for recurring Swedish periods like bokrean and kraftskivesasong
- tighten the sidebar presentation for seasonal information
- add more varied supporting copy for upcoming notes and ordinary themeday context

## Testing
- npm test -- --runInBand --watchAll=false
- npm run build