### PR TITLE
[codex] bump frontend version to 0.1.7

### DIFF
--- a/fredagskoll-frontend/package.json
+++ b/fredagskoll-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vadkanmanfira-frontend",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.1",


### PR DESCRIPTION
## Summary

This PR bumps the frontend package version from `0.1.6` to `0.1.7` so the build stamp reflects the recently merged mood-aware editorial copy work. The previous PR changed visible product behavior but left the version unchanged, which would have made the deployed footer/build metadata misleading.

This follow-up only updates the package version. I also removed the temporary PR body file from the local working tree before creating this PR, but that file was never tracked and is therefore not part of the diff.

## Validation

No code path changed in this PR beyond package metadata, so no additional test run was necessary.
