### PR TITLE
[codex] Gracefully serve cache during refill throttling

### DIFF
--- a/api/blurbs/index.js
+++ b/api/blurbs/index.js
@@ -19,6 +19,18 @@ function json(status, body) {
   };
 }
 
+async function tryGenerateVariant(request, cacheState) {
+  try {
+    return await generateBlurbBundle(request);
+  } catch (error) {
+    if (cacheState && cacheState.freshVariants.length > 0) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
 module.exports = async function blurbHandler(context, req) {
   try {
     const request = normalizeRequestBody(req.body || {});
@@ -55,8 +67,8 @@ module.exports = async function blurbHandler(context, req) {
       cacheState.staleVariants.length > 0;
 
     if (shouldGenerateVariant) {
-      const generated = await generateBlurbBundle(request);
-      if (!generated.enabled || !generated.bundle) {
+      const generated = await tryGenerateVariant(request, cacheState);
+      if (!generated || !generated.enabled || !generated.bundle) {
         if (!cacheState || cacheState.freshVariants.length === 0) {
           context.res = json(204, null);
           return;
@@ -68,8 +80,12 @@ module.exports = async function blurbHandler(context, req) {
         if (updatedVariants.length < MAX_VARIANTS_PER_KEY) {
           updatedVariants.push(generatedVariant);
         } else {
-          const staleIds = new Set(cacheState.staleVariants.map((variant) => variant.id));
-          const replacementIndex = updatedVariants.findIndex((variant) => staleIds.has(variant.id));
+          const staleBundleIds = new Set(
+            cacheState.staleVariants.map((variant) => variant.bundleId)
+          );
+          const replacementIndex = updatedVariants.findIndex((variant) =>
+            staleBundleIds.has(variant.bundleId)
+          );
           const targetIndex = replacementIndex >= 0 ? replacementIndex : 0;
           updatedVariants[targetIndex] = generatedVariant;
         }
@@ -87,7 +103,7 @@ module.exports = async function blurbHandler(context, req) {
 
     const selectedVariant = chooseVariant(
       cacheState ? cacheState.freshVariants : [],
-      cacheState ? cacheState.lastServedVariantId : null
+      cacheState ? cacheState.lastBundleId : null
     );
 
     if (!selectedVariant) {


### PR DESCRIPTION
This follow-up fixes a runtime regression discovered during live verification of the new rotating cache library.

The new cache model correctly split hot request metadata from the bundle library table, but while the variant pool was still underfilled the handler would try to generate another bundle on every request. If Azure OpenAI returned a 429 rate-limit response during that refill attempt, the exception bubbled out to the outer catch and the function returned the empty fallback payload even when a fresh cached variant already existed.

That behaviour was wrong for production. Under quota pressure the service should degrade to serving an existing fresh cached bundle, not pretend the cache is unusable and hand back nothing.

This PR changes the refill path so generation failures during cache expansion are treated as soft failures whenever a fresh variant is already available. In that case the handler now continues and serves cached content. It also fixes the bundle identifier field usage in the refill logic so stale replacement and last-served tracking are aligned with the new `bundleId` / `lastBundleId` model instead of the older `id` naming.

Validation was done by loading the updated module locally, reproducing the live rate-limit condition through Application Insights traces, and then confirming the intended control flow before redeploying the function app.
