### PR TITLE
Wire frontend to dedicated AI API

### DIFF
--- a/.github/workflows/deploy-static-apps.yml
+++ b/.github/workflows/deploy-static-apps.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REACT_APP_CONTENT_PACK: public
+      REACT_APP_AI_API_BASE_URL: https://vkmf-blurbs-api.azurewebsites.net
       GITHUB_SHA: ${{ github.sha }}
       GITHUB_RUN_NUMBER: ${{ github.run_number }}
     steps:
@@ -32,7 +33,6 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: upload
           app_location: fredagskoll-frontend
-          api_location: api
           output_location: build
 
   deploy_team:
@@ -40,6 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REACT_APP_CONTENT_PACK: team
+      REACT_APP_AI_API_BASE_URL: https://vkmf-blurbs-api.azurewebsites.net
       GITHUB_SHA: ${{ github.sha }}
       GITHUB_RUN_NUMBER: ${{ github.run_number }}
     steps:
@@ -56,5 +57,4 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: upload
           app_location: fredagskoll-frontend
-          api_location: api
           output_location: build

--- a/api/blurbs/function.json
+++ b/api/blurbs/function.json
@@ -1,4 +1,5 @@
 {
+  "scriptFile": "index.js",
   "bindings": [
     {
       "authLevel": "anonymous",

--- a/api/package.json
+++ b/api/package.json
@@ -2,7 +2,6 @@
   "name": "vadkanmanfira-api",
   "version": "0.1.0",
   "private": true,
-  "main": "index.js",
   "dependencies": {
     "@azure/data-tables": "^13.3.1"
   }

--- a/api/ping/function.json
+++ b/api/ping/function.json
@@ -1,4 +1,5 @@
 {
+  "scriptFile": "index.js",
   "bindings": [
     {
       "authLevel": "anonymous",

--- a/fredagskoll-frontend/package.json
+++ b/fredagskoll-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vadkanmanfira-frontend",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/fredagskoll-frontend/src/aiBlurbs.ts
+++ b/fredagskoll-frontend/src/aiBlurbs.ts
@@ -31,11 +31,20 @@ export type AiBlurbBundle = {
   model?: string | null;
 };
 
+function getAiBlurbsEndpoint(): string {
+  const configuredBaseUrl = process.env.REACT_APP_AI_API_BASE_URL?.trim();
+  if (!configuredBaseUrl) {
+    return '/api/blurbs';
+  }
+
+  return `${configuredBaseUrl.replace(/\/+$/, '')}/api/blurbs`;
+}
+
 export async function fetchAiBlurbBundle(
   request: AiBlurbRequest,
   signal?: AbortSignal
 ): Promise<AiBlurbBundle | null> {
-  const response = await fetch('/api/blurbs', {
+  const response = await fetch(getAiBlurbsEndpoint(), {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/fredagskoll-frontend/src/buildInfo.generated.ts
+++ b/fredagskoll-frontend/src/buildInfo.generated.ts
@@ -1,6 +1,6 @@
 export const buildInfo = {
-  "version": "0.1.5",
-  "gitSha": "542f4f0",
-  "buildRef": "542f4f0",
-  "builtAt": "2026-03-15T05:34:46.797Z"
+  "version": "0.1.6",
+  "gitSha": "dbd1ad6",
+  "buildRef": "dbd1ad6",
+  "builtAt": "2026-03-15T06:02:01.224Z"
 } as const;


### PR DESCRIPTION
## Summary
- point the frontend AI calls at the dedicated Azure Function App instead of the broken managed SWA API
- remove managed API deployment from the static app workflow and pass the dedicated API base URL into both builds
- bump the frontend version to 0.1.6 so the live footer proves the deploy actually moved

## Verification
- npm test -- --runInBand --watchAll=false
- npm run build
