### PR TITLE
[codex] implement mood-aware editorial copy

### DIFF
--- a/TEXT-SURFACE-AUDIT.md
+++ b/TEXT-SURFACE-AUDIT.md
@@ -1,0 +1,178 @@
+# Text Surface Audit
+
+Date: 2026-03-15
+
+## Goal
+
+Mood should not control every string in the app.
+
+The app has two different text systems:
+
+- Stable UI copy: labels, buttons, navigation, settings, helper text
+- Editorial copy: blurbs, narrative notes, fallback prose, celebratory lines
+
+Only the editorial layer should become mood-aware.
+
+## Stable UI Copy
+
+These should remain locale-driven and structurally stable.
+
+### Primary sources
+
+- `fredagskoll-frontend/src/appText.ts`
+- `fredagskoll-frontend/src/App.tsx`
+
+### Keep stable
+
+- Navigation labels
+- Picker labels
+- Buttons and toggles
+- Dialog and credits labels
+- Section headers
+- Build/version labels
+- Accessibility and explanatory helper text
+- Error/loading/status text that is operational rather than editorial
+
+### Why
+
+If mood affects the app chrome, the product voice starts shifting in places where users expect consistency. That creates noise rather than personality.
+
+## Mood-Aware Editorial Copy
+
+These are the visible text surfaces that actually define tone. If mood only affects AI blurbs, the feature will feel partial because the rest of the app still speaks in the existing dry house voice.
+
+### High priority
+
+- `fredagskoll-frontend/src/appText.ts`
+  - `ordinaryTitle`
+  - `ordinaryThemeDayLead`
+  - `ordinaryNoHitBody`
+  - `asIfThatWasNotEnough`
+  - `ordinaryThemeDayTitleEndingsByLocale`
+  - `ordinaryThemeDayCardNotesByLocale`
+- `fredagskoll-frontend/src/celebrations.ts`
+  - celebratory/fallback blurbs
+- `fredagskoll-frontend/src/aiBlurbs.ts`
+  - request model already carries mood
+- `api/shared/prompt.js`
+  - prompt guidance already carries mood
+
+### Medium priority
+
+- `fredagskoll-frontend/src/themeDaySpecificBlurbs.ts`
+  - hand-written override blurbs for named theme days
+- `fredagskoll-frontend/src/themeDayCategoryBlurbs.ts`
+  - category-based fallback blurbs
+- `fredagskoll-frontend/src/themeDayDynamicBlurbs.ts`
+  - dynamic multi-theme narrative blurbs
+- `fredagskoll-frontend/src/upcomingNotables.ts`
+  - narrative notes for upcoming notable dates
+- `fredagskoll-frontend/src/seasonalNotes.ts`
+  - seasonal narrative notes
+- `fredagskoll-frontend/src/nationalDays.ts`
+  - country/day narrative framing where it is editorial rather than raw factual data
+
+### Why
+
+These files are where the app currently sounds like itself. They contain the "dry, resigned, lightly amused" editorial voice. If mood support is real, these surfaces need a route to choose variants by mood.
+
+## Mostly Factual Or Leave-Alone Text
+
+These should not be rewritten aggressively for mood.
+
+- Raw holiday or date names
+- Country names
+- Locale names
+- Theme-day source data
+- Structured metadata labels
+- Image/source attribution text
+- External references or citations
+
+Mood can wrap these with editorial framing, but should not mutate the factual values themselves.
+
+## Recommended Model
+
+Use a shared frontend `Mood` type and pass it only into content-producing functions.
+
+### Layer split
+
+- `UI copy`
+  - locale-driven
+  - stable
+  - no mood input
+- `Editorial copy`
+  - locale-driven
+  - mood-aware
+  - can fall back to `dry`
+
+### Implementation shape
+
+Prefer functions over giant nested dictionaries where practical.
+
+Examples:
+
+- `getOrdinaryThemeDayLead(locale, mood)`
+- `getCelebrationBlurb(locale, mood, context)`
+- `getThemeDaySpecificBlurbs(themeDay, locale, mood)`
+- `buildThemeDayDynamicBlurbs(themeDays, locale, mood, displayThemeDays)`
+
+This is better than trying to make every string table in `appText.ts` mood-indexed immediately.
+
+## Rollout Order
+
+### Phase 1
+
+Wire mood into the highest-visibility editorial fallbacks:
+
+- ordinary fallback prose in `appText.ts`
+- celebration blurbs
+- theme-day specific/category/dynamic blurbs
+
+This gives the user a visible change on most screens.
+
+### Phase 2
+
+Extend mood into secondary narrative surfaces:
+
+- `upcomingNotables.ts`
+- `seasonalNotes.ts`
+- editorial framing inside `nationalDays.ts`
+
+### Phase 3
+
+Clean up duplication by extracting reusable tone helpers:
+
+- dry
+- cheerful
+- formal
+- absurd
+- later: warm, chaotic
+
+Do not start with all moods everywhere. Ship a smaller set cleanly.
+
+## Product Boundary
+
+Mood should describe the editorial tone of the content, not the personality of the entire interface.
+
+Good:
+
+- "today's card note sounds more cheerful"
+- "theme-day blurbs are more absurd"
+
+Bad:
+
+- buttons, toggles, or menus changing voice
+- inconsistent operational copy
+- factual content rewritten into character bits
+
+## Conclusion
+
+Yes, the app needs broader text handling than "AI blurbs only".
+
+No, it should not make every field mood-aware.
+
+The correct boundary is:
+
+- stable UI copy stays stable
+- editorial copy becomes mood-aware
+- factual/source text remains factual

--- a/api/shared/blurbSchema.js
+++ b/api/shared/blurbSchema.js
@@ -1,6 +1,7 @@
 const SUPPORTED_LOCALES = new Set(['sv', 'en', 'pt-BR']);
 const SUPPORTED_PACKS = new Set(['public', 'team']);
 const SUPPORTED_KINDS = new Set(['celebration', 'themeDay', 'ordinary']);
