### PR TITLE
[codex] add cache observability columns

### DIFF
--- a/api/shared/cache.js
+++ b/api/shared/cache.js
@@ -153,6 +153,12 @@ function buildBundleEntity(requestHash, variant) {
     rowKey: variant.bundleId,
     requestHash,
     bundleId: variant.bundleId,
+    locale: variant.locale || null,
+    contentPack: variant.contentPack || null,
+    kind: variant.kind || null,
+    mood: variant.mood || null,
+    date: variant.date || null,
+    title: variant.title || null,
     generatedAt: variant.generatedAt,
     model: variant.model || 'unknown',
     useCount: Number.isFinite(variant.useCount) ? Number(variant.useCount) : 0,
@@ -229,6 +235,12 @@ function buildLegacyVariants(hotEntity, requestHash) {
             : typeof source.createdAt === 'string' && source.createdAt.length > 0
               ? source.createdAt
               : hotEntity.createdAt || new Date().toISOString(),
+        locale: hotEntity.locale || null,
+        contentPack: hotEntity.contentPack || null,
+        kind: hotEntity.kind || null,
+        mood: hotEntity.mood || null,
+        date: hotEntity.date || null,
+        title: hotEntity.title || null,
         model:
           typeof source.model === 'string' && source.model.length > 0
             ? source.model
@@ -266,6 +278,12 @@ function buildLegacyVariants(hotEntity, requestHash) {
       bundleId: createBundleId(),
       requestHash,
       generatedAt: hotEntity.createdAt || new Date().toISOString(),
+      locale: hotEntity.locale || null,
+      contentPack: hotEntity.contentPack || null,
+      kind: hotEntity.kind || null,
+      mood: hotEntity.mood || null,
+      date: hotEntity.date || null,
+      title: hotEntity.title || null,
       model: hotEntity.model || 'unknown',
       useCount: Number.isFinite(hotEntity.useCount) ? Number(hotEntity.useCount) : 0,
       lastUsedAt:
@@ -382,6 +400,12 @@ async function saveCacheState(request, state) {
 
   for (const variant of variants) {
     variant.requestHash = requestHash;
+    variant.locale = request.locale;
+    variant.contentPack = request.contentPack;
+    variant.kind = request.kind;
+    variant.mood = request.mood;
+    variant.date = request.date;
+    variant.title = request.title;
   }
 
   await Promise.all(
@@ -392,6 +416,16 @@ async function saveCacheState(request, state) {
     partitionKey: entityKey.partitionKey,
     rowKey: entityKey.rowKey,
     requestHash,
+    locale: request.locale,
+    contentPack: request.contentPack,
+    kind: request.kind,
+    mood: request.mood,
+    date: request.date,
+    dateLabel: request.dateLabel,
+    dayType: request.dayType,
+    title: request.title,
+    subtitle: request.subtitle || null,
+    kicker: request.kicker || null,
     createdAt,
     updatedAt: nowIso,
     lastUsedAt:


### PR DESCRIPTION
## Summary

This PR makes the Azure Table Storage rows for AI blurb caching readable without having to reverse-engineer the request hash. Functionally, the cache was already correct because `mood` and the rest of the request context were part of the hash used for the hot cache row key. The problem was observability: when inspecting `blurbcache` or `blurblibrary` manually, there was no explicit `mood` field or other basic request metadata on the stored rows, so it was annoying to confirm what a cached bundle actually represented.

The root cause was that the table schema was optimized only for lookup and reuse. The hot row stored enough to fetch bundle IDs, and the bundle rows stored enough to serve content, but neither table preserved the most useful human-facing request metadata as first-class columns.

This change keeps the existing lookup behavior intact and only adds explicit metadata fields to persisted rows. The hot cache row now stores locale, content pack, kind, mood, date, date label, day type, title, subtitle, and kicker. Bundle library rows now store locale, content pack, kind, mood, date, and title. Legacy rows are still handled safely by the compatibility path, and newly written rows become much easier to inspect in Azure Portal or Storage Explorer.

## Validation

I ran a direct Node module load check against the updated cache module:

- `node -` with `require('./api/shared/cache')`

The module loaded successfully.
