### PR TITLE
Make AI API syntax runtime-safe

### DIFF
--- a/api/blurbs/index.js
+++ b/api/blurbs/index.js
@@ -50,9 +50,9 @@ module.exports = async function blurbHandler(context, req) {
       model: generated.model,
     });
   } catch (error) {
-    if (context?.log && typeof context.log.error === 'function') {
+    if (context && context.log && typeof context.log.error === 'function') {
       context.log.error('Failed to produce AI blurbs', error);
-    } else if (typeof context?.log === 'function') {
+    } else if (context && typeof context.log === 'function') {
       context.log('Failed to produce AI blurbs', error);
     }
 

--- a/api/shared/azureOpenAi.js
+++ b/api/shared/azureOpenAi.js
@@ -34,14 +34,15 @@ function parseJsonResponse(text) {
 }
 
 function sanitizeBundle(bundle, request) {
-  const titleEndings = Array.isArray(bundle?.titleEndings)
-    ? bundle.titleEndings.filter((value) => typeof value === 'string' && value.trim().length > 0)
+  const sourceBundle = bundle && typeof bundle === 'object' ? bundle : {};
+  const titleEndings = Array.isArray(sourceBundle.titleEndings)
+    ? sourceBundle.titleEndings.filter((value) => typeof value === 'string' && value.trim().length > 0)
     : [];
-  const cardNotes = Array.isArray(bundle?.cardNotes)
-    ? bundle.cardNotes.filter((value) => typeof value === 'string' && value.trim().length > 0)
+  const cardNotes = Array.isArray(sourceBundle.cardNotes)
+    ? sourceBundle.cardNotes.filter((value) => typeof value === 'string' && value.trim().length > 0)
     : [];
-  const blurbs = Array.isArray(bundle?.blurbs)
-    ? bundle.blurbs.filter((value) => typeof value === 'string' && value.trim().length > 0)
+  const blurbs = Array.isArray(sourceBundle.blurbs)
+    ? sourceBundle.blurbs.filter((value) => typeof value === 'string' && value.trim().length > 0)
     : [];
 
   return {
@@ -90,14 +91,19 @@ async function generateBlurbBundle(request) {
   }
 
   const payload = await response.json();
-  const content = payload?.choices?.[0]?.message?.content;
+  const content =
+    payload &&
+    payload.choices &&
+    payload.choices[0] &&
+    payload.choices[0].message &&
+    payload.choices[0].message.content;
   if (typeof content !== 'string' || content.trim().length === 0) {
     throw new Error('Azure OpenAI returned no content.');
   }
 
   return {
     enabled: true,
-    model: payload?.model || config.deployment,
+    model: (payload && payload.model) || config.deployment,
     bundle: sanitizeBundle(parseJsonResponse(content), request),
   };
 }

--- a/api/shared/blurbSchema.js
+++ b/api/shared/blurbSchema.js
@@ -22,30 +22,31 @@ function coerceBoolean(value, fallback = false) {
 }
 
 function normalizeRequestBody(body) {
-  const locale = SUPPORTED_LOCALES.has(body?.locale) ? body.locale : 'sv';
-  const contentPack = SUPPORTED_PACKS.has(body?.contentPack) ? body.contentPack : 'public';
-  const kind = SUPPORTED_KINDS.has(body?.kind) ? body.kind : 'ordinary';
+  const source = body && typeof body === 'object' ? body : {};
+  const locale = SUPPORTED_LOCALES.has(source.locale) ? source.locale : 'sv';
+  const contentPack = SUPPORTED_PACKS.has(source.contentPack) ? source.contentPack : 'public';
+  const kind = SUPPORTED_KINDS.has(source.kind) ? source.kind : 'ordinary';
 
   return {
     locale,
     contentPack,
     kind,
-    date: coerceString(body?.date),
-    dateLabel: coerceString(body?.dateLabel),
-    dayType: coerceString(body?.dayType, 'ordinary'),
-    title: coerceString(body?.title),
-    subtitle: coerceString(body?.subtitle),
-    kicker: coerceString(body?.kicker),
-    fallbackTitleEnding: coerceString(body?.fallbackTitleEnding),
-    fallbackCardNote: coerceString(body?.fallbackCardNote),
-    fallbackBlurbs: coerceStringArray(body?.fallbackBlurbs),
-    themeDays: coerceStringArray(body?.themeDays),
-    extraThemeDays: coerceStringArray(body?.extraThemeDays),
-    seasonalTitles: coerceStringArray(body?.seasonalTitles),
-    upcomingTitles: coerceStringArray(body?.upcomingTitles),
-    upcomingHolidayName: coerceString(body?.upcomingHolidayName),
-    nationalDaySummary: coerceString(body?.nationalDaySummary),
-    allowHumor: coerceBoolean(body?.allowHumor, true),
+    date: coerceString(source.date),
+    dateLabel: coerceString(source.dateLabel),
+    dayType: coerceString(source.dayType, 'ordinary'),
+    title: coerceString(source.title),
+    subtitle: coerceString(source.subtitle),
+    kicker: coerceString(source.kicker),
+    fallbackTitleEnding: coerceString(source.fallbackTitleEnding),
+    fallbackCardNote: coerceString(source.fallbackCardNote),
+    fallbackBlurbs: coerceStringArray(source.fallbackBlurbs),
+    themeDays: coerceStringArray(source.themeDays),
+    extraThemeDays: coerceStringArray(source.extraThemeDays),
+    seasonalTitles: coerceStringArray(source.seasonalTitles),
+    upcomingTitles: coerceStringArray(source.upcomingTitles),
+    upcomingHolidayName: coerceString(source.upcomingHolidayName),
+    nationalDaySummary: coerceString(source.nationalDaySummary),
+    allowHumor: coerceBoolean(source.allowHumor, true),
   };
 }
 

--- a/fredagskoll-frontend/src/buildInfo.generated.ts
+++ b/fredagskoll-frontend/src/buildInfo.generated.ts
@@ -1,6 +1,6 @@
 export const buildInfo = {
   "version": "0.1.5",
-  "gitSha": "d60ab80",
-  "buildRef": "d60ab80",
-  "builtAt": "2026-03-15T05:26:28.153Z"
+  "gitSha": "303bf43",
+  "buildRef": "303bf43",
+  "builtAt": "2026-03-15T05:31:00.443Z"
 } as const;


### PR DESCRIPTION
## Summary
- remove optional chaining from the managed API code so the Static Web Apps function host does not get to choke on newer syntax
- keep the runtime behavior unchanged while making the API files more conservative for Azure's parser/runtime

## Verification
- `npm run build`
- local API module load