### PR TITLE
Add managed API ping canary

### DIFF
--- a/api/ping/function.json
+++ b/api/ping/function.json
@@ -1,0 +1,17 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["get"],
+      "route": "ping"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/api/ping/index.js
+++ b/api/ping/index.js
@@ -1,0 +1,12 @@
+module.exports = async function pingHandler(context) {
+  context.res = {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      ok: true,
+      runtime: 'managed-api',
+    }),
+  };
+};


### PR DESCRIPTION
## Summary
- add a minimal `api/ping` canary route with no imports to prove whether the managed Static Web Apps API host can execute any simple function successfully