+const SUPPORTED_MOODS = new Set(['dry', 'cheerful', 'chaotic', 'formal', 'absurd', 'warm']);
 
 function coerceString(value, fallback = '') {
   return typeof value === 'string' ? value.trim() : fallback;
@@ -26,11 +27,13 @@ function normalizeRequestBody(body) {
   const locale = SUPPORTED_LOCALES.has(source.locale) ? source.locale : 'sv';
   const contentPack = SUPPORTED_PACKS.has(source.contentPack) ? source.contentPack : 'public';
   const kind = SUPPORTED_KINDS.has(source.kind) ? source.kind : 'ordinary';
+  const mood = SUPPORTED_MOODS.has(source.mood) ? source.mood : 'dry';
 
   return {
     locale,
     contentPack,
     kind,
+    mood,
     date: coerceString(source.date),
     dateLabel: coerceString(source.dateLabel),
     dayType: coerceString(source.dayType, 'ordinary'),

--- a/api/shared/cache.js
+++ b/api/shared/cache.js
@@ -52,6 +52,7 @@ function buildRequestHash(request) {
       locale: request.locale,
       contentPack: request.contentPack,
       kind: request.kind,
+      mood: request.mood,
       date: request.date,
       dayType: request.dayType,
       title: request.title,

--- a/api/shared/prompt.js
+++ b/api/shared/prompt.js
@@ -9,10 +9,27 @@ function getLocaleLabel(locale) {
   }
 }
 
+function getMoodGuidance(mood) {
+  switch (mood) {
+    case 'cheerful':
+      return 'Make the tone lightly upbeat, generous, and playful without becoming sugary or generic.';
+    case 'chaotic':
+      return 'Make the tone lively, unruly, and slightly frazzled, but still readable and controlled.';
+    case 'formal':
+      return 'Make the tone drier, tidier, and more ceremonially officious than usual.';
+    case 'absurd':
+      return 'Lean into surreal observations and odd juxtapositions while keeping the copy concise.';
+    case 'warm':
+      return 'Make the tone warmer, more humane, and gently amused without losing sharpness.';
+    default:
+      return 'Keep the tone dry, witty, officious, ironic, and observant.';
+  }
+}
+
 function buildSystemPrompt() {
   return [
     'You write dry, witty microcopy for a humorous Swedish calendar app.',
-    'The tone is officious, ironic, and observant.',
+    'The default tone is officious, ironic, and observant unless the requested mood says otherwise.',
     'Avoid generic cheerfulness, marketing fluff, and emoji.',
     'Never joke about tragedy, disease, disability, violence, or memorial-type observances.',
     'Return valid JSON only.',
@@ -26,6 +43,7 @@ function buildUserPrompt(request) {
     `Locale: ${getLocaleLabel(request.locale)}`,
     `Content pack: ${request.contentPack}`,
     `Kind: ${request.kind}`,
+    `Mood: ${request.mood}`,
     `Date: ${request.date}`,
     `Primary title: ${request.title}`,
   ];
@@ -65,6 +83,7 @@ function buildUserPrompt(request) {
   lines.push(`Fallback title ending: ${request.fallbackTitleEnding || '(none)'}`);
   lines.push(`Fallback card note: ${request.fallbackCardNote || '(none)'}`);
   lines.push(`Fallback blurbs: ${request.fallbackBlurbs.join(' | ')}`);
+  lines.push(`Mood guidance: ${getMoodGuidance(request.mood)}`);
 
   if (request.kind === 'themeDay') {
     lines.push('Generate 6 alternative short title endings, 6 alternative supporting card notes, and 8 blurbs.');

--- a/fredagskoll-frontend/src/App.tsx
+++ b/fredagskoll-frontend/src/App.tsx
@@ -5,8 +5,6 @@ import mojoLogo from './mojo-logo.png';
 import publicLogo from './vkmf-logo-public.png';
 import {
   appText,
-  ordinaryThemeDayCardNotesByLocale,
-  ordinaryThemeDayTitleEndingsByLocale,
 } from './appText';
 import { buildInfo } from './buildInfo.generated';
 import { usesCompactPrimaryMedia, formatTitle, hasLongTitleWord } from './celebrationPresentation';
@@ -40,7 +38,16 @@ import {
 } from './locale';
 import { fetchNameDays } from './nameDays';
 import { getNationalDayPanel } from './nationalDays';
+import {
+  getAsIfThatWasNotEnough,
+  getOrdinaryNoHitBody,
+  getOrdinaryThemeDayCardNotes,
+  getOrdinaryThemeDayLead,
+  getOrdinaryThemeDayTitleEndings,
+  getOrdinaryTitle,
+} from './editorialText';
 import { getSeasonalNotes } from './seasonalNotes';
+import { getInitialMood, getMoodLabel, moodOptions, MOOD_STORAGE_KEY, Mood } from './mood';
 import { buildThemeDayBlurbs, filterThemeDays, joinWithAnd } from './themeDayBlurbs';
 import { getThemeDaysForDate } from './temadagar';
 import { getUpcomingNotables } from './upcomingNotables';
@@ -156,6 +163,7 @@ function App({
   const [showLanguageMenu, setShowLanguageMenu] = useState(false);
   const [showImageCredits, setShowImageCredits] = useState(false);
   const [isMobileLayout, setIsMobileLayout] = useState(getInitialMobileLayout);
+  const [mood, setMood] = useState<Mood>(getInitialMood);
   const [showUpcoming, setShowUpcoming] = useState(true);
   const [expandedMobileSections, setExpandedMobileSections] = useState<
     Record<MobileSectionKey, boolean>
@@ -170,18 +178,21 @@ function App({
   const [nameDays, setNameDays] = useState<string[]>([]);
   const [nameDayState, setNameDayState] = useState<NameDayState>('loading');
   const [aiBundle, setAiBundle] = useState<AiBlurbBundle | null>(null);
-  const [blurb, setBlurb] = useState(getOrdinaryBlurb(getInitialLocale()));
+  const [blurb, setBlurb] = useState(getOrdinaryBlurb(getInitialLocale(), getInitialMood()));
   const [themeDayTitleEnding, setThemeDayTitleEnding] = useState(
-    ordinaryThemeDayTitleEndingsByLocale[getInitialLocale()][0]
+    getOrdinaryThemeDayTitleEndings(getInitialLocale(), getInitialMood())[0]
   );
   const [themeDayCardNote, setThemeDayCardNote] = useState(
-    ordinaryThemeDayCardNotesByLocale[getInitialLocale()][0]
+    getOrdinaryThemeDayCardNotes(getInitialLocale(), getInitialMood())[0]
   );
 
   const text = appText[locale];
   const buildStamp = useMemo(() => formatBuildStamp(locale), [locale]);
-  const celebrations = useMemo(() => getCelebrations(locale, contentPack), [contentPack, locale]);
-  const ordinaryBlurb = useMemo(() => getOrdinaryBlurb(locale), [locale]);
+  const celebrations = useMemo(
+    () => getCelebrations(locale, contentPack, mood),
+    [contentPack, locale, mood]
+  );
+  const ordinaryBlurb = useMemo(() => getOrdinaryBlurb(locale, mood), [locale, mood]);
   const selectedDateObject = useMemo(
     () => new Date(`${selectedDate}T12:00:00`),
     [selectedDate]
@@ -233,8 +244,8 @@ function App({
   const theme = celebration?.theme ?? 'ordinary';
   const compactPrimaryMedia = usesCompactPrimaryMedia(dayStatus.dayType);
   const themeDayBlurbs = useMemo(
-    () => (!celebration && hasThemeDays ? buildThemeDayBlurbs(visibleThemeDays, locale) : null),
-    [celebration, hasThemeDays, locale, visibleThemeDays]
+    () => (!celebration && hasThemeDays ? buildThemeDayBlurbs(visibleThemeDays, locale, mood) : null),
+    [celebration, hasThemeDays, locale, mood, visibleThemeDays]
   );
   const currentBlurbs = useMemo(() => {
     if (aiBundle?.blurbs.length) {
@@ -253,8 +264,12 @@ function App({
       return null;
     }
 
-    return getOrdinaryDayBlurbs(locale, selectedDateObject.getDay() === 0 || selectedDateObject.getDay() === 6);
-  }, [aiBundle, celebration, dayStatus.dayType, locale, selectedDateObject, themeDayBlurbs]);
+    return getOrdinaryDayBlurbs(
+      locale,
+      selectedDateObject.getDay() === 0 || selectedDateObject.getDay() === 6,
+      mood
+    );
+  }, [aiBundle, celebration, dayStatus.dayType, locale, mood, selectedDateObject, themeDayBlurbs]);
   const kicker = celebration
     ? celebration.kicker
     : hasThemeDays
@@ -276,7 +291,7 @@ function App({
     ? celebration.title
     : hasThemeDays
       ? `${themeDayDisplayTitle}. ${themeDayTitleEnding}`
-      : text.ordinaryTitle;
+      : getOrdinaryTitle(locale, mood);
   const hasLongWordTitle = hasLongTitleWord(themeDayDisplayTitle ?? mainTitle);
 
   useEffect(() => {
@@ -302,13 +317,17 @@ function App({
   }, [locale]);
 
   useEffect(() => {
+    window.localStorage.setItem(MOOD_STORAGE_KEY, mood);
+  }, [mood]);
+
+  useEffect(() => {
     setShowLanguageMenu(false);
   }, [locale]);
 
   useEffect(() => {
     const controller = new AbortController();
-    const fallbackTitleEnding = ordinaryThemeDayTitleEndingsByLocale[locale][0];
-    const fallbackCardNote = ordinaryThemeDayCardNotesByLocale[locale][0];
+    const fallbackTitleEnding = getOrdinaryThemeDayTitleEndings(locale, mood)[0];
+    const fallbackCardNote = getOrdinaryThemeDayCardNotes(locale, mood)[0];
     const fallbackBlurbs = celebration
       ? celebration.blurbs
       : themeDayBlurbs
@@ -316,7 +335,8 @@ function App({
         : dayStatus.dayType === 'ordinary'
           ? getOrdinaryDayBlurbs(
               locale,
-              selectedDateObject.getDay() === 0 || selectedDateObject.getDay() === 6
+              selectedDateObject.getDay() === 0 || selectedDateObject.getDay() === 6,
+              mood
             )
           : [];
 
@@ -325,10 +345,11 @@ function App({
       locale,
       contentPack,
       kind,
+      mood,
       date: selectedDate,
       dateLabel: dayStatus.dateLabel,
       dayType: dayStatus.dayType,
-      title: celebration ? celebration.title : themeDayDisplayTitle ?? text.ordinaryTitle,
+      title: celebration ? celebration.title : themeDayDisplayTitle ?? getOrdinaryTitle(locale, mood),
       subtitle: celebration?.subtitle,
       kicker,
       fallbackTitleEnding,
@@ -374,11 +395,11 @@ function App({
     hasThemeDays,
     kicker,
     locale,
+    mood,
     nationalDayPanel,
     selectedDate,
     selectedDateObject,
     seasonalNotes,
-    text.ordinaryTitle,
     themeDayBlurbs,
     themeDayDisplayTitle,
     upcomingHolidayName,
@@ -398,27 +419,27 @@ function App({
     const endings =
       aiBundle?.titleEndings.length && themeDayDisplayTitle && !celebration
         ? aiBundle.titleEndings
-        : ordinaryThemeDayTitleEndingsByLocale[locale];
+        : getOrdinaryThemeDayTitleEndings(locale, mood);
     if (!themeDayDisplayTitle || celebration) {
       setThemeDayTitleEnding(endings[0]);
       return;
     }
 
     setThemeDayTitleEnding(getRandomItem(endings, endings[0]));
-  }, [aiBundle, selectedDate, locale, themeDayDisplayTitle, celebration]);
+  }, [aiBundle, selectedDate, locale, mood, themeDayDisplayTitle, celebration]);
 
   useEffect(() => {
     const notes =
       aiBundle?.cardNotes.length && hasThemeDays && !celebration
         ? aiBundle.cardNotes
-        : ordinaryThemeDayCardNotesByLocale[locale];
+        : getOrdinaryThemeDayCardNotes(locale, mood);
     if (!hasThemeDays || celebration) {
       setThemeDayCardNote(notes[0]);
       return;
     }
 
     setThemeDayCardNote(getRandomItem(notes, notes[0]));
-  }, [aiBundle, selectedDate, locale, hasThemeDays, celebration]);
+  }, [aiBundle, selectedDate, locale, mood, hasThemeDays, celebration]);
 
   useEffect(() => {
     let isCurrent = true;
@@ -543,6 +564,24 @@ function App({
               <span>{humanDate}</span>
               <span>{dayStatus.dateLabel}</span>
             </div>
+          </div>
+
+          <label htmlFor="mood-picker" className="picker-label">
+            {text.moodLabel}
+          </label>
+          <div className="picker-shell">
+            <select
+              id="mood-picker"
+              value={mood}
+              onChange={(event) => setMood(event.target.value as Mood)}
+              className="date-picker mood-picker"
+            >
+              {moodOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {getMoodLabel(option.value, locale)}
+                </option>
+              ))}
+            </select>
           </div>
 
           <div className="nameday-card">
@@ -770,7 +809,9 @@ function App({
                   <div className="theme-day-panel">
                     <span className="ordinary-badge">{text.extraThemeDays}</span>
                     <p>
-                      {text.asIfThatWasNotEnough(
+                      {getAsIfThatWasNotEnough(
+                        locale,
+                        mood,
                         extraThemeDayLead ?? '',
                         joinWithAnd(extraDisplayThemeDays, locale)
                       )}
@@ -791,8 +832,13 @@ function App({
               </span>
               <p>
                 {hasThemeDays
-                  ? text.ordinaryThemeDayLead(joinWithAnd(displayThemeDays, locale), themeDayCardNote)
-                  : text.ordinaryNoHitBody}
+                  ? getOrdinaryThemeDayLead(
+                      locale,
+                      mood,
+                      joinWithAnd(displayThemeDays, locale),
+                      themeDayCardNote
+                    )
+                  : getOrdinaryNoHitBody(locale, mood)}
               </p>
               {hasThemeDays ? (
                 <ul className="theme-day-list">

--- a/fredagskoll-frontend/src/aiBlurbs.ts
+++ b/fredagskoll-frontend/src/aiBlurbs.ts
@@ -1,10 +1,12 @@
 import { ContentPack } from './contentPack';
 import { Locale } from './locale';
+import { Mood } from './mood';
 
 export type AiBlurbRequest = {
   locale: Locale;
   contentPack: ContentPack;
   kind: 'celebration' | 'themeDay' | 'ordinary';
+  mood: Mood;
   date: string;
   dateLabel: string;
   dayType: string;

--- a/fredagskoll-frontend/src/appText.ts
+++ b/fredagskoll-frontend/src/appText.ts
@@ -76,6 +76,7 @@ export const appText: Record<
     title: string;
     lede: string;
     pickDate: string;
+    moodLabel: string;
     nameday: string;
     namedayLoading: string;
     namedayError: string;
@@ -136,6 +137,7 @@ export const appText: Record<
     lede:
       'Välj ett datum och låt appen avgöra om dagen förtjänar flaggor, bakverk, högtidston eller bara ett torrt konstaterande av kalenderns begränsningar.',
     pickDate: 'Välj datum',
+    moodLabel: 'Ton',
     nameday: 'Dagens namnsdag',
     namedayLoading: 'Laddar namnsdag från öppet API.',
     namedayError:
@@ -203,6 +205,7 @@ export const appText: Record<
     lede:
       'Pick a date and let the app decide whether it calls for flags, pastries, ceremonial energy, or just a dry acknowledgement of the calendar’s limitations.',
     pickDate: 'Choose date',
+    moodLabel: 'Tone',
     nameday: "Today's name day",
     namedayLoading: 'Loading name day from the open API.',
     namedayError:
@@ -270,6 +273,7 @@ export const appText: Record<
     lede:
       'Escolha uma data e deixe o app decidir se o dia merece bandeiras, doces, solenidade ou apenas um comentário seco sobre as limitações do calendário.',
     pickDate: 'Escolher data',
+    moodLabel: 'Tom',
     nameday: 'Nome do dia',
     namedayLoading: 'Carregando nome do dia pela API aberta.',
     namedayError:

--- a/fredagskoll-frontend/src/celebrations.ts
+++ b/fredagskoll-frontend/src/celebrations.ts
@@ -10,6 +10,7 @@ import celebrationsEn from './data/celebrations.en.json';
 import celebrationsPtBr from './data/celebrations.pt-BR.json';
 import { DayType } from './dayLogic';
 import { Locale } from './locale';
+import { Mood } from './mood';
 export type CelebrationTheme =
   | 'ordinary'
   | 'jam'
@@ -116,6 +117,417 @@ const ordinaryWeekendBlurbsSv = [
   'Ingen officiell anledning att samlas, skåla eller baka. Bara ett fritt datum med skrämmande mycket eget ansvar.',
   'Helgens stora innehåll idag är att den pågår. Man får tydligen vara tacksam för det.',
 ];
+
+function getMoodOrdinaryBlurb(locale: Locale, mood: Mood): string | null {
+  if (mood === 'dry') {
+    return null;
+  }
+
+  switch (mood) {
+    case 'cheerful':
+      return locale === 'en'
+        ? 'No major Swedish celebration is carrying the date, but the day is still workable with decent snacks and a little goodwill.'
+        : locale === 'pt-BR'
+          ? 'Nenhuma grande celebracao sueca esta carregando a data, mas o dia ainda funciona com um lanche decente e alguma boa vontade.'
+          : 'Ingen större svensk firardag bär datumet, men dagen är fortfarande fullt användbar med något gott och lite god vilja.';
+    case 'formal':
+      return locale === 'en'
+        ? 'No Swedish celebration of sufficient weight has been identified for this date.'
+        : locale === 'pt-BR'
+          ? 'Nenhuma celebracao sueca de peso suficiente foi identificada para esta data.'
+          : 'Ingen svensk firardag av tillräcklig dignitet har identifierats för detta datum.';
+    case 'warm':
+      return locale === 'en'
+        ? 'No major Swedish celebration turned up here, but the date does not have to be treated harshly for that.'
+        : locale === 'pt-BR'
+          ? 'Nenhuma grande celebracao sueca apareceu aqui, mas a data nao precisa ser tratada com dureza por isso.'
+          : 'Ingen större svensk firardag dök upp här, men datumet behöver inte behandlas hårt för det.';
+    case 'chaotic':
+      return locale === 'en'
+        ? 'No Swedish celebration arrived to stabilize the situation. The date is basically freestyling now.'
+        : locale === 'pt-BR'
+          ? 'Nenhuma celebracao sueca apareceu para estabilizar a situacao. A data esta basicamente improvisando agora.'
+          : 'Ingen svensk firardag kom för att stabilisera läget. Datumet frijazzar i princip nu.';
+    case 'absurd':
+      return locale === 'en'
+        ? 'No Swedish celebration claimed the date, so it is left wandering the halls in ordinary office clothes.'
+        : locale === 'pt-BR'
+          ? 'Nenhuma celebracao sueca reivindicou a data, entao ela ficou vagando pelos corredores em roupa de escritorio.'
+          : 'Ingen svensk firardag gjorde anspråk på datumet, så det går nu runt i korridoren klätt som en vanlig arbetsdag.';
+    default:
+      return null;
+  }
+}
+
+function getMoodOrdinaryDayBlurbs(
+  locale: Locale,
+  isWeekend: boolean,
+  mood: Mood
+): string[] | null {
+  if (mood === 'dry') {
+    return null;
+  }
+
+  if (locale === 'en') {
+    if (mood === 'cheerful') {
+      return isWeekend
+        ? [
+            'It is a plain weekend, which is still a respectable excuse to move slowly and drink something warm.',
+            'No holiday is carrying the weekend, but the schedule has at least relaxed its jaw a little.',
+            'The date offers no official party, only free time with decent recovery potential.',
+            'Nothing ceremonial is happening, which leaves more room for snacks, air, and low-stakes plans.',
+          ]
+        : [
+            'It is a regular workday, but the day is still salvageable with coffee and moderate competence.',
+            'No celebration has rescued the date, though it remains structurally capable of becoming decent.',
+            'This is an ordinary weekday, which mostly means the bar for success can stay pleasantly low.',
+            'The calendar provided no fanfare, but the day still has room for one useful decision and a proper lunch.',
+          ];
+    }
+    if (mood === 'formal') {
+      return isWeekend
+        ? [
+            'This weekend date carries no official ceremonial burden.',
+            'No holiday directive has been attached to the day. Private management is therefore advised.',
+            'The weekend remains in standard operating condition, absent any larger tradition.',
+            'No formal observance intervenes here; the date is proceeding under ordinary leisure rules.',
+          ]
+        : [
+            'This is a standard workday with no sanctioned festive exception.',
+            'No official observance has been assigned to the date.',
+            'The weekday remains operationally ordinary and will require self-supplied motivation.',
+            'No public tradition has been registered here; routine procedures remain in force.',
+          ];
+    }
+    if (mood === 'warm') {
+      return isWeekend
+        ? [
+            'It is only a normal weekend, but that still leaves room for gentler pacing and a little grace.',
+            'No holiday is lifting the date, though the day can still be kind if people allow it.',
+            'The weekend arrived without fireworks, which is not the same thing as arriving empty.',
+            'Nothing official is happening, and that may be reason enough to breathe a bit.',
+          ]
+        : [
+            'It is a regular workday, but not every decent day needs ceremonial help.',
+            'No celebration came to rescue the date, though a calm lunch and a humane tone would still improve it.',
+            'The day is ordinary, which is not ideal, but not a moral failure either.',
+            'No holiday is carrying this weekday. People will have to be slightly nicer on their own.',
+          ];
+    }
+    if (mood === 'chaotic') {
+      return isWeekend
+        ? [
+            'It is technically the weekend, though the date is carrying a faint smell of abandoned plans.',
+            'No holiday took command here, so the day is mostly free-range leisure with loose wiring.',
+            'The weekend has no official plot today, only momentum and whatever was left in the fridge.',
+            'Nothing ceremonial showed up, so the date is just roaming around in socks with poor supervision.',
+          ]
+        : [
+            'This is a regular workday and the calendar has provided no protective equipment.',
+            'No celebration has saved the date, so the day is out here making eye contact with meetings unaided.',
+            'The weekday is fully ordinary and therefore exposed to all the usual operational nonsense.',
+            'No tradition is carrying this date. It is just you, the clock, and a slightly unstable chain of decisions.',
+          ];
+    }
+    return isWeekend
+      ? [
+          'It is an ordinary weekend, drifting around with no official costume and suspiciously little doctrine.',
+          'No holiday claimed the date. It has therefore become a free-floating pocket of leisure in civilian clothes.',
+          'The weekend is unsupervised by tradition today, which gives it a mildly experimental quality.',
+          'Nothing formal is happening. The date is basically lying on a sofa inside the calendar.',
+        ]
+      : [
+          'This is a standard weekday with no festival attached, a beige rectangle wearing a wristwatch.',
+          'No celebration arrived, so the day has been left to walk upright under its own administrative power.',
+          'The calendar submitted an unadorned weekday and expected everyone to pretend that was normal.',
+          'No public excuse is available. The date is simply standing there in office shoes.',
+        ];
+  }
+
+  if (locale === 'pt-BR') {
+    if (mood === 'cheerful') {
+      return isWeekend
+        ? [
+            'E um fim de semana comum, o que ainda e uma desculpa bastante respeitavel para andar devagar e beber algo quente.',
+            'Nenhum feriado esta carregando o dia, mas a agenda ao menos afrouxou a gravata.',
+            'A data nao oferece festa oficial, so tempo livre com algum potencial de recuperacao.',
+            'Nada cerimonial esta acontecendo, o que deixa mais espaco para lanches, ar fresco e planos modestos.',
+          ]
+        : [
+            'E um dia util comum, mas ainda perfeitamente salvavel com cafe e alguma competencia.',
+            'Nenhuma celebracao salvou a data, mas ela continua estruturalmente capaz de ficar decente.',
+            'E um dia de semana comum, o que tambem significa que a barra do sucesso pode continuar agradavelmente baixa.',
+            'O calendario nao ofereceu fanfarra nenhuma, mas o dia ainda comporta uma boa decisao e um almoco digno.',
+          ];
+    }
+    if (mood === 'formal') {
+      return isWeekend
+        ? [
+            'Esta data de fim de semana nao possui carga cerimonial oficial.',
+            'Nenhuma diretriz festiva foi anexada ao dia. Recomenda-se gestao privada.',
+            'O fim de semana permanece em condicao operacional padrao, sem tradicao maior associada.',
+            'Nenhuma observancia formal intervem aqui; a data segue em regime comum de lazer.',
+          ]
+        : [
+            'Trata-se de um dia util padrao sem excecao festiva sancionada.',
+            'Nenhuma observancia oficial foi atribuida a data.',
+            'O dia util permanece operacionalmente comum e exigira motivacao fornecida pelo proprio usuario.',
+            'Nenhuma tradicao publica foi registrada aqui; os procedimentos rotineiros seguem em vigor.',
+          ];
+    }
+    if (mood === 'warm') {
+      return isWeekend
+        ? [
+            'E apenas um fim de semana comum, mas isso ainda deixa espaco para um ritmo mais gentil.',
+            'Nenhum feriado elevou a data, embora o dia ainda possa ser acolhedor se as pessoas permitirem.',
+            'O fim de semana chegou sem fogos de artificio, o que nao e a mesma coisa que chegar vazio.',
+            'Nada oficial esta acontecendo, e isso talvez ja seja motivo suficiente para respirar com calma.',
+          ]
+        : [
+            'E um dia util comum, mas nem todo bom dia precisa de ajuda cerimonial.',
+            'Nenhuma celebracao veio salvar a data, embora um almoco tranquilo e um tom humano ainda ajudem muito.',
+            'O dia e ordinario, o que nao e ideal, mas tambem nao e uma tragedia moral.',
+            'Nenhum feriado esta carregando esta quarta-feira. As pessoas vao ter de ser um pouco mais gentis por conta propria.',
+          ];
+    }
+    if (mood === 'chaotic') {
+      return isWeekend
+        ? [
+            'Tecnicamente e fim de semana, embora a data carregue um cheiro leve de planos abandonados.',
+            'Nenhum feriado assumiu o comando aqui, entao o dia virou lazer de criacao livre com fiacao frouxa.',
+            'O fim de semana nao tem enredo oficial hoje, so impulso e o que restou na geladeira.',
+            'Nada cerimonial apareceu, entao a data esta andando por ai de meia e sem supervisao.',
+          ]
+        : [
+            'Isto e um dia util comum e o calendario nao forneceu equipamento de protecao.',
+            'Nenhuma celebracao salvou a data, entao o dia esta encarando reunioes sem assistencia.',
+            'O dia util e completamente comum e, portanto, exposto a todo o absurdo operacional habitual.',
+            'Nenhuma tradicao esta carregando esta data. E so voce, o relogio e uma cadeia meio instavel de decisoes.',
+          ];
+    }
+    return isWeekend
+      ? [
+          'E um fim de semana comum, vagando por ai sem fantasia oficial e com surpreendentemente pouca doutrina.',
+          'Nenhum feriado reivindicou a data. Ela virou um bolso de lazer flutuando em roupa civil.',
+          'O fim de semana esta hoje sem supervisao da tradicao, o que lhe confere uma qualidade levemente experimental.',
+          'Nada formal esta acontecendo. A data basicamente se deitou no sofa dentro do calendario.',
+        ]
+      : [
+          'Isto e um dia util padrao sem festa associada, um retangulo bege de relogio no pulso.',
+          'Nenhuma celebracao chegou, entao o dia foi deixado para caminhar ereto por conta propria.',
+          'O calendario enviou um dia util sem adornos e esperou que todos fingissem que isso era normal.',
+          'Nenhuma desculpa publica esta disponivel. A data esta apenas ali, em sapatos sociais.',
+        ];
+  }
+
+  if (mood === 'cheerful') {
+    return isWeekend
+      ? [
+          'Det är en vanlig helg, vilket fortfarande är en fullt respektabel ursäkt att ta det lugnt och dricka något varmt.',
+          'Ingen högtid bär datumet, men schemat har åtminstone släppt käkarna lite.',
+          'Datumet erbjuder ingen officiell fest, bara ledig tid med hygglig återhämtningspotential.',
+          'Inget ceremoniellt pågår, vilket lämnar mer utrymme för fika, luft och rimliga småplaner.',
+        ]
+      : [
+          'Det är en vanlig arbetsdag, men dagen är fortfarande räddningsbar med kaffe och måttlig kompetens.',
+          'Ingen högtid kom och räddade datumet, men det är fortfarande strukturellt kapabelt att bli helt okej.',
+          'Det här är en vanlig vardag, vilket också betyder att ribban för framgång får vara behagligt låg.',
+          'Kalendern bjöd inte på fanfarer, men dagen rymmer fortfarande ett klokt beslut och en vettig lunch.',
+        ];
+  }
+
+  if (mood === 'formal') {
+    return isWeekend
+      ? [
+          'Denna helgdag saknar officiell ceremoniell belastning.',
+          'Ingen högtidsanvisning har knutits till datumet. Privat hantering rekommenderas.',
+          'Helgen befinner sig i standardläge, utan större traditionellt ingrepp.',
+          'Ingen formell observans intervenerar här; datumet fortgår under ordinarie fritidsregim.',
+        ]
+      : [
+          'Detta är en standardarbetsdag utan sanktionerat festundantag.',
+          'Ingen officiell observans har tilldelats datumet.',
+          'Vardagen förblir operativt ordinär och kräver självförsörjd motivation.',
+          'Ingen offentlig tradition har registrerats här; rutinmässiga förfaranden gäller fortsatt.',
+        ];
+  }
+
+  if (mood === 'warm') {
+    return isWeekend
+      ? [
+          'Det är bara en vanlig helg, men det lämnar ändå plats för ett lite vänligare tempo.',
+          'Ingen högtid lyfter datumet, men dagen kan fortfarande bli mild om folk tillåter det.',
+          'Helgen kom utan fanfarer, vilket inte är samma sak som att den kom tomhänt.',
+          'Inget officiellt pågår, och det kan faktiskt räcka långt för en stunds återhämtning.',
+        ]
+      : [
+          'Det är en vanlig arbetsdag, men inte varje hygglig dag behöver ceremoniell hjälp.',
+          'Ingen högtid kom och bar datumet, men lugn lunch och mänskligt tonfall hjälper fortfarande.',
+          'Dagen är ordinär, vilket inte är idealiskt men heller inte ett moraliskt misslyckande.',
+          'Ingen tradition bär den här vardagen. Folk får vara lite trevligare på eget initiativ.',
+        ];
+  }
+
+  if (mood === 'chaotic') {
+    return isWeekend
+      ? [
+          'Det är tekniskt sett helg, även om datumet luktar svagt av övergivna planer.',
+          'Ingen högtid tog kommandot här, så dagen blev frilansfritid med lös kabeldragning.',
+          'Helgen har ingen officiell intrig idag, bara momentum och det som låg kvar i kylen.',
+          'Inget ceremoniellt dök upp, så datumet går mest runt i strumplästen utan vuxenstöd.',
+        ]
+      : [
+          'Det här är en vanlig arbetsdag och kalendern har inte tillhandahållit skyddsutrustning.',
+          'Ingen högtid räddade datumet, så dagen får ta ögonkontakt med möten helt oskyddad.',
+          'Vardagen är fullt ordinär och därmed utsatt för all den vanliga operativa dårskapen.',
+          'Ingen tradition bär det här datumet. Det är bara du, klockan och en lätt instabil kedja av beslut.',
+        ];
+  }
+
+  return isWeekend
+    ? [
+        'Det är en vanlig helg som glider runt utan officiell kostym och med misstänkt lite doktrin.',
+        'Ingen högtid gjorde anspråk på datumet. Det blev alltså ett fritt flytande fritidsfack i civila kläder.',
+        'Helgen saknar idag tillsyn från traditionen, vilket ger den en lätt experimentell kvalitet.',
+        'Inget formellt pågår. Datumet ligger i princip på en soffa inne i kalendern.',
+      ]
+    : [
+        'Det här är en standardvardag utan fest kopplad till sig, en beige rektangel med armbandsur.',
+        'Ingen högtid anlände, så dagen lämnades åt att gå upprätt under egen administrativ kraft.',
+        'Kalendern skickade fram en osmyckad vardag och väntade sig att alla skulle låtsas att det var normalt.',
+        'Ingen offentlig ursäkt står till buds. Datumet står bara där i kontorsskor.',
+      ];
+}
+
+function getMoodCelebrationBlurbs(
+  content: CelebrationContent,
+  locale: Locale,
+  mood: Mood
+): string[] | null {
+  if (mood === 'dry') {
+    return null;
+  }
+
+  const subject = content.alt ?? content.title;
+
+  if (locale === 'en') {
+    switch (mood) {
+      case 'cheerful':
+        return [
+          `${subject} is in charge today, which is honestly a decent reason to lighten up a little.`,
+          `The date has handed itself over to ${content.kicker.toLowerCase()}, and the atmosphere is better for it.`,
+          `If ${subject} gets to run the day, the sensible response is snacks, generosity, and lower shoulders.`,
+          `${subject} gives the calendar enough energy to make even routine look slightly more forgivable.`,
+        ];
+      case 'formal':
+        return [
+          `${subject} has been granted temporary ceremonial priority.`,
+          `Today's operational mood is best summarized as ${content.kicker.toLowerCase()}.`,
+          `${subject} carries sufficient symbolic weight to justify a modest change in posture.`,
+          `The date is now proceeding under the influence of ${subject}.`,
+        ];
+      case 'warm':
+        return [
+          `${subject} is steering the date today, and the day is probably better for being treated a little more gently.`,
+          `There are harsher ways to spend a date than under the influence of ${content.kicker.toLowerCase()}.`,
+          `${subject} makes the day feel less mechanical and a bit more human.`,
+          `If the calendar insists on ${subject}, we may as well meet it with some grace.`,
+        ];
+      case 'chaotic':
+        return [
+          `${subject} has clearly seized the controls, and the schedule is not recovering elegantly.`,
+          `Today's official energy is ${content.kicker.toLowerCase()}, which explains quite a lot.`,
+          `${subject} is now running the room with more confidence than the adults present.`,
+          `The date has tilted hard toward ${subject}, and normal procedure can only wave from the shore.`,
+        ];
+      default:
+        return [
+          `${subject} has slipped into the date and started rearranging the furniture.`,
+          `Today's atmosphere can only be described as ${content.kicker.toLowerCase()} wearing a borrowed badge.`,
+          `${subject} gives the calendar a strangely specific face and expects everyone to accept it.`,
+          `The day is now under the decorative authority of ${subject}. Resistance would be theatrical.`,
+        ];
+    }
+  }
+
+  if (locale === 'pt-BR') {
+    switch (mood) {
+      case 'cheerful':
+        return [
+          `${subject} esta no comando hoje, o que honestamente ja e um bom motivo para relaxar um pouco.`,
+          `A data se entregou a ${content.kicker.toLowerCase()}, e o clima ficou melhor por isso.`,
+          `Se ${subject} vai conduzir o dia, a resposta sensata e lanches, generosidade e ombros menos tensos.`,
+          `${subject} da ao calendario energia suficiente para tornar a rotina um pouco mais perdoavel.`,
+        ];
+      case 'formal':
+        return [
+          `${subject} recebeu prioridade cerimonial temporaria.`,
+          `O estado operacional de hoje pode ser resumido como ${content.kicker.toLowerCase()}.`,
+          `${subject} carrega peso simbolico suficiente para justificar uma pequena mudanca de postura.`,
+          `A data prossegue agora sob influencia de ${subject}.`,
+        ];
+      case 'warm':
+        return [
+          `${subject} esta conduzindo a data hoje, e o dia provavelmente melhora se for tratado com um pouco mais de gentileza.`,
+          `Existem maneiras bem mais duras de passar uma data do que sob a influencia de ${content.kicker.toLowerCase()}.`,
+          `${subject} faz o dia parecer menos mecanico e um pouco mais humano.`,
+          `Se o calendario insiste em ${subject}, o minimo e responder com alguma graca.`,
+        ];
+      case 'chaotic':
+        return [
+          `${subject} claramente tomou os controles, e a agenda nao vai se recuperar com elegancia.`,
+          `A energia oficial de hoje e ${content.kicker.toLowerCase()}, o que explica muita coisa.`,
+          `${subject} esta comandando o ambiente com mais confianca do que os adultos presentes.`,
+          `A data tombou forte na direcao de ${subject}, e o procedimento normal so consegue acenar de longe.`,
+        ];
+      default:
+        return [
+          `${subject} entrou na data e comecou a rearranjar os moveis.`,
+          `A atmosfera de hoje so pode ser descrita como ${content.kicker.toLowerCase()} usando um cracha emprestado.`,
+          `${subject} deu ao calendario um rosto estranhamente especifico e espera que todo mundo aceite.`,
+          `O dia agora opera sob a autoridade decorativa de ${subject}. Resistir seria puro teatro.`,
+        ];
+    }
+  }
+
+  switch (mood) {
+    case 'cheerful':
+      return [
+        `${subject} håller i taktpinnen idag, vilket faktiskt är en rätt hygglig anledning att lätta lite på axlarna.`,
+        `Datumet har överlämnat sig till ${content.kicker.toLowerCase()}, och stämningen mår märkbart bättre av det.`,
+        `Om ${subject} får styra dagen är det klokast att svara med fika, generositet och lägre axelparti.`,
+        `${subject} ger kalendern precis nog energi för att till och med rutinen ska kännas lite mer förlåtlig.`,
+      ];
+    case 'formal':
+      return [
+        `${subject} har tilldelats tillfällig ceremoniell prioritet.`,
+        `Dagens operativa läge kan sammanfattas som ${content.kicker.toLowerCase()}.`,
+        `${subject} bär tillräcklig symbolisk tyngd för att motivera viss hållningsförändring.`,
+        `Datumet fortgår nu under påverkan av ${subject}.`,
+      ];
+    case 'warm':
+      return [
+        `${subject} styr datumet idag, och dagen blir sannolikt bättre om den behandlas lite vänligare än vanligt.`,
+        `Det finns betydligt hårdare sätt att tillbringa ett datum än under inflytande av ${content.kicker.toLowerCase()}.`,
+        `${subject} gör dagen mindre mekanisk och något mer mänsklig.`,
+        `Om kalendern nu insisterar på ${subject}, kan vi åtminstone möta det med viss grace.`,
+      ];
+    case 'chaotic':
+      return [
+        `${subject} har tydligt tagit kontrollerna och schemat återhämtar sig inte särskilt värdigt.`,
+        `Dagens officiella energi är ${content.kicker.toLowerCase()}, vilket förklarar en hel del.`,
+        `${subject} driver nu rummet med större självförtroende än de vuxna som råkar vara där.`,
+        `Datumet har lutat hårt åt ${subject}, och normalförfarandet får mest stå vid strandlinjen och vinka.`,
+      ];
+    default:
+      return [
+        `${subject} har glidit in i datumet och börjat möblera om.`,
+        `Dagens atmosfär kan bara beskrivas som ${content.kicker.toLowerCase()} med lånat tjänstekort.`,
+        `${subject} ger kalendern ett märkligt specifikt ansikte och förväntar sig att alla accepterar läget.`,
+        `Dagen står nu under dekorativ auktoritet från ${subject}. Motstånd vore mest teater.`,
+      ];
+  }
+}
 
 function getCelebrationThemeAliasesSv(dayType: Exclude<DayType, 'ordinary'>): string[] {
   switch (dayType) {
@@ -593,7 +1005,12 @@ const { shared: sharedAliasesEn, teamOnly: teamAliasesEn } =
 const { shared: sharedAliasesPtBr, teamOnly: teamAliasesPtBr } =
   splitCelebrationsByPack(portugueseCelebrationContent.celebrationThemeAliases);
 
-export function getOrdinaryBlurb(locale: Locale): string {
+export function getOrdinaryBlurb(locale: Locale, mood: Mood = 'dry'): string {
+  const moodSpecific = getMoodOrdinaryBlurb(locale, mood);
+  if (moodSpecific) {
+    return moodSpecific;
+  }
+
   if (locale === 'en') {
     return englishCelebrationContent.ordinaryBlurb;
   }
@@ -605,7 +1022,16 @@ export function getOrdinaryBlurb(locale: Locale): string {
   return ordinaryBlurbSv;
 }
 
-export function getOrdinaryDayBlurbs(locale: Locale, isWeekend: boolean): string[] {
+export function getOrdinaryDayBlurbs(
+  locale: Locale,
+  isWeekend: boolean,
+  mood: Mood = 'dry'
+): string[] {
+  const moodSpecific = getMoodOrdinaryDayBlurbs(locale, isWeekend, mood);
+  if (moodSpecific) {
+    return moodSpecific;
+  }
+
   if (locale === 'en') {
     return isWeekend
       ? englishCelebrationContent.ordinaryWeekendBlurbs
@@ -649,8 +1075,10 @@ export function getCelebrationThemeAliases(
 
 export function getCelebrations(
   locale: Locale,
-  contentPack: ContentPack = getActiveContentPack()
+  contentPack: ContentPack = getActiveContentPack(),
+  mood: Mood = 'dry'
 ): Record<Exclude<DayType, 'ordinary'>, CelebrationContent> {
+  const base = (() => {
   if (locale === 'en') {
     return (contentPack === 'team'
       ? { ...sharedCelebrationsEn, ...teamCelebrationsEn }
@@ -666,4 +1094,19 @@ export function getCelebrations(
   return (contentPack === 'team'
     ? { ...sharedCelebrationsSv, ...teamCelebrationsSv }
     : sharedCelebrationsSv) as Record<Exclude<DayType, 'ordinary'>, CelebrationContent>;
+  })();
+
+  if (mood === 'dry') {
+    return base;
+  }
+
+  return Object.fromEntries(
+    Object.entries(base).map(([dayType, content]) => [
+      dayType,
+      {
+        ...content,
+        blurbs: getMoodCelebrationBlurbs(content, locale, mood) ?? content.blurbs,
+      },
+    ])
+  ) as Record<Exclude<DayType, 'ordinary'>, CelebrationContent>;
 }

--- a/fredagskoll-frontend/src/editorialText.ts
+++ b/fredagskoll-frontend/src/editorialText.ts
@@ -1,0 +1,283 @@
+import { Locale } from './locale';
+import { Mood } from './mood';
+
+function byLocale(locale: Locale, values: Record<Locale, string>): string {
+  return values[locale];
+}
+
+export function getOrdinaryTitle(locale: Locale, mood: Mood): string {
+  switch (mood) {
+    case 'cheerful':
+      return byLocale(locale, {
+        sv: 'En vanlig dag. Ovant nog fullt brukbar.',
+        en: 'Just an ordinary day. Surprisingly serviceable.',
+        'pt-BR': 'So um dia comum. Estranhamente aproveitavel.',
+      });
+    case 'formal':
+      return byLocale(locale, {
+        sv: 'En ordinär dag. Administrationen fortgår.',
+        en: 'An ordinary day. Operations proceed.',
+        'pt-BR': 'Um dia ordinario. A operacao prossegue.',
+      });
+    case 'warm':
+      return byLocale(locale, {
+        sv: 'En vanlig dag. Den får väl behandlas hyggligt ändå.',
+        en: 'Just an ordinary day. It still deserves decent treatment.',
+        'pt-BR': 'So um dia comum. Ainda merece um pouco de decencia.',
+      });
+    case 'chaotic':
+      return byLocale(locale, {
+        sv: 'En vanlig dag. Ingen styr den här skutan särskilt snyggt.',
+        en: 'Just an ordinary day. Nobody is steering this ship elegantly.',
+        'pt-BR': 'So um dia comum. Ninguem esta conduzindo isso com elegancia.',
+      });
+    case 'absurd':
+      return byLocale(locale, {
+        sv: 'En vanlig dag. Kalendern har återigen valt beige dramatik.',
+        en: 'Just an ordinary day. The calendar chose beige drama again.',
+        'pt-BR': 'So um dia comum. O calendario escolheu um drama bege de novo.',
+      });
+    default:
+      return byLocale(locale, {
+        sv: 'En vanlig dag. Så sorgligt är det.',
+        en: 'Just an ordinary day. Grim stuff.',
+        'pt-BR': 'Só um dia comum. Triste, mas é isso.',
+      });
+  }
+}
+
+export function getOrdinaryNoHitBody(locale: Locale, mood: Mood): string {
+  switch (mood) {
+    case 'cheerful':
+      return byLocale(locale, {
+        sv: 'Datumet är kontrollerat. Ingen officiell fest dök upp, men dagen är åtminstone fortfarande användbar för kaffe, luft och rimliga ambitioner.',
+        en: 'The date has been checked. No official celebration turned up, but the day remains perfectly usable for coffee, air, and modest ambition.',
+        'pt-BR': 'A data foi verificada. Nao apareceu nenhuma celebracao oficial, mas o dia ainda serve muito bem para cafe, ar fresco e ambicoes modestas.',
+      });
+    case 'formal':
+      return byLocale(locale, {
+        sv: 'Datumet har granskats. Ingen semla, ingen sill och ingen officiell ursäkt kunde konstateras.',
+        en: 'The date has been reviewed. No semla, no herring, and no official excuse could be established.',
+        'pt-BR': 'A data foi analisada. Nao se constatou semla, arenque nem desculpa oficial.',
+      });
+    case 'warm':
+      return byLocale(locale, {
+        sv: 'Datumet har kollats. Ingen tradition kom och lyfte det, men dagen klarar sig nog med lite tålamod och hyggligt tonfall.',
+        en: 'The date has been checked. No tradition came to lift it, but the day will probably manage with a little patience and a decent tone.',
+        'pt-BR': 'A data foi verificada. Nenhuma tradicao veio salvar o dia, mas ele provavelmente se aguenta com um pouco de paciencia e um tom decente.',
+      });
+    case 'chaotic':
+      return byLocale(locale, {
+        sv: 'Datumet är genomsökt. Ingen semla, ingen sill, ingen bullplikt. Bara ren operativ friktion och vad det nu är vi håller på med här.',
+        en: 'The date has been searched. No semla, no herring, no bun obligation. Just raw operational friction and whatever it is we are doing here.',
+        'pt-BR': 'A data foi vasculhada. Nada de semla, nada de arenque, nada de obrigacao de bolo. So friccao operacional e seja la o que estamos fazendo aqui.',
+      });
+    case 'absurd':
+      return byLocale(locale, {
+        sv: 'Datumet har undersökts och visade sig sakna både högtid och användbar mytologi. Bara en frigående vardag i slips.',
+        en: 'The date was examined and proved to contain neither celebration nor useful mythology. Just a free-range weekday in a tie.',
+        'pt-BR': 'A data foi examinada e revelou nao conter nem celebracao nem mitologia util. So um dia util de gravata andando solto.',
+      });
+    default:
+      return byLocale(locale, {
+        sv: 'Datumet har kollats. Systemet fann ingen semla, ingen sill, ingen bullplikt och ingen kollektiv ursäkt för att tappa fokus.',
+        en: 'The date has been checked. The system found no semla, no herring, no bun obligation, and no collective excuse to lose focus.',
+        'pt-BR': 'A data foi verificada. O sistema nao encontrou semla, arenque, obrigacao de bolo nem desculpa coletiva para perder o foco.',
+      });
+  }
+}
+
+export function getOrdinaryThemeDayLead(
+  locale: Locale,
+  mood: Mood,
+  days: string,
+  note: string
+): string {
+  switch (mood) {
+    case 'cheerful':
+      return byLocale(locale, {
+        sv: `Temadagsmotorn hittade ${days}. ${note}`,
+        en: `The theme-day engine found ${days}. ${note}`,
+        'pt-BR': `O motor de datas tematicas encontrou ${days}. ${note}`,
+      });
+    case 'formal':
+      return byLocale(locale, {
+        sv: `Temadagsmotorn identifierade ${days}. ${note}`,
+        en: `The theme-day engine identified ${days}. ${note}`,
+        'pt-BR': `O motor de datas tematicas identificou ${days}. ${note}`,
+      });
+    case 'warm':
+      return byLocale(locale, {
+        sv: `Temadagsmotorn lyckades faktiskt hitta ${days}. ${note}`,
+        en: `The theme-day engine actually managed to find ${days}. ${note}`,
+        'pt-BR': `O motor de datas tematicas conseguiu achar ${days}. ${note}`,
+      });
+    case 'chaotic':
+      return byLocale(locale, {
+        sv: `Temadagsmotorn hittade ${days}, vilket åtminstone förklarar varför datumet plötsligt beter sig märkligt. ${note}`,
+        en: `The theme-day engine found ${days}, which at least explains why the date is behaving strangely. ${note}`,
+        'pt-BR': `O motor de datas tematicas encontrou ${days}, o que pelo menos explica por que a data esta agindo de forma estranha. ${note}`,
+      });
+    case 'absurd':
+      return byLocale(locale, {
+        sv: `Temadagsmotorn hittade ${days}. Kalendern har alltså återigen beviljat ett märkligt ämne officiell-ish luft. ${note}`,
+        en: `The theme-day engine found ${days}. The calendar has once again granted an odd subject semi-official oxygen. ${note}`,
+        'pt-BR': `O motor de datas tematicas encontrou ${days}. O calendario voltou a conceder oxigenio semi-oficial a um assunto esquisito. ${note}`,
+      });
+    default:
+      return byLocale(locale, {
+        sv: `Temadagsmotorn hittade ${days}. ${note}`,
+        en: `The theme-day engine found ${days}. ${note}`,
+        'pt-BR': `O motor de datas tematicas encontrou ${days}. ${note}`,
+      });
+  }
+}
+
+export function getAsIfThatWasNotEnough(
+  locale: Locale,
+  mood: Mood,
+  leadDay: string,
+  days: string
+): string {
+  const lowerLead = leadDay.toLowerCase();
+  switch (mood) {
+    case 'cheerful':
+      return byLocale(locale, {
+        sv: `Som om ${lowerLead} inte redan gav dagen tillräckligt med energi, så ligger även ${days} och hjälper till i kulisserna.`,
+        en: `As if ${lowerLead} did not already give the day enough energy, ${days} is also helping from the wings.`,
+        'pt-BR': `Como se ${lowerLead} ja nao desse energia suficiente ao dia, ${days} tambem esta ajudando nos bastidores.`,
+      });
+    case 'formal':
+      return byLocale(locale, {
+        sv: `Som om ${lowerLead} inte var tillräckligt, pågår även ${days} parallellt.`,
+        en: `As if ${lowerLead} were not sufficient, ${days} is also in progress.`,
+        'pt-BR': `Como se ${lowerLead} nao bastasse, ${days} tambem esta em curso.`,
+      });
+    case 'warm':
+      return byLocale(locale, {
+        sv: `Som om ${lowerLead} inte räckte, så får dagen även sällskap av ${days} i bakgrunden.`,
+        en: `As if ${lowerLead} were not enough, the day is also quietly accompanied by ${days}.`,
+        'pt-BR': `Como se ${lowerLead} nao bastasse, o dia ainda conta com a companhia de ${days} ao fundo.`,
+      });
+    case 'chaotic':
+      return byLocale(locale, {
+        sv: `Som om ${lowerLead} inte var nog, pågår även ${days} och gör schemat märkbart mindre trovärdigt.`,
+        en: `As if ${lowerLead} were not enough, ${days} is also happening and making the schedule less credible.`,
+        'pt-BR': `Como se ${lowerLead} nao bastasse, ${days} tambem esta acontecendo e reduzindo bastante a credibilidade da agenda.`,
+      });
+    case 'absurd':
+      return byLocale(locale, {
+        sv: `Som om ${lowerLead} inte räckte, har även ${days} glidit in och börjat andas i datumets nacke.`,
+        en: `As if ${lowerLead} were not enough, ${days} has also drifted in and started breathing on the date's neck.`,
+        'pt-BR': `Como se ${lowerLead} nao bastasse, ${days} tambem entrou de fininho e comecou a respirar no pescoco da data.`,
+      });
+    default:
+      return byLocale(locale, {
+        sv: `Som om ${lowerLead} inte räckte, så pågår även ${days} i bakgrunden.`,
+        en: `As if ${lowerLead} was not enough, ${days} is also rattling around in the background.`,
+        'pt-BR': `Como se ${lowerLead} nao bastasse, ${days} tambem esta rondando a data ao fundo.`,
+      });
+  }
+}
+
+export function getOrdinaryThemeDayTitleEndings(locale: Locale, mood: Mood): string[] {
+  switch (mood) {
+    case 'cheerful':
+      return [
+        byLocale(locale, { sv: 'Det piggar upp mer än man kunde begära.', en: 'It brightens the day more than strictly necessary.', 'pt-BR': 'Anima o dia mais do que o necessario.' }),
+        byLocale(locale, { sv: 'Det får gärna bära stämningen en stund.', en: 'It may as well carry the mood for a while.', 'pt-BR': 'Pode muito bem sustentar o clima por um tempo.' }),
+        byLocale(locale, { sv: 'Det här känns ändå ganska trevligt.', en: 'This is honestly rather pleasant.', 'pt-BR': 'Isso esta honestamente bem agradavel.' }),
+        byLocale(locale, { sv: 'Kalendern kunde ha gjort betydligt sämre ifrån sig.', en: 'The calendar could have done considerably worse.', 'pt-BR': 'O calendario poderia ter se saído muito pior.' }),
+      ];
+    case 'formal':
+      return [
+        byLocale(locale, { sv: 'Det får anses tillräckligt för ändamålet.', en: 'This will be considered sufficient for present purposes.', 'pt-BR': 'Isto sera considerado suficiente para os fins atuais.' }),
+        byLocale(locale, { sv: 'Det tillför åtminstone viss struktur åt dagen.', en: 'It adds at least some structure to the day.', 'pt-BR': 'Ao menos adiciona alguma estrutura ao dia.' }),
+        byLocale(locale, { sv: 'Det får härmed bära dagens innehåll.', en: 'It is hereby assigned to carry the day.', 'pt-BR': 'Fica assim encarregado de sustentar o dia.' }),
+        byLocale(locale, { sv: 'Det duger som officiell-ish motivering.', en: 'It will do as an official-ish justification.', 'pt-BR': 'Serve como justificativa quase oficial.' }),
+      ];
+    case 'warm':
+      return [
+        byLocale(locale, { sv: 'Det får väl ge dagen lite mänsklig hjälp på traven.', en: 'It may as well give the day a little human assistance.', 'pt-BR': 'Pode ao menos dar ao dia uma ajudinha humana.' }),
+        byLocale(locale, { sv: 'Det räcker faktiskt rätt fint idag.', en: 'That is honestly enough for today.', 'pt-BR': 'Isso honestamente ja basta hoje.' }),
+        byLocale(locale, { sv: 'Det gör datumet lite lättare att tycka om.', en: 'It makes the date a little easier to like.', 'pt-BR': 'Torna a data um pouco mais facil de gostar.' }),
+        byLocale(locale, { sv: 'Det är ändå en hygglig sak att samlas kring.', en: 'It is still a decent thing to gather around.', 'pt-BR': 'Ainda e uma coisa decente em torno da qual se reunir.' }),
+      ];
+    case 'chaotic':
+      return [
+        byLocale(locale, { sv: 'Det får väl styra cirkusen en stund då.', en: 'It may as well run the circus for a while.', 'pt-BR': 'Entao que isso conduza o circo por um tempo.' }),
+        byLocale(locale, { sv: 'Ingen stoppade det i tid.', en: 'No one stopped it in time.', 'pt-BR': 'Ninguem impediu isso a tempo.' }),
+        byLocale(locale, { sv: 'Det är nu officiellt dagens märkliga motorik.', en: 'It is now the day\'s strange motor function.', 'pt-BR': 'Agora isso e a estranha motricidade do dia.' }),
+        byLocale(locale, { sv: 'Schemat kommer inte återhämta sig från detta.', en: 'The schedule will not recover from this.', 'pt-BR': 'A agenda nao vai se recuperar disso.' }),
+      ];
+    case 'absurd':
+      return [
+        byLocale(locale, { sv: 'Kalendern har låtit ämnet sätta sig i chefsstolen.', en: 'The calendar has allowed the subject to occupy the executive chair.', 'pt-BR': 'O calendario permitiu que o assunto ocupasse a cadeira executiva.' }),
+        byLocale(locale, { sv: 'Det får väl bära dagen i sin märkliga lilla kostym.', en: 'It may as well carry the day in its strange little suit.', 'pt-BR': 'Que isso sustente o dia em seu pequeno terno esquisito.' }),
+        byLocale(locale, { sv: 'Det här är uppenbarligen vad datumet ville bli när det blev stort.', en: 'This is apparently what the date wanted to be when it grew up.', 'pt-BR': 'Aparentemente era isso que a data queria ser quando crescesse.' }),
+        byLocale(locale, { sv: 'Man får respektera hur orimligt konkret det blev.', en: 'One has to respect how unreasonably specific this became.', 'pt-BR': 'E preciso respeitar o quanto isso ficou absurdamente especifico.' }),
+      ];
+    default:
+      return [
+        byLocale(locale, { sv: 'Det får väl bära dagen då.', en: 'That will have to carry the day, then.', 'pt-BR': 'Vai ter que sustentar o dia, entao.' }),
+        byLocale(locale, { sv: 'Det är åtminstone något att skylla på.', en: "At least it's something to blame it on.", 'pt-BR': 'Pelo menos ja existe algo em que por a culpa.' }),
+        byLocale(locale, { sv: 'Ingen i organisationen var stark nog att stoppa det.', en: 'Nobody in the organization was strong enough to stop it.', 'pt-BR': 'Ninguem na organizacao teve forca para impedir.' }),
+        byLocale(locale, { sv: 'Det är mer än kalendern brukar erbjuda.', en: "It's more than the calendar usually offers.", 'pt-BR': 'E mais do que o calendario costuma oferecer.' }),
+        byLocale(locale, { sv: 'Det blir inte bättre än så här idag.', en: "This is about as good as today's getting.", 'pt-BR': 'Hoje nao vai ficar melhor do que isso.' }),
+        byLocale(locale, { sv: 'Det får duga som dagens professionella ursäkt.', en: "It'll do as today's professional excuse.", 'pt-BR': 'Serve como desculpa profissional do dia.' }),
+        byLocale(locale, { sv: 'Vi tar det och går vidare.', en: "We'll take it and move on.", 'pt-BR': 'A gente aceita e segue em frente.' }),
+        byLocale(locale, { sv: 'Det är i alla fall bättre än ren tomhet.', en: "It's still better than pure emptiness.", 'pt-BR': 'Ainda e melhor do que vazio absoluto.' }),
+      ];
+  }
+}
+
+export function getOrdinaryThemeDayCardNotes(locale: Locale, mood: Mood): string[] {
+  switch (mood) {
+    case 'cheerful':
+      return [
+        byLocale(locale, { sv: 'Det är inte officiellt, men tillräckligt många ville uppenbarligen ge dagen lite liv.', en: 'It is not official, but clearly enough people wanted to give the day some life.', 'pt-BR': 'Nao e oficial, mas gente suficiente claramente quis dar alguma vida ao dia.' }),
+        byLocale(locale, { sv: 'Kalendern fick något användbart att jobba med och det får man nästan kalla framsteg.', en: 'The calendar got something usable to work with, which nearly counts as progress.', 'pt-BR': 'O calendario recebeu algo util com que trabalhar, o que quase conta como progresso.' }),
+        byLocale(locale, { sv: 'Det här är smalt, men på ett ganska charmigt sätt.', en: 'This is niche, but in a fairly charming way.', 'pt-BR': 'Isso e nichado, mas de um jeito ate charmoso.' }),
+        byLocale(locale, { sv: 'Dagen fick lite innehåll och det gör den märkbart lättare att vara vän med.', en: 'The day got a little content, which makes it noticeably easier to befriend.', 'pt-BR': 'O dia ganhou algum conteudo, e isso o torna bem mais facil de suportar.' }),
+      ];
+    case 'formal':
+      return [
+        byLocale(locale, { sv: 'Detta är inte officiellt, men tillräckligt etablerat för att kunna behandlas med viss seriositet.', en: 'This is not official, but sufficiently established to be treated with some seriousness.', 'pt-BR': 'Isto nao e oficial, mas esta suficientemente estabelecido para receber alguma seriedade.' }),
+        byLocale(locale, { sv: 'Kalendern arbetar med tillgängligt material och dagens underlag får anses acceptabelt.', en: 'The calendar works with available material, and today\'s basis must be considered acceptable.', 'pt-BR': 'O calendario trabalha com o material disponivel, e a base de hoje pode ser considerada aceitavel.' }),
+        byLocale(locale, { sv: 'Det är smalt men tillräckligt sammanhållet för att ge datumet visst stöd.', en: 'It is niche but coherent enough to provide the date with some support.', 'pt-BR': 'E nichado, mas coeso o bastante para dar algum apoio a data.' }),
+        byLocale(locale, { sv: 'Ingen formell myndighet står bakom detta, men viss respekt kan ändå anses motiverad.', en: 'No formal authority stands behind it, but some respect is still warranted.', 'pt-BR': 'Nenhuma autoridade formal assina isso, mas algum respeito ainda se justifica.' }),
+      ];
+    case 'warm':
+      return [
+        byLocale(locale, { sv: 'Det är inte officiellt, men någon tog ändå sig tid att ge dagen lite ryggrad.', en: 'It is not official, but someone still took the time to give the day a little backbone.', 'pt-BR': 'Nao e oficial, mas alguem ainda assim se deu ao trabalho de dar alguma espinha ao dia.' }),
+        byLocale(locale, { sv: 'Kalendern fick något att hålla i och det gör faktiskt skillnad.', en: 'The calendar got something to hold on to, and that does make a difference.', 'pt-BR': 'O calendario ganhou algo em que se apoiar, e isso realmente faz diferenca.' }),
+        byLocale(locale, { sv: 'Det här är kanske litet, men det gör dagen mindre tom och mer mänsklig.', en: 'This may be small, but it makes the day less empty and more human.', 'pt-BR': 'Talvez seja pequeno, mas deixa o dia menos vazio e mais humano.' }),
+        byLocale(locale, { sv: 'Ingen stor institution behövde godkänna det här för att det skulle kännas rätt okej ändå.', en: 'No large institution had to approve this for it to feel fairly okay anyway.', 'pt-BR': 'Nao foi preciso aprovacao de grande instituicao nenhuma para isso parecer bem valido mesmo assim.' }),
+      ];
+    case 'chaotic':
+      return [
+        byLocale(locale, { sv: 'Det är inte officiellt, men tillräckligt många har tydligen kastat energi på datumet för att det ska börja låta som ett beslut.', en: 'It is not official, but enough people have clearly thrown energy at the date for it to start sounding like policy.', 'pt-BR': 'Nao e oficial, mas gente suficiente claramente atirou energia na data para isso comecar a soar como politica publica.' }),
+        byLocale(locale, { sv: 'Kalendern fick något att jobba med och sprang genast iväg lite för fort med det.', en: 'The calendar got something to work with and immediately ran a little too fast with it.', 'pt-BR': 'O calendario recebeu algo com que trabalhar e imediatamente saiu correndo um pouco rapido demais com isso.' }),
+        byLocale(locale, { sv: 'Det är löst sammanhållet, överentusiastiskt och ändå märkbart bättre än tomgång.', en: 'It is loosely assembled, overenthusiastic, and still noticeably better than idling.', 'pt-BR': 'E frouxamente montado, entusiasmado demais e ainda assim bem melhor do que a marcha lenta.' }),
+        byLocale(locale, { sv: 'Ingen regering står bakom det här, men någonstans står säkert en gruppchatt och hyperventilerar av stolthet.', en: 'No government stands behind this, but somewhere a group chat is certainly hyperventilating with pride.', 'pt-BR': 'Nenhum governo assina isso, mas em algum lugar um grupo de chat certamente esta hiperventilando de orgulho.' }),
+      ];
+    case 'absurd':
+      return [
+        byLocale(locale, { sv: 'Det är inte officiellt, men tillräckligt många människor tittade på datumet och gav det en märklig liten hatt.', en: 'It is not official, but enough people looked at the date and gave it a strange little hat.', 'pt-BR': 'Nao e oficial, mas gente suficiente olhou para a data e lhe deu um chapeuzinho esquisito.' }),
+        byLocale(locale, { sv: 'Kalendern får arbeta med det material den har, och idag råkade materialet vara ovanligt specifikt.', en: 'The calendar works with the material available, and today the material happened to be unusually specific.', 'pt-BR': 'O calendario trabalha com o material disponivel, e hoje o material acabou sendo especifico demais.' }),
+        byLocale(locale, { sv: 'Det här är smalt, löst sammanhållet och ändå tillräckligt för att ge datumet ett ansiktsuttryck.', en: 'It is niche, loosely assembled, and still enough to give the date a facial expression.', 'pt-BR': 'E nichado, frouxamente montado e ainda assim suficiente para dar uma expressao facial a data.' }),
+        byLocale(locale, { sv: 'Ingen regering står bakom det här, men världen blev ändå något mer detaljerad för en stund.', en: 'No government stands behind this, but the world still became slightly more detailed for a while.', 'pt-BR': 'Nenhum governo assina isso, mas o mundo ainda assim ficou um pouco mais detalhado por um momento.' }),
+      ];
+    default:
+      return [
+        byLocale(locale, { sv: 'Det är inte officiellt, men tillräckligt många har uppenbarligen bestämt sig för att göra något av det här datumet.', en: "It's not official, but clearly enough people decided this date deserved some sort of content.", 'pt-BR': 'Nao e oficial, mas claramente gente suficiente resolveu que essa data merecia algum conteudo.' }),
+        byLocale(locale, { sv: 'Kalendern får arbeta med det material den har, och idag blev det ändå förvånansvärt dugligt.', en: 'The calendar has to work with the material available, and today it ended up with something surprisingly serviceable.', 'pt-BR': 'O calendario trabalha com o material que tem, e hoje saiu algo surpreendentemente aproveitavel.' }),
+        byLocale(locale, { sv: 'Det här är inte statsbärande direkt, men absolut tillräckligt för att spela lite större än datumet först såg ut.', en: "This isn't exactly state-bearing, but it's absolutely enough to make the date play slightly above its station.", 'pt-BR': 'Nao e exatamente assunto de Estado, mas basta para a data parecer ligeiramente mais importante do que parecia no inicio.' }),
+        byLocale(locale, { sv: 'Ingen regering står bakom det här, men folk har ändå visat den goda smaken att fylla dagen med något märkbart.', en: "No government stands behind this, but people still had the good judgment to give the day some visible substance.", 'pt-BR': 'Nenhum governo assina isso, mas alguem ao menos teve o bom senso de dar algum corpo ao dia.' }),
+        byLocale(locale, { sv: 'Det är smalt, löst sammanhållet och fullt tillräckligt för att ge datumet någon sorts ryggrad.', en: "It's niche, loosely assembled, and still more than enough to give the date some kind of spine.", 'pt-BR': 'E nichado, meio frouxo e ainda assim suficiente para dar alguma espinha dorsal a data.' }),
+        byLocale(locale, { sv: 'Officiellt är det tunt. Inofficiellt är det ändå nog för att låta dagen slippa total förnedring.', en: "Officially it's thin. Unofficially it's enough to spare the day total humiliation.", 'pt-BR': 'Oficialmente e pouco. Extraoficialmente ja basta para poupar o dia da humilhacao completa.' }),
+        byLocale(locale, { sv: 'Någon tog sig tid att ge dagen innehåll, och det vore småaktigt att inte arbeta vidare på det.', en: 'Someone took the trouble to give the day some content, and it would be petty not to build on that.', 'pt-BR': 'Alguem se deu ao trabalho de dar algum conteudo ao dia, e seria mesquinho nao aproveitar isso.' }),
+        byLocale(locale, { sv: 'Det här får duga som folkligt initiativ. Inte majestätiskt, men klart bättre än kalendermässig öken.', en: 'This will do as a piece of public initiative. Not majestic, but clearly better than calendar desert.', 'pt-BR': 'Serve como iniciativa popular. Nada majestoso, mas nitidamente melhor do que um deserto de calendario.' }),
+      ];
+  }
+}

--- a/fredagskoll-frontend/src/mood.ts
+++ b/fredagskoll-frontend/src/mood.ts
@@ -1,0 +1,47 @@
+import { Locale } from './locale';
+
+export type Mood = 'dry' | 'cheerful' | 'chaotic' | 'formal' | 'absurd' | 'warm';
+
+export const MOOD_STORAGE_KEY = 'vadkanmanfira.aiMood';
+
+export const moodOptions: Array<{ value: Mood; labels: Record<Locale, string> }> = [
+  {
+    value: 'dry',
+    labels: { sv: 'Torr', en: 'Dry', 'pt-BR': 'Seco' },
+  },
+  {
+    value: 'cheerful',
+    labels: { sv: 'Glad', en: 'Cheerful', 'pt-BR': 'Alegre' },
+  },
+  {
+    value: 'formal',
+    labels: { sv: 'Formell', en: 'Formal', 'pt-BR': 'Formal' },
+  },
+  {
+    value: 'warm',
+    labels: { sv: 'Varm', en: 'Warm', 'pt-BR': 'Afetuoso' },
+  },
+  {
+    value: 'chaotic',
+    labels: { sv: 'Kaotisk', en: 'Chaotic', 'pt-BR': 'Caotico' },
+  },
+  {
+    value: 'absurd',
+    labels: { sv: 'Absurd', en: 'Absurd', 'pt-BR': 'Absurdo' },
+  },
+];
+
+const supportedMoods = new Set<Mood>(moodOptions.map((option) => option.value));
+
+export function getInitialMood(): Mood {
+  if (typeof window === 'undefined') {
+    return 'dry';
+  }
+
+  const value = window.localStorage.getItem(MOOD_STORAGE_KEY);
+  return value && supportedMoods.has(value as Mood) ? (value as Mood) : 'dry';
+}
+
+export function getMoodLabel(mood: Mood, locale: Locale): string {
+  return moodOptions.find((option) => option.value === mood)?.labels[locale] ?? mood;
+}

--- a/fredagskoll-frontend/src/themeDayBlurbs.ts
+++ b/fredagskoll-frontend/src/themeDayBlurbs.ts
@@ -1,4 +1,5 @@
 import { Locale, translateThemeDayName } from './locale';
+import { Mood } from './mood';
 import { buildThemeDayDynamicBlurbs } from './themeDayDynamicBlurbs';
 import { getThemeDayCategoryBlurbs } from './themeDayCategoryBlurbs';
 import { getThemeDaySpecificBlurbs } from './themeDaySpecificBlurbs';
@@ -6,13 +7,17 @@ import { normalizeLabel } from './themeDayTextUtils';
 
 export { joinWithAnd } from './themeDayTextUtils';
 
-export function buildThemeDayBlurbs(themeDays: string[], locale: Locale = 'sv'): string[] {
+export function buildThemeDayBlurbs(
+  themeDays: string[],
+  locale: Locale = 'sv',
+  mood: Mood = 'dry'
+): string[] {
   const leadDay = themeDays[0];
   const displayThemeDays = themeDays.map((themeDay) => translateThemeDayName(themeDay, locale));
-  const specific = locale === 'sv' ? getThemeDaySpecificBlurbs(leadDay) : null;
+  const specific = getThemeDaySpecificBlurbs(leadDay, locale, mood, displayThemeDays[0]);
   const leadDayBlurbs =
-    specific ?? getThemeDayCategoryBlurbs(leadDay, locale, displayThemeDays[0]);
-  const dynamicBlurbs = buildThemeDayDynamicBlurbs(themeDays, locale, displayThemeDays);
+    specific ?? getThemeDayCategoryBlurbs(leadDay, locale, displayThemeDays[0], mood);
+  const dynamicBlurbs = buildThemeDayDynamicBlurbs(themeDays, locale, displayThemeDays, mood);
 
   return [
     ...leadDayBlurbs,

--- a/fredagskoll-frontend/src/themeDayCategoryBlurbs.ts
+++ b/fredagskoll-frontend/src/themeDayCategoryBlurbs.ts
@@ -1,4 +1,5 @@
 import { Locale } from './locale';
+import { Mood } from './mood';
 import { includesAny, normalizeLabel } from './themeDayTextUtils';
 
 function lower(value: string): string {
@@ -8,10 +9,131 @@ function lower(value: string): string {
 export function getThemeDayCategoryBlurbs(
   themeDay: string,
   locale: Locale = 'sv',
-  displayThemeDay = themeDay
+  displayThemeDay = themeDay,
+  mood: Mood = 'dry'
 ): string[] {
   const normalized = normalizeLabel(themeDay);
   const shownDay = displayThemeDay;
+
+  if (mood !== 'dry') {
+    if (locale === 'en') {
+      switch (mood) {
+        case 'cheerful':
+          return [
+            `${shownDay} gives the date a welcome little pulse of personality.`,
+            `It's ${lower(shownDay)} today, which is still more fun than a blank weekday.`,
+            `${shownDay} makes the calendar feel a little more alive and a little less bureaucratic.`,
+            `If the day wants to be about ${lower(shownDay)}, that seems harmless enough to enjoy.`,
+          ];
+        case 'formal':
+          return [
+            `${shownDay} has been designated as the day's operative theme.`,
+            `It is ${lower(shownDay)} today, and the calendar is treating that as sufficient structure.`,
+            `${shownDay} provides a narrow but valid framework for the date.`,
+            `The schedule is now proceeding under the thematic influence of ${lower(shownDay)}.`,
+          ];
+        case 'warm':
+          return [
+            `${shownDay} gives the date a little more warmth than it would otherwise have had.`,
+            `It's ${lower(shownDay)} today, which at least makes the calendar feel less cold.`,
+            `${shownDay} helps the day feel less empty and a bit easier to like.`,
+            `If the date gets to lean on ${lower(shownDay)}, that is not the worst arrangement.`,
+          ];
+        case 'chaotic':
+          return [
+            `${shownDay} has attached itself to the date and made the whole thing wobble a little.`,
+            `It's ${lower(shownDay)} today, which explains the sudden loss of conventional discipline.`,
+            `${shownDay} gives the schedule a very specific instability.`,
+            `The calendar has handed the controls to ${lower(shownDay)} and then quietly backed away.`,
+          ];
+        default:
+          return [
+            `${shownDay} is so specific that the date now feels oddly curated.`,
+            `It's ${lower(shownDay)} today, which means the calendar has once again acquired a costume.`,
+            `${shownDay} lends the day a strangely intentional shape.`,
+            `The date is currently being supervised by ${lower(shownDay)} with mixed but memorable results.`,
+          ];
+      }
+    }
+
+    if (locale === 'pt-BR') {
+      switch (mood) {
+        case 'cheerful':
+          return [
+            `${shownDay} da a data uma pequena e bem-vinda pulsacao de personalidade.`,
+            `Hoje e ${lower(shownDay)}, o que ainda e mais divertido do que um dia vazio.`,
+            `${shownDay} faz o calendario parecer um pouco mais vivo e um pouco menos burocratico.`,
+            `Se o dia quer ser sobre ${lower(shownDay)}, isso parece inofensivo o bastante para aproveitar.`,
+          ];
+        case 'formal':
+          return [
+            `${shownDay} foi designado como tema operativo do dia.`,
+            `Hoje e ${lower(shownDay)}, e o calendario trata isso como estrutura suficiente.`,
+            `${shownDay} fornece uma moldura estreita, mas valida, para a data.`,
+            `A agenda segue agora sob influencia tematica de ${lower(shownDay)}.`,
+          ];
+        case 'warm':
+          return [
+            `${shownDay} da a data um pouco mais de calor do que ela teria sozinha.`,
+            `Hoje e ${lower(shownDay)}, o que pelo menos faz o calendario parecer menos frio.`,
+            `${shownDay} ajuda o dia a parecer menos vazio e um pouco mais facil de gostar.`,
+            `Se a data pode se apoiar em ${lower(shownDay)}, isso esta longe de ser um mau arranjo.`,
+          ];
+        case 'chaotic':
+          return [
+            `${shownDay} se prendeu a data e fez o conjunto inteiro balancar um pouco.`,
+            `Hoje e ${lower(shownDay)}, o que explica a perda repentina de disciplina convencional.`,
+            `${shownDay} da a agenda uma instabilidade muito especifica.`,
+            `O calendario entregou os controles a ${lower(shownDay)} e depois se afastou em silencio.`,
+          ];
+        default:
+          return [
+            `${shownDay} e tao especifico que a data agora parece estranhamente curada.`,
+            `Hoje e ${lower(shownDay)}, o que significa que o calendario ganhou figurino mais uma vez.`,
+            `${shownDay} empresta ao dia uma forma estranhamente intencional.`,
+            `A data esta atualmente sendo supervisionada por ${lower(shownDay)} com resultados mistos, mas memoraveis.`,
+          ];
+      }
+    }
+
+    switch (mood) {
+      case 'cheerful':
+        return [
+          `${shownDay} ger datumet en välkommen liten puls av personlighet.`,
+          `Det är ${lower(shownDay)} idag, vilket fortfarande är roligare än ren blankvardag.`,
+          `${shownDay} gör kalendern lite mer levande och lite mindre byråkratisk.`,
+          `Om dagen vill handla om ${lower(shownDay)} så känns det ofarligt nog att uppskatta.`,
+        ];
+      case 'formal':
+        return [
+          `${shownDay} har utsetts till dagens operativa tema.`,
+          `Det är ${lower(shownDay)} idag, och kalendern behandlar det som tillräcklig struktur.`,
+          `${shownDay} tillför datumet en smal men giltig ram.`,
+          `Schemat fortgår nu under tematisk påverkan av ${lower(shownDay)}.`,
+        ];
+      case 'warm':
+        return [
+          `${shownDay} ger datumet lite mer värme än det annars hade haft.`,
+          `Det är ${lower(shownDay)} idag, vilket åtminstone gör kalendern mindre kall i tonen.`,
+          `${shownDay} hjälper dagen att kännas mindre tom och lite lättare att tycka om.`,
+          `Om datumet får luta sig mot ${lower(shownDay)} så är det långt ifrån den sämsta lösningen.`,
+        ];
+      case 'chaotic':
+        return [
+          `${shownDay} har hängt sig fast i datumet och gjort hela upplägget lite mer svajigt.`,
+          `Det är ${lower(shownDay)} idag, vilket förklarar den plötsliga bristen på konventionell disciplin.`,
+          `${shownDay} ger schemat en väldigt specifik instabilitet.`,
+          `Kalendern lämnade över kontrollerna till ${lower(shownDay)} och backade sedan långsamt ut ur rummet.`,
+        ];
+      default:
+        return [
+          `${shownDay} är så specifik att datumet nu känns märkligt kurerat.`,
+          `Det är ${lower(shownDay)} idag, vilket betyder att kalendern återigen tagit på sig kostym.`,
+          `${shownDay} lånar dagen en märkligt avsiktlig form.`,
+          `Datumet står just nu under tillsyn av ${lower(shownDay)} med blandat men minnesvärt resultat.`,
+        ];
+    }
+  }
 
   if (
     includesAny(normalized, [

--- a/fredagskoll-frontend/src/themeDayDynamicBlurbs.ts
+++ b/fredagskoll-frontend/src/themeDayDynamicBlurbs.ts
@@ -1,4 +1,5 @@
 import { Locale } from './locale';
+import { Mood } from './mood';
 import { includesAny, joinWithAnd, normalizeLabel } from './themeDayTextUtils';
 
 function lowerFirst(value: string): string {
@@ -398,12 +399,118 @@ function buildFallbackBlurbs(
 export function buildThemeDayDynamicBlurbs(
   themeDays: string[],
   locale: Locale = 'sv',
-  displayThemeDays = themeDays
+  displayThemeDays = themeDays,
+  mood: Mood = 'dry'
 ): string[] {
   const leadDay = displayThemeDays[0];
   const allDays = joinWithAnd(displayThemeDays, locale);
   const themeDayCount = displayThemeDays.length;
   const normalized = normalizeLabel(themeDays[0]);
+
+  if (mood !== 'dry') {
+    if (locale === 'en') {
+      switch (mood) {
+        case 'cheerful':
+          return [
+            `${leadDay} gives the date a welcome little lift all by itself.`,
+            `${allDays} share the slot today, which at least means the calendar did not arrive empty-handed.`,
+            `The date is carrying ${leadDay.toLowerCase()} with more enthusiasm than usual, and that is probably good for morale.`,
+          ];
+        case 'formal':
+          return [
+            `${leadDay} has been entered as the lead thematic item for the date.`,
+            `${allDays} are concurrently attached to the day in supporting roles.`,
+            `The calendar is presently operating under a clearly non-neutral thematic brief.`,
+          ];
+        case 'warm':
+          return [
+            `${leadDay} makes the date feel less bare than it otherwise might have.`,
+            `${allDays} are sharing the day, which gives it at least some human texture.`,
+            `It is easier to like the calendar when ${leadDay.toLowerCase()} shows up and softens the edges.`,
+          ];
+        case 'chaotic':
+          return [
+            `${leadDay} has clearly taken the wheel, and the rest of the date is just trying not to spill.`,
+            `${allDays} are piled onto the same slot, which is not exactly helping the schedule breathe evenly.`,
+            `The day now has the energy of a committee that refused to pick one strange thing and go home.`,
+          ];
+        default:
+          return [
+            `${leadDay} sits on the date like a very specific hat.`,
+            `${allDays} are all crowding onto the same calendar square with notable confidence.`,
+            `The day now looks less like a date and more like a themed waiting room.`,
+          ];
+      }
+    }
+
+    if (locale === 'pt-BR') {
+      switch (mood) {
+        case 'cheerful':
+          return [
+            `${leadDay} ja da a data uma elevacao bem-vinda por conta propria.`,
+            `${allDays} dividem o espaco hoje, o que ao menos significa que o calendario nao chegou de maos vazias.`,
+            `A data esta carregando ${leadDay.toLowerCase()} com mais entusiasmo do que o normal, e isso provavelmente ajuda o moral.`,
+          ];
+        case 'formal':
+          return [
+            `${leadDay} foi registrado como item tematico principal da data.`,
+            `${allDays} estao associados ao dia em papeis de apoio.`,
+            `O calendario opera neste momento sob uma diretriz tematica claramente nao neutra.`,
+          ];
+        case 'warm':
+          return [
+            `${leadDay} faz a data parecer menos vazia do que pareceria sozinha.`,
+            `${allDays} dividem o dia, o que lhe da alguma textura humana.`,
+            `Fica mais facil gostar do calendario quando ${leadDay.toLowerCase()} aparece e amacia as quinas.`,
+          ];
+        case 'chaotic':
+          return [
+            `${leadDay} claramente tomou o volante, e o resto da data esta so tentando nao derramar nada.`,
+            `${allDays} foram empilhados no mesmo espaco, o que nao ajuda a agenda a respirar com calma.`,
+            `O dia agora tem a energia de um comite que se recusou a escolher uma coisa esquisita so e ir para casa.`,
+          ];
+        default:
+          return [
+            `${leadDay} pousou na data como um chapeu muito especifico.`,
+            `${allDays} estao todos amontoados no mesmo quadrado do calendario com notavel confianca.`,
+            `O dia agora parece menos uma data e mais uma sala de espera tematica.`,
+          ];
+      }
+    }
+
+    switch (mood) {
+      case 'cheerful':
+        return [
+          `${leadDay} ger datumet ett välkommet litet lyft alldeles på egen hand.`,
+          `${allDays} samsas här idag, vilket åtminstone betyder att kalendern inte dök upp tomhänt.`,
+          `Datumet bär ${leadDay.toLowerCase()} med mer entusiasm än vanligt, och det är sannolikt bra för moralen.`,
+        ];
+      case 'formal':
+        return [
+          `${leadDay} har registrerats som datumets ledande tematiska inslag.`,
+          `${allDays} är samtidigt knutna till dagen i understödjande roller.`,
+          `Kalendern arbetar för närvarande under ett tydligt icke-neutralt tematiskt uppdrag.`,
+        ];
+      case 'warm':
+        return [
+          `${leadDay} gör datumet mindre kalt än det annars hade varit.`,
+          `${allDays} delar dagen, vilket ger den åtminstone lite mänsklig struktur.`,
+          `Det blir lättare att tycka om kalendern när ${leadDay.toLowerCase()} dyker upp och rundar av kanterna.`,
+        ];
+      case 'chaotic':
+        return [
+          `${leadDay} har tydligt tagit ratten och resten av datumet försöker mest att inte spilla.`,
+          `${allDays} har staplats på samma ruta, vilket inte direkt hjälper schemat att andas jämnt.`,
+          `Dagen har nu energin hos en kommitté som vägrade välja en märklig sak och gå hem.`,
+        ];
+      default:
+        return [
+          `${leadDay} sitter på datumet som en väldigt specifik hatt.`,
+          `${allDays} trängs alla i samma kalenderfyrkant med anmärkningsvärd självklarhet.`,
+          `Dagen ser nu mindre ut som ett datum och mer som ett tematiserat väntrum.`,
+        ];
+    }
+  }
 
   if (
     includesAny(normalized, [

--- a/fredagskoll-frontend/src/themeDaySpecificBlurbs.ts
+++ b/fredagskoll-frontend/src/themeDaySpecificBlurbs.ts
@@ -1,6 +1,134 @@
+import { Locale } from './locale';
+import { Mood } from './mood';
 import { normalizeLabel } from './themeDayTextUtils';
 
-export function getThemeDaySpecificBlurbs(themeDay: string): string[] | null {
+function getMoodSpecificBlurbs(
+  themeDay: string,
+  locale: Locale,
+  mood: Mood,
+  displayThemeDay = themeDay
+): string[] | null {
+  if (mood === 'dry') {
+    return null;
+  }
+
+  const shownDay = displayThemeDay;
+
+  if (locale === 'en') {
+    switch (mood) {
+      case 'cheerful':
+        return [
+          `${shownDay} is exactly the sort of oddly specific theme that can improve a weekday by surprise.`,
+          `It's ${shownDay.toLowerCase()} today, which is at least a friendlier plot than a blank square in the calendar.`,
+          `${shownDay} gives the date enough personality to justify a modest smile.`,
+        ];
+      case 'formal':
+        return [
+          `${shownDay} has been entered into the date with notable specificity.`,
+          `It is ${shownDay.toLowerCase()} today, and the calendar expects a certain procedural acceptance.`,
+          `${shownDay} provides the date with a narrow but usable thematic mandate.`,
+        ];
+      case 'warm':
+        return [
+          `${shownDay} gives the date a little more heart than it would otherwise have managed.`,
+          `It's ${shownDay.toLowerCase()} today, which makes the calendar feel slightly less indifferent.`,
+          `${shownDay} is specific, but in a way that makes the day easier to like.`,
+        ];
+      case 'chaotic':
+        return [
+          `${shownDay} has landed on the date and immediately made the whole schedule less believable.`,
+          `It's ${shownDay.toLowerCase()} today, which explains why the calendar suddenly feels overcaffeinated.`,
+          `${shownDay} gives the day a very specific wobble and no obvious supervision.`,
+        ];
+      default:
+        return [
+          `${shownDay} is so specific that the date has stopped behaving like neutral infrastructure.`,
+          `It's ${shownDay.toLowerCase()} today, which means the calendar has once again dressed itself oddly.`,
+          `${shownDay} gives the day a strangely deliberate silhouette.`,
+        ];
+    }
+  }
+
+  if (locale === 'pt-BR') {
+    switch (mood) {
+      case 'cheerful':
+        return [
+          `${shownDay} e exatamente aquele tipo de tema especifico demais que consegue melhorar uma data por surpresa.`,
+          `Hoje e ${shownDay.toLowerCase()}, o que ja e um enredo bem mais simpatico do que um quadrado vazio no calendario.`,
+          `${shownDay} da a data personalidade suficiente para justificar um sorriso modesto.`,
+        ];
+      case 'formal':
+        return [
+          `${shownDay} foi inscrito na data com especificidade notavel.`,
+          `Hoje e ${shownDay.toLowerCase()}, e o calendario espera certa aceitacao procedimental.`,
+          `${shownDay} fornece a data um mandato tematico estreito, mas utilizavel.`,
+        ];
+      case 'warm':
+        return [
+          `${shownDay} da a data um pouco mais de coracao do que ela conseguiria sozinha.`,
+          `Hoje e ${shownDay.toLowerCase()}, o que torna o calendario um pouco menos indiferente.`,
+          `${shownDay} e especifico, mas de um jeito que torna o dia mais facil de gostar.`,
+        ];
+      case 'chaotic':
+        return [
+          `${shownDay} caiu na data e imediatamente reduziu bastante a credibilidade da agenda.`,
+          `Hoje e ${shownDay.toLowerCase()}, o que explica por que o calendario de repente parece cafeinado demais.`,
+          `${shownDay} da ao dia uma oscilacao muito especifica e nenhuma supervisao evidente.`,
+        ];
+      default:
+        return [
+          `${shownDay} e tao especifico que a data deixou de parecer infraestrutura neutra.`,
+          `Hoje e ${shownDay.toLowerCase()}, o que significa que o calendario voltou a se vestir de maneira estranha.`,
+          `${shownDay} da ao dia uma silhueta estranhamente deliberada.`,
+        ];
+    }
+  }
+
+  switch (mood) {
+    case 'cheerful':
+      return [
+        `${shownDay} är exakt den sortens överraskande specifika tema som kan förbättra en vardag lite i smyg.`,
+        `Det är ${shownDay.toLowerCase()} idag, vilket ändå är ett trevligare narrativ än en tom ruta i kalendern.`,
+        `${shownDay} ger datumet tillräckligt med personlighet för att motivera ett måttligt leende.`,
+      ];
+    case 'formal':
+      return [
+        `${shownDay} har införts i datumet med anmärkningsvärd specificitet.`,
+        `Det är ${shownDay.toLowerCase()} idag, och kalendern förväntar sig viss proceduriell acceptans.`,
+        `${shownDay} tillför datumet ett smalt men användbart tematiskt mandat.`,
+      ];
+    case 'warm':
+      return [
+        `${shownDay} ger dagen lite mer hjärta än den annars hade lyckats uppbåda.`,
+        `Det är ${shownDay.toLowerCase()} idag, vilket gör kalendern något mindre likgiltig.`,
+        `${shownDay} är specifikt, men på ett sätt som gör dagen lättare att tycka om.`,
+      ];
+    case 'chaotic':
+      return [
+        `${shownDay} landade på datumet och gjorde genast schemat märkbart mindre trovärdigt.`,
+        `Det är ${shownDay.toLowerCase()} idag, vilket förklarar varför kalendern plötsligt känns överkoffeinad.`,
+        `${shownDay} ger dagen ett väldigt specifikt svaj och ingen självklar vuxennärvaro.`,
+      ];
+    default:
+      return [
+        `${shownDay} är så specifik att datumet slutat bete sig som neutral infrastruktur.`,
+        `Det är ${shownDay.toLowerCase()} idag, vilket betyder att kalendern återigen klätt sig märkligt.`,
+        `${shownDay} ger dagen en märkligt avsiktlig silhuett.`,
+      ];
+  }
+}
+
+export function getThemeDaySpecificBlurbs(
+  themeDay: string,
+  locale: Locale = 'sv',
+  mood: Mood = 'dry',
+  displayThemeDay = themeDay
+): string[] | null {
+  const moodSpecific = getMoodSpecificBlurbs(themeDay, locale, mood, displayThemeDay);
+  if (moodSpecific) {
+    return moodSpecific;
+  }
+
   const normalized = normalizeLabel(themeDay);
   const overrides: Array<[string, string[]]> = [
     [


### PR DESCRIPTION
## Summary

This PR adds mood as a first-class input for the dedicated AI blurb path and extends that same tone model into the app's highest-visibility editorial fallback copy. Before this change, only the backend prompt wiring knew about mood locally, while the frontend always sent `dry` and the rest of the app still spoke in the same fixed house voice. That meant a mood feature would have felt fake even when the AI response changed, because ordinary-day copy, celebration fallback blurbs, and theme-day prose all remained static.

The root issue was that the app had no clear separation between stable UI strings and editorial strings. The UI layer should stay consistent, but the editorial layer needs to adapt tone. This change introduces that boundary explicitly. A shared frontend `Mood` model now persists the selected mood in local storage, the user can choose it in the main app UI, and that value is sent to the function request so the cache key and Azure OpenAI prompt both stay aligned with the chosen tone.

On the frontend, the mood now affects the most visible editorial text surfaces: ordinary-day blurbs, celebration blurbs, theme-day specific/category/dynamic blurbs, and the ordinary theme-day title endings and card notes. The dry tone remains the default and preserves current behavior, while the other supported moods provide alternate editorial variants without destabilizing the rest of the interface. Stable UI copy remains stable, apart from adding the mood picker label itself.

The PR also adds a short audit document describing the intended text-surface boundary so the next round of work can extend mood into secondary narrative panels without accidentally turning operational UI strings into character acting.

## Validation

I ran the frontend test suite in CI mode:

- `CI=true npm test -- --watch=false`

All 48 tests passed.
