### PR TITLE
[codex] hide fallback blurbs while ai loads

### DIFF
--- a/fredagskoll-frontend/package.json
+++ b/fredagskoll-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vadkanmanfira-frontend",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/fredagskoll-frontend/src/App.css
+++ b/fredagskoll-frontend/src/App.css
@@ -637,6 +637,11 @@
   font-size: var(--mood-blurb-size);
 }
 
+.celebration-blurb--loading {
+  min-height: 3.2rem;
+  color: color-mix(in srgb, var(--muted) 88%, var(--tone-accent) 12%);
+}
+
 .blurb-row {
   display: grid;
   gap: 0.9rem;

--- a/fredagskoll-frontend/src/App.test.tsx
+++ b/fredagskoll-frontend/src/App.test.tsx
@@ -14,13 +14,25 @@ const mockedFetchAiBlurbBundle = fetchAiBlurbBundle as jest.MockedFunction<
   typeof fetchAiBlurbBundle
 >;
 
-async function renderAppAt(date: Date, contentPack?: ContentPack): Promise<void> {
+async function renderAppAt(
+  date: Date,
+  contentPack?: ContentPack,
+  options: { waitForAi?: boolean } = {}
+): Promise<void> {
+  const { waitForAi = true } = options;
+
   render(<App initialDate={date} contentPack={contentPack} />);
   await waitFor(() =>
     expect(
       screen.queryByText(/Laddar namnsdag från öppet API/i)
     ).not.toBeInTheDocument()
   );
+
+  if (waitForAi) {
+    await waitFor(() =>
+      expect(screen.queryByText(/Hämtar dagens text\./i)).not.toBeInTheDocument()
+    );
+  }
 }
 
 beforeEach(() => {
@@ -400,6 +412,44 @@ test('steps between days from the center navigation buttons', async () => {
   expect(
     screen.getByRole('heading', { level: 2, name: /Våffeldagen har tagit över/i })
   ).toBeInTheDocument();
+});
+
+test('hides fallback blurbs until the ai request resolves', async () => {
+  let resolveBundle!: (value: {
+    source: 'cache';
+    titleEndings: string[];
+    cardNotes: string[];
+    blurbs: string[];
+  }) => void;
+
+  mockedFetchAiBlurbBundle.mockImplementationOnce(
+    () =>
+      new Promise((resolve) => {
+        resolveBundle = resolve;
+      })
+  );
+
+  await renderAppAt(new Date(2026, 1, 16), undefined, { waitForAi: false });
+
+  expect(screen.getByText(/Hämtar dagens text\./i)).toBeInTheDocument();
+  expect(
+    screen.queryByText(
+      /Det är en vanlig arbetsdag\. Du får skapa din egen stämning, och det känns ju tveksamt\./i
+    )
+  ).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /Ny ursäkt/i })).not.toBeInTheDocument();
+
+  resolveBundle({
+    source: 'cache',
+    titleEndings: [],
+    cardNotes: [],
+    blurbs: ['AI-cachead text som faktiskt hör till datumet.'],
+  });
+
+  await waitFor(() =>
+    expect(screen.getByText(/AI-cachead text som faktiskt hör till datumet\./i)).toBeInTheDocument()
+  );
+  expect(screen.queryByText(/Hämtar dagens text\./i)).not.toBeInTheDocument();
 });
 
 test('persists the selected mood and exposes it on the app root', async () => {

--- a/fredagskoll-frontend/src/App.tsx
+++ b/fredagskoll-frontend/src/App.tsx
@@ -65,6 +65,7 @@ type AppProps = {
 };
 
 type NameDayState = 'loading' | 'ready' | 'error';
+type AiBundleState = 'loading' | 'ready' | 'fallback';
 type MobileSectionKey =
   | 'holiday'
   | 'season'
@@ -185,6 +186,7 @@ function App({
   const [nameDays, setNameDays] = useState<string[]>([]);
   const [nameDayState, setNameDayState] = useState<NameDayState>('loading');
   const [aiBundle, setAiBundle] = useState<AiBlurbBundle | null>(null);
+  const [aiBundleState, setAiBundleState] = useState<AiBundleState>('loading');
   const [blurb, setBlurb] = useState(getOrdinaryBlurb(getInitialLocale(), getInitialMood()));
   const [themeDayTitleEnding, setThemeDayTitleEnding] = useState(
     getOrdinaryThemeDayTitleEndings(getInitialLocale(), getInitialMood())[0]
@@ -254,9 +256,14 @@ function App({
     () => (!celebration && hasThemeDays ? buildThemeDayBlurbs(visibleThemeDays, locale, mood) : null),
     [celebration, hasThemeDays, locale, mood, visibleThemeDays]
   );
+  const isAiBundleLoading = aiBundleState === 'loading';
   const currentBlurbs = useMemo(() => {
     if (aiBundle?.blurbs.length) {
       return aiBundle.blurbs;
+    }
+
+    if (isAiBundleLoading) {
+      return null;
     }
 
     if (celebration) {
@@ -276,7 +283,7 @@ function App({
       selectedDateObject.getDay() === 0 || selectedDateObject.getDay() === 6,
       mood
     );
-  }, [aiBundle, celebration, dayStatus.dayType, locale, mood, selectedDateObject, themeDayBlurbs]);
+  }, [aiBundle, celebration, dayStatus.dayType, isAiBundleLoading, locale, mood, selectedDateObject, themeDayBlurbs]);
   const kicker = celebration
     ? celebration.kicker
     : hasThemeDays
@@ -372,14 +379,17 @@ function App({
     } as const;
 
     setAiBundle(null);
+    setAiBundleState('loading');
 
     Promise.resolve(fetchAiBlurbBundle(request, controller.signal))
       .then((bundle) => {
         if (bundle === null) {
+          setAiBundleState('fallback');
           return;
         }
 
         setAiBundle(bundle);
+        setAiBundleState('ready');
       })
       .catch(() => {
         if (controller.signal.aborted) {
@@ -387,6 +397,7 @@ function App({
         }
 
         setAiBundle(null);
+        setAiBundleState('fallback');
       });
 
     return () => {
@@ -414,13 +425,17 @@ function App({
   ]);
 
   useEffect(() => {
+    if (isAiBundleLoading) {
+      return;
+    }
+
     if (!currentBlurbs) {
       setBlurb(ordinaryBlurb);
       return;
     }
 
     setBlurb(getRandomItem(currentBlurbs, ordinaryBlurb));
-  }, [selectedDate, locale, currentBlurbs, ordinaryBlurb]);
+  }, [selectedDate, locale, currentBlurbs, ordinaryBlurb, isAiBundleLoading]);
 
   useEffect(() => {
     const endings =
@@ -769,8 +784,14 @@ function App({
             </h2>
           )}
           <div className="blurb-row">
-            <p className="celebration-blurb">{blurb}</p>
-            {currentBlurbs ? (
+            {isAiBundleLoading ? (
+              <p className="celebration-blurb celebration-blurb--loading" aria-live="polite">
+                {text.blurbLoading}
+              </p>
+            ) : (
+              <p className="celebration-blurb">{blurb}</p>
+            )}
+            {currentBlurbs && !isAiBundleLoading ? (
               <button
                 type="button"
                 className="reroll-button"

--- a/fredagskoll-frontend/src/appText.ts
+++ b/fredagskoll-frontend/src/appText.ts
@@ -100,6 +100,7 @@ export const appText: Record<
     previousDay: string;
     nextDay: string;
     reroll: string;
+    blurbLoading: string;
     unofficialThemeDay: string;
     unofficialThemeDays: (count: number) => string;
     noOfficialEnergy: string;
@@ -164,6 +165,7 @@ export const appText: Record<
     previousDay: 'Föregående dag',
     nextDay: 'Nästa dag',
     reroll: 'Ny ursäkt',
+    blurbLoading: 'Hämtar dagens text.',
     unofficialThemeDay: 'Inofficiell temadag',
     unofficialThemeDays: (count: number) => `Inofficiella temadagar x${count}`,
     noOfficialEnergy: 'Ingen officiell stordådskänsla',
@@ -232,6 +234,7 @@ export const appText: Record<
     previousDay: 'Previous day',
     nextDay: 'Next day',
     reroll: 'New excuse',
+    blurbLoading: "Fetching today's copy.",
     unofficialThemeDay: 'Unofficial theme day',
     unofficialThemeDays: (count: number) => `Unofficial theme days x${count}`,
     noOfficialEnergy: 'No official sense of occasion',
@@ -300,6 +303,7 @@ export const appText: Record<
     previousDay: 'Dia anterior',
     nextDay: 'Próximo dia',
     reroll: 'Nova desculpa',
+    blurbLoading: 'Buscando o texto do dia.',
     unofficialThemeDay: 'Data temática não oficial',
     unofficialThemeDays: (count: number) => `Datas temáticas não oficiais x${count}`,
     noOfficialEnergy: 'Nenhum senso oficial de ocasião',

--- a/fredagskoll-frontend/src/buildInfo.generated.ts
+++ b/fredagskoll-frontend/src/buildInfo.generated.ts
@@ -1,6 +1,6 @@
 export const buildInfo = {
-  "version": "0.1.9",
-  "gitSha": "183dce0",
-  "buildRef": "183dce0",
-  "builtAt": "2026-03-15T07:56:44.669Z"
+  "version": "0.1.10",
+  "gitSha": "6c0da4e",
+  "buildRef": "6c0da4e",
+  "builtAt": "2026-03-15T08:22:43.774Z"
 } as const;


### PR DESCRIPTION
## Summary
The blurb area was showing static fallback copy first and then swapping to the AI/cache result once the request came back. That made the app feel like it was changing its mind for no visible reason, especially on ordinary days where the text could visibly jump after initial render.

The root cause was that the frontend cleared the AI bundle as soon as a new request started, which immediately re-enabled the local fallback blurb sources. When the request later resolved, the UI swapped a second time to the fetched text. Users were effectively seeing an implementation detail of the loading flow.

This change makes the blurb area stay in an explicit loading state until the request for the selected date resolves. The app now hides the visible blurb and reroll button while the AI/cache lookup is in flight, and only falls back to local static copy if the request actually fails or returns no usable content. That removes the misleading intermediate blurb and makes the eventual text feel intentional.

The release version is also bumped to `0.1.10`, and the build metadata is regenerated to match.

## Validation
- `CI=true npm test -- --watch=false App.test.tsx`
- `npm run build`
