### PR TITLE
Serialize AI API responses explicitly

### DIFF
--- a/api/blurbs/index.js
+++ b/api/blurbs/index.js
@@ -8,7 +8,7 @@ function json(status, body) {
     headers: {
       'Content-Type': 'application/json',
     },
-    body,
+    body: body === null ? '' : JSON.stringify(body),
   };
 }
 

--- a/fredagskoll-frontend/src/buildInfo.generated.ts
+++ b/fredagskoll-frontend/src/buildInfo.generated.ts
@@ -1,6 +1,6 @@
 export const buildInfo = {
   "version": "0.1.5",
-  "gitSha": "303bf43",
-  "buildRef": "303bf43",
-  "builtAt": "2026-03-15T05:31:00.443Z"
+  "gitSha": "542f4f0",
+  "buildRef": "542f4f0",
+  "builtAt": "2026-03-15T05:34:46.797Z"
 } as const;


### PR DESCRIPTION
## Summary
- serialize the AI API response body explicitly as JSON so the managed function host is not asked to infer object serialization
- keep the existing handler logic and fallback behavior intact while making the HTTP response shape more conservative

## Verification
- `npm run build`
- local handler execution