### PR TITLE
Harden AI blurb fallback handling

### DIFF
--- a/api/blurbs/index.js
+++ b/api/blurbs/index.js
@@ -50,7 +50,12 @@ module.exports = async function blurbHandler(context, req) {
       model: generated.model,
     });
   } catch (error) {
-    context.log.error('Failed to produce AI blurbs', error);
+    if (context?.log && typeof context.log.error === 'function') {
+      context.log.error('Failed to produce AI blurbs', error);
+    } else if (typeof context?.log === 'function') {
+      context.log('Failed to produce AI blurbs', error);
+    }
+
     context.res = json(200, {
       source: 'fallback',
       error: 'ai_unavailable',

--- a/fredagskoll-frontend/src/buildInfo.generated.ts
+++ b/fredagskoll-frontend/src/buildInfo.generated.ts
@@ -1,6 +1,6 @@
 export const buildInfo = {
   "version": "0.1.5",
-  "gitSha": "6ebaf90",
-  "buildRef": "6ebaf90",
-  "builtAt": "2026-03-15T05:20:22.104Z"
+  "gitSha": "d60ab80",
+  "buildRef": "d60ab80",
+  "builtAt": "2026-03-15T05:26:28.153Z"
 } as const;


### PR DESCRIPTION
## Summary
- harden the AI error path so the function returns a clean fallback even if the managed runtime exposes a weird logger shape
- keep the live endpoint from turning handled AI failures into raw HTTP 500s

## Verification
- `npm test -- --runInBand --watchAll=false`
- `npm run build`
- local handler execution with forced AI failure and fallback path