### PR TITLE
Fix single-themeday self-reference copy

### DIFF
--- a/fredagskoll-frontend/package-lock.json
+++ b/fredagskoll-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vadkanmanfira-frontend",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vadkanmanfira-frontend",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",

--- a/fredagskoll-frontend/package.json
+++ b/fredagskoll-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vadkanmanfira-frontend",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/fredagskoll-frontend/src/appText.ts
+++ b/fredagskoll-frontend/src/appText.ts
@@ -4,7 +4,7 @@ export const ordinaryThemeDayTitleEndingsByLocale: Record<Locale, string[]> = {
   sv: [
     'Det får väl bära dagen då.',
     'Det är åtminstone något att skylla på.',
-    'Kontoret får helt enkelt acceptera saken.',
+    'Ingen i organisationen var stark nog att stoppa det.',
     'Det är mer än kalendern brukar erbjuda.',
     'Det blir inte bättre än så här idag.',
     'Det får duga som dagens professionella ursäkt.',
@@ -14,7 +14,7 @@ export const ordinaryThemeDayTitleEndingsByLocale: Record<Locale, string[]> = {
   en: [
     'That will have to carry the day, then.',
     "At least it's something to blame it on.",
-    'The office will simply have to accept it.',
+    'Nobody in the organization was strong enough to stop it.',
     "It's more than the calendar usually offers.",
     "This is about as good as today's getting.",
     "It'll do as today's professional excuse.",
@@ -24,7 +24,7 @@ export const ordinaryThemeDayTitleEndingsByLocale: Record<Locale, string[]> = {
   'pt-BR': [
     'Vai ter que sustentar o dia, então.',
     'Pelo menos já existe algo em que pôr a culpa.',
-    'O escritório vai simplesmente ter que aceitar.',
+    'Ninguém na organização teve força para impedir.',
     'É mais do que o calendário costuma oferecer.',
     'Hoje não vai ficar melhor do que isso.',
     'Serve como desculpa profissional do dia.',

--- a/fredagskoll-frontend/src/buildInfo.generated.ts
+++ b/fredagskoll-frontend/src/buildInfo.generated.ts
@@ -1,6 +1,6 @@
 export const buildInfo = {
-  "version": "0.1.2",
-  "gitSha": "e9ef56d",
-  "buildRef": "e9ef56d",
-  "builtAt": "2026-03-14T20:52:07.254Z"
+  "version": "0.1.3",
+  "gitSha": "3564a86",
+  "buildRef": "3564a86",
+  "builtAt": "2026-03-14T21:17:49.734Z"
 } as const;

--- a/fredagskoll-frontend/src/themeDayBlurbs.test.ts
+++ b/fredagskoll-frontend/src/themeDayBlurbs.test.ts
@@ -14,3 +14,16 @@ test('builds non-generic blurbs for non-overridden themedays', () => {
     )
   ).toBe(true);
 });
+
+test('does not generate plural self-reference blurbs for a single themeday', () => {
+  const blurbs = buildThemeDayBlurbs(['Såpbubblans dag']);
+
+  expect(
+    blurbs.some(
+      (blurb) =>
+        blurb.includes('samsas på samma datum') ||
+        blurb.includes('delar datumet') ||
+        blurb.includes('trängs på samma datum')
+    )
+  ).toBe(false);
+});

--- a/fredagskoll-frontend/src/themeDayDynamicBlurbs.ts
+++ b/fredagskoll-frontend/src/themeDayDynamicBlurbs.ts
@@ -9,13 +9,30 @@ function lowerFirst(value: string): string {
   return value.charAt(0).toLowerCase() + value.slice(1);
 }
 
-function buildFoodBlurbs(leadDay: string, allDays: string, locale: Locale): string[] {
+function pickSingularOrPlural(
+  themeDayCount: number,
+  singularLine: string,
+  pluralLine: string
+): string {
+  return themeDayCount > 1 ? pluralLine : singularLine;
+}
+
+function buildFoodBlurbs(
+  leadDay: string,
+  allDays: string,
+  locale: Locale,
+  themeDayCount: number
+): string[] {
   const lead = lowerFirst(leadDay);
   if (locale === 'en') {
     return [
       `${leadDay} is hanging over the date as a perfectly legitimate excuse to take food and drink more seriously than work.`,
       `If the day feels a little more flavor-driven than usual, that is only because ${lead} has already occupied the calendar and refuses to leave.`,
-      `${allDays} share the date, but ${lead} still feels like the point where self-control first gave way.`,
+      pickSingularOrPlural(
+        themeDayCount,
+        `${leadDay} alone is enough to mark the point where self-control first gave way.`,
+        `${allDays} share the date, but ${lead} still feels like the point where self-control first gave way.`
+      ),
     ];
   }
 
@@ -23,24 +40,41 @@ function buildFoodBlurbs(leadDay: string, allDays: string, locale: Locale): stri
     return [
       `${leadDay} paira sobre a data como uma desculpa perfeitamente legítima para levar comida e bebida mais a sério do que o trabalho.`,
       `Se o dia parece com um sabor um pouco mais evidente do que o normal, é só porque ${lead} já invadiu o calendário e não pretende sair.`,
-      `${allDays} dividem a data, mas ${lead} ainda parece o ponto onde o bom senso desistiu.`,
+      pickSingularOrPlural(
+        themeDayCount,
+        `${leadDay} sozinho já marca o ponto em que o bom senso resolveu se aposentar.`,
+        `${allDays} dividem a data, mas ${lead} ainda parece o ponto onde o bom senso desistiu.`
+      ),
     ];
   }
 
   return [
     `${leadDay} ligger över datumet som en fullt legitim ursäkt att ta mat och dryck på större allvar än arbetsuppgifter.`,
     `Om dagen känns lite mer smakstyrd än vanligt är det bara för att ${lead} redan tagit plats i kalendern och vägrar flytta på sig.`,
-    `${allDays} delar datumet, men ${lead} känns ändå som den punkt där självkontrollen först började ge vika.`,
+    pickSingularOrPlural(
+      themeDayCount,
+      `${leadDay} räcker på egen hand för att markera exakt var självkontrollen började ge vika.`,
+      `${allDays} delar datumet, men ${lead} känns ändå som den punkt där självkontrollen först började ge vika.`
+    ),
   ];
 }
 
-function buildCultureBlurbs(leadDay: string, allDays: string, locale: Locale): string[] {
+function buildCultureBlurbs(
+  leadDay: string,
+  allDays: string,
+  locale: Locale,
+  themeDayCount: number
+): string[] {
   const lead = lowerFirst(leadDay);
   if (locale === 'en') {
     return [
       `${leadDay} gives the date a very thin but fully usable layer of culture.`,
       `It becomes harder to treat the day as banal when ${lead} is already sitting there demanding a little dignity.`,
-      `${allDays} are all crowding onto the same date, which at least gives the calendar more substance than an ordinary meeting block.`,
+      pickSingularOrPlural(
+        themeDayCount,
+        `${leadDay} is enough on its own to give the calendar more substance than an ordinary meeting block.`,
+        `${allDays} are all crowding onto the same date, which at least gives the calendar more substance than an ordinary meeting block.`
+      ),
     ];
   }
 
@@ -48,24 +82,41 @@ function buildCultureBlurbs(leadDay: string, allDays: string, locale: Locale): s
     return [
       `${leadDay} adiciona à data uma camada fina, mas bem utilizável, de cultura.`,
       `Fica mais difícil tratar o dia como banal quando ${lead} já está ali, exigindo um pouco de dignidade.`,
-      `${allDays} amontoam-se na mesma data, o que ao menos dá mais conteúdo ao calendário do que uma reunião chata qualquer.`,
+      pickSingularOrPlural(
+        themeDayCount,
+        `${leadDay} sozinho já dá ao calendário mais conteúdo do que uma reunião chata qualquer.`,
+        `${allDays} amontoam-se na mesma data, o que ao menos dá mais conteúdo ao calendário do que uma reunião chata qualquer.`
+      ),
     ];
   }
 
   return [
     `${leadDay} ger datumet ett ovanligt tunt men fullt användbart lager av bildning.`,
     `Det är svårt att behandla dagen som banal när ${lead} redan sitter där och kräver lite kulturell värdighet.`,
-    `${allDays} trängs på samma datum, vilket åtminstone ger kalendern mer innehåll än ett vanligt mötesblock.`,
+    pickSingularOrPlural(
+      themeDayCount,
+      `${leadDay} räcker faktiskt på egen hand för att ge kalendern mer innehåll än ett vanligt mötesblock.`,
+      `${allDays} trängs på samma datum, vilket åtminstone ger kalendern mer innehåll än ett vanligt mötesblock.`
+    ),
   ];
 }
 
-function buildCommunityBlurbs(leadDay: string, allDays: string, locale: Locale): string[] {
+function buildCommunityBlurbs(
+  leadDay: string,
+  allDays: string,
+  locale: Locale,
+  themeDayCount: number
+): string[] {
   const lead = lowerFirst(leadDay);
   if (locale === 'en') {
     return [
       `${leadDay} lifts the date slightly above raw daily operations, which it honestly needed.`,
       `Once ${lead} lands first in the calendar, the rest of the day has to accept being a little less self-important than usual.`,
-      `${allDays} are sharing the same date, which at least gives the day more backbone than it usually has.`,
+      pickSingularOrPlural(
+        themeDayCount,
+        `${leadDay} is enough by itself to give the date more backbone than it usually has.`,
+        `${allDays} are sharing the same date, which at least gives the day more backbone than it usually has.`
+      ),
     ];
   }
 
@@ -73,99 +124,167 @@ function buildCommunityBlurbs(leadDay: string, allDays: string, locale: Locale):
     return [
       `${leadDay} eleva a data um pouco acima da correria diária, coisa que ela precisava, sejamos sinceros.`,
       `Quando ${lead} chega primeiro no calendário, o resto do dia tem que aceitar ser um pouco menos cheio de si do que o normal.`,
-      `${allDays} dividem a mesma data, o que dá mais coluna vertebral ao dia do que ele normalmente tem.`,
+      pickSingularOrPlural(
+        themeDayCount,
+        `${leadDay} sozinho já dá ao dia mais coluna vertebral do que ele normalmente tem.`,
+        `${allDays} dividem a mesma data, o que dá mais coluna vertebral ao dia do que ele normalmente tem.`
+      ),
     ];
   }
 
   return [
     `${leadDay} höjer ribban något över ren vardagsdrift, vilket datumet uppriktigt sagt behövde.`,
     `När ${lead} ligger först i kalendern får resten av dagen finna sig i att vara lite mindre självtillräcklig än vanligt.`,
-    `${allDays} samsas på samma datum, och det ger åtminstone dagen en tydligare ryggrad än den brukar ha.`,
+    pickSingularOrPlural(
+      themeDayCount,
+      `${leadDay} räcker faktiskt ensam för att ge dagen mer ryggrad än den brukar ha.`,
+      `${allDays} samsas på samma datum, och det ger åtminstone dagen en tydligare ryggrad än den brukar ha.`
+    ),
   ];
 }
 
-function buildNatureBlurbs(leadDay: string, allDays: string, locale: Locale): string[] {
+function buildNatureBlurbs(
+  leadDay: string,
+  allDays: string,
+  locale: Locale,
+  themeDayCount: number
+): string[] {
   const lead = lowerFirst(leadDay);
   if (locale === 'en') {
     return [
       `${leadDay} makes it harder than usual to pretend office lighting is the whole world.`,
       `You can tell ${lead} is hanging over the date, because the day suddenly feels a little less humanly self-satisfied.`,
-      `${allDays} are sharing the slot today, which in practice means nature has been granted interpretive priority over the schedule for a while.`,
+      pickSingularOrPlural(
+        themeDayCount,
+        `${leadDay} alone is enough to give nature temporary interpretive priority over the schedule.`,
+        `${allDays} are sharing the slot today, which in practice means nature has been granted interpretive priority over the schedule for a while.`
+      ),
     ];
   }
 
   if (locale === 'pt-BR') {
     return [
-      `${leadDay} dificulta do que o normal fingir que a luz do escritório é o mundo todo.`,
+      `${leadDay} dificulta mais do que o normal fingir que a luz do escritório é o mundo todo.`,
       `Dá para perceber que ${lead} domina a data, porque o dia de repente parece menos convencido como ser humano.`,
-      `${allDays} dividem a vaga hoje, o que na prática significa que a natureza tem prioridade para interpretar o horário por um tempo.`,
+      pickSingularOrPlural(
+        themeDayCount,
+        `${leadDay} sozinho já basta para dar à natureza prioridade temporária sobre o horário.`,
+        `${allDays} dividem a vaga hoje, o que na prática significa que a natureza tem prioridade para interpretar o horário por um tempo.`
+      ),
     ];
   }
 
   return [
     `${leadDay} gör det svårare än vanligt att låtsas att kontorsljus är hela verkligheten.`,
     `Det märks att ${lead} ligger över datumet, för dagen känns plötsligt lite mindre mänskligt självtillräcklig.`,
-    `${allDays} samsas här idag, vilket i praktiken betyder att naturen fått tolkningsföreträde över schemat en stund.`,
+    pickSingularOrPlural(
+      themeDayCount,
+      `${leadDay} räcker ensam för att ge naturen tillfälligt tolkningsföreträde över schemat.`,
+      `${allDays} samsas här idag, vilket i praktiken betyder att naturen fått tolkningsföreträde över schemat en stund.`
+    ),
   ];
 }
 
-function buildAnimalBlurbs(leadDay: string, allDays: string, locale: Locale): string[] {
+function buildAnimalBlurbs(
+  leadDay: string,
+  allDays: string,
+  locale: Locale,
+  themeDayCount: number
+): string[] {
   const lead = lowerFirst(leadDay);
   if (locale === 'en') {
     return [
       `${leadDay} gives the date a significantly better moral profile than many other theme days manage.`,
       `It becomes very difficult to object to ${lead} without immediately looking worse than necessary.`,
-      `${allDays} may share the date, but ${lead} is still the kind of theme people are simply expected to accept with humility.`,
+      pickSingularOrPlural(
+        themeDayCount,
+        `${leadDay} is already the kind of theme people are simply expected to accept with humility.`,
+        `${allDays} may share the date, but ${lead} is still the kind of theme people are simply expected to accept with humility.`
+      ),
     ];
   }
 
   if (locale === 'pt-BR') {
     return [
-      `${leadDay} dá à data um perfil moral muito mais legal do que muitos outros temas conseguem.`,
+      `${leadDay} dá à data um perfil moral muito melhor do que muitos outros temas conseguem.`,
       `Fica muito difícil contestar ${lead} sem parecer pior do que o necessário.`,
-      `${allDays} podem dividir a data, mas ${lead} continua sendo aquele tema que o pessoal espera que você aceite com humildade.`,
+      pickSingularOrPlural(
+        themeDayCount,
+        `${leadDay} já é aquele tema que as pessoas simplesmente devem aceitar com alguma humildade.`,
+        `${allDays} podem dividir a data, mas ${lead} continua sendo aquele tema que o pessoal espera que você aceite com humildade.`
+      ),
     ];
   }
 
   return [
     `${leadDay} ger datumet en klart trevligare moralisk profil än många andra temadagar lyckas med.`,
     `Det är svårt att invända mot ${lead} utan att omedelbart framstå som en sämre människa än nödvändigt.`,
-    `${allDays} råkar dela datum, men ${lead} är fortfarande den sortens tema folk bara får acceptera med viss ödmjukhet.`,
+    pickSingularOrPlural(
+      themeDayCount,
+      `${leadDay} är redan precis den sortens tema folk bara får acceptera med viss ödmjukhet.`,
+      `${allDays} råkar dela datum, men ${lead} är fortfarande den sortens tema folk bara får acceptera med viss ödmjukhet.`
+    ),
   ];
 }
 
-function buildTechBlurbs(leadDay: string, allDays: string, locale: Locale): string[] {
+function buildTechBlurbs(
+  leadDay: string,
+  allDays: string,
+  locale: Locale,
+  themeDayCount: number
+): string[] {
   const lead = lowerFirst(leadDay);
   if (locale === 'en') {
     return [
       `${leadDay} gives the date a clear smell of enthusiasts who absolutely do not intend to be normal today either.`,
       `Once ${lead} sits at the top of the calendar, the rest of the day just has to accept that nerdiness temporarily counts as leadership.`,
-      `${allDays} share the space, but ${lead} still feels like the main reason the date became strangely specific.`,
+      pickSingularOrPlural(
+        themeDayCount,
+        `${leadDay} is enough on its own to explain why the date suddenly became strangely specific.`,
+        `${allDays} share the space, but ${lead} still feels like the main reason the date became strangely specific.`
+      ),
     ];
   }
 
   if (locale === 'pt-BR') {
     return [
       `${leadDay} dá à data aquele cheirinho claro de entusiastas que não vão se contentar em ser normais hoje também.`,
-      `Quando ${lead} domina o calendário, o resto do dia tem que aceitar que nerdice conta como liderança – pelo menos por enquanto.`,
-      `${allDays} compartilham o espaço, mas ${lead} ainda parece a principal razão da data ter virado algo estranhamente específico.`,
+      `Quando ${lead} domina o calendário, o resto do dia tem que aceitar que nerdice conta como liderança, pelo menos por enquanto.`,
+      pickSingularOrPlural(
+        themeDayCount,
+        `${leadDay} sozinho já explica por que a data ficou estranhamente específica.`,
+        `${allDays} compartilham o espaço, mas ${lead} ainda parece a principal razão da data ter virado algo estranhamente específico.`
+      ),
     ];
   }
 
   return [
     `${leadDay} ger datumet en tydlig doft av entusiaster som absolut inte tänker nöja sig med att vara normala idag heller.`,
     `När ${lead} ligger överst i kalendern får resten av dagen bara acceptera att nörderi tillfälligt räknas som ledarskap.`,
-    `${allDays} delar utrymmet, men ${lead} känns ändå som huvudorsaken till att dagen blivit märkligt specifik.`,
+    pickSingularOrPlural(
+      themeDayCount,
+      `${leadDay} räcker på egen hand för att förklara varför dagen plötsligt blivit märkligt specifik.`,
+      `${allDays} delar utrymmet, men ${lead} känns ändå som huvudorsaken till att dagen blivit märkligt specifik.`
+    ),
   ];
 }
 
-function buildProfessionBlurbs(leadDay: string, allDays: string, locale: Locale): string[] {
+function buildProfessionBlurbs(
+  leadDay: string,
+  allDays: string,
+  locale: Locale,
+  themeDayCount: number
+): string[] {
   const lead = lowerFirst(leadDay);
   if (locale === 'en') {
     return [
       `${leadDay} is a fairly direct way of reminding everyone which people actually keep daily life stitched together for the rest of us.`,
       `If the date feels unusually functional today, that is only because ${lead} has already given it some structure.`,
-      `${allDays} are on the schedule, but ${lead} still carries the sort of weight that makes the rest fall into line.`,
+      pickSingularOrPlural(
+        themeDayCount,
+        `${leadDay} alone carries the kind of weight that makes the rest of the day fall into line.`,
+        `${allDays} are on the schedule, but ${lead} still carries the sort of weight that makes the rest fall into line.`
+      ),
     ];
   }
 
@@ -173,49 +292,83 @@ function buildProfessionBlurbs(leadDay: string, allDays: string, locale: Locale)
     return [
       `${leadDay} é um jeito bem direto de lembrar quem realmente mantém a vida diária costurada para o resto de nós.`,
       `Se a data parece especialmente funcional hoje, é só porque ${lead} já deu uma estrutura para ela.`,
-      `${allDays} estão na agenda, mas ${lead} tem aquele peso que faz o resto se alinhar sem reclamar.`,
+      pickSingularOrPlural(
+        themeDayCount,
+        `${leadDay} sozinho já tem aquele peso que faz o resto do dia se alinhar sem reclamar.`,
+        `${allDays} estão na agenda, mas ${lead} tem aquele peso que faz o resto se alinhar sem reclamar.`
+      ),
     ];
   }
 
   return [
     `${leadDay} är ett ganska tydligt sätt att påminna om vilka människor som faktiskt håller ihop vardagen åt resten av oss.`,
     `Om datumet känns ovanligt funktionellt idag är det bara för att ${lead} redan hunnit ge det lite struktur.`,
-    `${allDays} står på schemat, men ${lead} bär ändå den sortens tyngd som gör att resten får rätta sig i ledet.`,
+    pickSingularOrPlural(
+      themeDayCount,
+      `${leadDay} bär ensam den sortens tyngd som gör att resten av dagen får rätta sig i ledet.`,
+      `${allDays} står på schemat, men ${lead} bär ändå den sortens tyngd som gör att resten får rätta sig i ledet.`
+    ),
   ];
 }
 
-function buildObjectBlurbs(leadDay: string, allDays: string, locale: Locale): string[] {
+function buildObjectBlurbs(
+  leadDay: string,
+  allDays: string,
+  locale: Locale,
+  themeDayCount: number
+): string[] {
   const lead = lowerFirst(leadDay);
   if (locale === 'en') {
     return [
       `${leadDay} is so specific that the date immediately stops feeling neutral and starts feeling faintly possessed.`,
       `It is hard to argue with ${lead} once the calendar has already chosen to give it full stage lighting.`,
-      `${allDays} share the day, but ${lead} is still exactly the kind of detail that makes the rest feel like extras.`,
+      pickSingularOrPlural(
+        themeDayCount,
+        `${leadDay} alone is exactly the kind of detail that makes the rest of the date feel like background noise.`,
+        `${allDays} share the day, but ${lead} is still exactly the kind of detail that makes the rest feel like extras.`
+      ),
     ];
   }
 
   if (locale === 'pt-BR') {
     return [
       `${leadDay} é tão específico que a data deixa de parecer neutra e começa a parecer meio possuída.`,
-      `É difícil discutir com ${lead} quando o calendário já decidiu dar todo o holofote pra ele.`,
-      `${allDays} dividem o dia, mas ${lead} ainda é justamente aquele detalhe que faz o resto parecer figurante.`,
+      `É difícil discutir com ${lead} quando o calendário já decidiu dar todo o holofote para ele.`,
+      pickSingularOrPlural(
+        themeDayCount,
+        `${leadDay} sozinho já é o detalhe exato que faz o resto da data parecer mera decoração.`,
+        `${allDays} dividem o dia, mas ${lead} ainda é justamente aquele detalhe que faz o resto parecer figurante.`
+      ),
     ];
   }
 
   return [
     `${leadDay} är så specifik att datumet omedelbart slutar kännas neutralt och börjar kännas lätt besatt.`,
     `Det är svårt att argumentera mot ${lead} när kalendern redan valt att ge ämnet full scenbelysning.`,
-    `${allDays} delar dagen, men ${lead} är fortfarande exakt den sortens detalj som får resten att kännas som statistroller.`,
+    pickSingularOrPlural(
+      themeDayCount,
+      `${leadDay} är ensam exakt den sortens detalj som får resten av datumet att kännas som bakgrundsbrus.`,
+      `${allDays} delar dagen, men ${lead} är fortfarande exakt den sortens detalj som får resten att kännas som statistroller.`
+    ),
   ];
 }
 
-function buildFallbackBlurbs(leadDay: string, allDays: string, locale: Locale): string[] {
+function buildFallbackBlurbs(
+  leadDay: string,
+  allDays: string,
+  locale: Locale,
+  themeDayCount: number
+): string[] {
   const lead = lowerFirst(leadDay);
   if (locale === 'en') {
     return [
       `${leadDay} has already taken possession of the date, so there is no point pretending this is a neutral weekday anymore.`,
       `Once ${lead} is in the calendar, the rest of the day mostly exists to adapt to its oddly specific energy.`,
-      `${allDays} are sharing the same date, which feels less like order and more like a committee that refused to choose.`,
+      pickSingularOrPlural(
+        themeDayCount,
+        `${leadDay} on its own is enough to make the date feel less like routine and more like a deliberate decision someone now has to defend.`,
+        `${allDays} are sharing the same date, which feels less like order and more like a committee that refused to choose.`
+      ),
     ];
   }
 
@@ -223,14 +376,22 @@ function buildFallbackBlurbs(leadDay: string, allDays: string, locale: Locale): 
     return [
       `${leadDay} já tomou posse da data, então não adianta fingir que é um dia comum de semana.`,
       `Depois que ${lead} aparece no calendário, o resto do dia serve principalmente para se adaptar àquela energia estranhamente específica.`,
-      `${allDays} dividem a mesma data, o que parece menos ordem e mais uma reunião que não quis decidir.`,
+      pickSingularOrPlural(
+        themeDayCount,
+        `${leadDay} sozinho já basta para fazer a data parecer menos rotina e mais uma decisão específica que alguém agora vai ter de justificar.`,
+        `${allDays} dividem a mesma data, o que parece menos ordem e mais uma reunião que não quis decidir.`
+      ),
     ];
   }
 
   return [
     `${leadDay} har redan tagit datumet i besittning, så det är bara att sluta låtsas att det här är en neutral vardag.`,
     `När ${lead} väl står i kalendern är resten av dagen mest till för att anpassa sig till den märkligt specifika energin.`,
-    `${allDays} samsas på samma datum, vilket känns mindre som ordning och mer som en kommitté som vägrade välja.`,
+    pickSingularOrPlural(
+      themeDayCount,
+      `${leadDay} räcker ensam för att få datumet att kännas mindre som rutin och mer som ett märkligt specifikt beslut någon nu måste stå för.`,
+      `${allDays} samsas på samma datum, vilket känns mindre som ordning och mer som en kommitté som vägrade välja.`
+    ),
   ];
 }
 
@@ -241,6 +402,7 @@ export function buildThemeDayDynamicBlurbs(
 ): string[] {
   const leadDay = displayThemeDays[0];
   const allDays = joinWithAnd(displayThemeDays, locale);
+  const themeDayCount = displayThemeDays.length;
   const normalized = normalizeLabel(themeDays[0]);
 
   if (
@@ -267,7 +429,7 @@ export function buildThemeDayDynamicBlurbs(
       'ol',
     ])
   ) {
-    return buildFoodBlurbs(leadDay, allDays, locale);
+    return buildFoodBlurbs(leadDay, allDays, locale, themeDayCount);
   }
 
   if (
@@ -288,7 +450,7 @@ export function buildThemeDayDynamicBlurbs(
       'kultur',
     ])
   ) {
-    return buildCultureBlurbs(leadDay, allDays, locale);
+    return buildCultureBlurbs(leadDay, allDays, locale, themeDayCount);
   }
 
   if (
@@ -309,7 +471,7 @@ export function buildThemeDayDynamicBlurbs(
       'kvan',
     ])
   ) {
-    return buildCommunityBlurbs(leadDay, allDays, locale);
+    return buildCommunityBlurbs(leadDay, allDays, locale, themeDayCount);
   }
 
   if (
@@ -331,7 +493,7 @@ export function buildThemeDayDynamicBlurbs(
       'vaxter',
     ])
   ) {
-    return buildNatureBlurbs(leadDay, allDays, locale);
+    return buildNatureBlurbs(leadDay, allDays, locale, themeDayCount);
   }
 
   if (
@@ -347,7 +509,7 @@ export function buildThemeDayDynamicBlurbs(
       'skoldpadd',
     ])
   ) {
-    return buildAnimalBlurbs(leadDay, allDays, locale);
+    return buildAnimalBlurbs(leadDay, allDays, locale, themeDayCount);
   }
 
   if (
@@ -365,7 +527,7 @@ export function buildThemeDayDynamicBlurbs(
       'rymdfarder',
     ])
   ) {
-    return buildTechBlurbs(leadDay, allDays, locale);
+    return buildTechBlurbs(leadDay, allDays, locale, themeDayCount);
   }
 
   if (
@@ -389,7 +551,7 @@ export function buildThemeDayDynamicBlurbs(
       'biomedicinska analytiker',
     ])
   ) {
-    return buildProfessionBlurbs(leadDay, allDays, locale);
+    return buildProfessionBlurbs(leadDay, allDays, locale, themeDayCount);
   }
 
   if (
@@ -408,8 +570,8 @@ export function buildThemeDayDynamicBlurbs(
       'fonsterrenovering',
     ])
   ) {
-    return buildObjectBlurbs(leadDay, allDays, locale);
+    return buildObjectBlurbs(leadDay, allDays, locale, themeDayCount);
   }
 
-  return buildFallbackBlurbs(leadDay, allDays, locale);
+  return buildFallbackBlurbs(leadDay, allDays, locale, themeDayCount);
 }


### PR DESCRIPTION
## Summary
- make themeday dynamic blurbs singular/plural aware so single-day dates stop acting like they are sharing with themselves
- replace one weak ordinary themeday title-ending with a sharper line
- bump the frontend version to 0.1.3 for deploy visibility

## Verification
- npm test -- --runInBand --watchAll=false
- npm run build