### PR TITLE
[codex] key ai loading state to the active request

### DIFF
--- a/fredagskoll-frontend/package.json
+++ b/fredagskoll-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vadkanmanfira-frontend",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/fredagskoll-frontend/src/App.test.tsx
+++ b/fredagskoll-frontend/src/App.test.tsx
@@ -452,6 +452,49 @@ test('hides fallback blurbs until the ai request resolves', async () => {
   expect(screen.queryByText(/Hämtar dagens text\./i)).not.toBeInTheDocument();
 });
 
+test('hides the previous ai blurb while a new date request is loading', async () => {
+  let resolveSecondBundle!: (value: {
+    source: 'cache';
+    titleEndings: string[];
+    cardNotes: string[];
+    blurbs: string[];
+  }) => void;
+
+  mockedFetchAiBlurbBundle
+    .mockResolvedValueOnce({
+      source: 'cache',
+      titleEndings: [],
+      cardNotes: [],
+      blurbs: ['Första rätta texten.'],
+    })
+    .mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSecondBundle = resolve;
+        })
+    );
+
+  await renderAppAt(new Date(2026, 1, 16));
+
+  expect(screen.getByText(/Första rätta texten\./i)).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: /Nästa dag/i }));
+
+  expect(screen.getByText(/Hämtar dagens text\./i)).toBeInTheDocument();
+  expect(screen.queryByText(/Första rätta texten\./i)).not.toBeInTheDocument();
+
+  resolveSecondBundle({
+    source: 'cache',
+    titleEndings: [],
+    cardNotes: [],
+    blurbs: ['Andra rätta texten.'],
+  });
+
+  await waitFor(() =>
+    expect(screen.getByText(/Andra rätta texten\./i)).toBeInTheDocument()
+  );
+});
+
 test('persists the selected mood and exposes it on the app root', async () => {
   await renderAppAt(new Date(2026, 2, 14));
 

--- a/fredagskoll-frontend/src/App.tsx
+++ b/fredagskoll-frontend/src/App.tsx
@@ -187,6 +187,7 @@ function App({
   const [nameDayState, setNameDayState] = useState<NameDayState>('loading');
   const [aiBundle, setAiBundle] = useState<AiBlurbBundle | null>(null);
   const [aiBundleState, setAiBundleState] = useState<AiBundleState>('loading');
+  const [resolvedAiRequestKey, setResolvedAiRequestKey] = useState<string | null>(null);
   const [blurb, setBlurb] = useState(getOrdinaryBlurb(getInitialLocale(), getInitialMood()));
   const [themeDayTitleEnding, setThemeDayTitleEnding] = useState(
     getOrdinaryThemeDayTitleEndings(getInitialLocale(), getInitialMood())[0]
@@ -256,9 +257,91 @@ function App({
     () => (!celebration && hasThemeDays ? buildThemeDayBlurbs(visibleThemeDays, locale, mood) : null),
     [celebration, hasThemeDays, locale, mood, visibleThemeDays]
   );
-  const isAiBundleLoading = aiBundleState === 'loading';
+  const kicker = celebration
+    ? celebration.kicker
+    : hasThemeDays
+      ? displayThemeDays.length > 1
+        ? text.unofficialThemeDays(displayThemeDays.length)
+        : text.unofficialThemeDay
+      : text.noOfficialEnergy;
+  const themeDayDisplayTitle = hasThemeDays ? displayThemeDays[0] : null;
+  const extraThemeDayLead = useMemo(() => {
+    if (celebration && dayStatus.dayType !== 'ordinary') {
+      const aliases = getCelebrationThemeAliases(dayStatus.dayType, locale, contentPack);
+      return aliases[0] ?? celebration.title;
+    }
+
+    return themeDayDisplayTitle;
+  }, [celebration, contentPack, dayStatus.dayType, locale, themeDayDisplayTitle]);
+  const celebrationSubtitle = celebration?.subtitle ?? null;
+  const mainTitle = celebration
+    ? celebration.title
+    : hasThemeDays
+      ? `${themeDayDisplayTitle}. ${themeDayTitleEnding}`
+      : getOrdinaryTitle(locale, mood);
+  const hasLongWordTitle = hasLongTitleWord(themeDayDisplayTitle ?? mainTitle);
+  const aiRequest = useMemo(() => {
+    const fallbackTitleEnding = getOrdinaryThemeDayTitleEndings(locale, mood)[0];
+    const fallbackCardNote = getOrdinaryThemeDayCardNotes(locale, mood)[0];
+    const fallbackBlurbs = celebration
+      ? celebration.blurbs
+      : themeDayBlurbs
+        ? themeDayBlurbs
+        : dayStatus.dayType === 'ordinary'
+          ? getOrdinaryDayBlurbs(
+              locale,
+              selectedDateObject.getDay() === 0 || selectedDateObject.getDay() === 6,
+              mood
+            )
+          : [];
+
+    return {
+      locale,
+      contentPack,
+      kind: celebration ? 'celebration' : hasThemeDays ? 'themeDay' : 'ordinary',
+      mood,
+      date: selectedDate,
+      dateLabel: dayStatus.dateLabel,
+      dayType: dayStatus.dayType,
+      title: celebration ? celebration.title : themeDayDisplayTitle ?? getOrdinaryTitle(locale, mood),
+      subtitle: celebration?.subtitle,
+      kicker,
+      fallbackTitleEnding,
+      fallbackCardNote,
+      fallbackBlurbs,
+      themeDays: displayThemeDays,
+      extraThemeDays: extraDisplayThemeDays,
+      seasonalTitles: seasonalNotes.map((item) => item.title),
+      upcomingTitles: upcomingNotables.map((item) => item.title),
+      upcomingHolidayName: upcomingHolidayName ?? undefined,
+      nationalDaySummary: nationalDayPanel?.summary,
+      allowHumor: true,
+    } as const;
+  }, [
+    celebration,
+    contentPack,
+    dayStatus.dateLabel,
+    dayStatus.dayType,
+    displayThemeDays,
+    extraDisplayThemeDays,
+    hasThemeDays,
+    kicker,
+    locale,
+    mood,
+    nationalDayPanel,
+    selectedDate,
+    selectedDateObject,
+    seasonalNotes,
+    themeDayBlurbs,
+    themeDayDisplayTitle,
+    upcomingHolidayName,
+    upcomingNotables,
+  ]);
+  const aiRequestKey = useMemo(() => JSON.stringify(aiRequest), [aiRequest]);
+  const isAiBundleLoading =
+    aiBundleState === 'loading' || resolvedAiRequestKey !== aiRequestKey;
   const currentBlurbs = useMemo(() => {
-    if (aiBundle?.blurbs.length) {
+    if (resolvedAiRequestKey === aiRequestKey && aiBundle?.blurbs.length) {
       return aiBundle.blurbs;
     }
 
@@ -283,30 +366,18 @@ function App({
       selectedDateObject.getDay() === 0 || selectedDateObject.getDay() === 6,
       mood
     );
-  }, [aiBundle, celebration, dayStatus.dayType, isAiBundleLoading, locale, mood, selectedDateObject, themeDayBlurbs]);
-  const kicker = celebration
-    ? celebration.kicker
-    : hasThemeDays
-      ? displayThemeDays.length > 1
-        ? text.unofficialThemeDays(displayThemeDays.length)
-        : text.unofficialThemeDay
-      : text.noOfficialEnergy;
-  const themeDayDisplayTitle = hasThemeDays ? displayThemeDays[0] : null;
-  const extraThemeDayLead = useMemo(() => {
-    if (celebration && dayStatus.dayType !== 'ordinary') {
-      const aliases = getCelebrationThemeAliases(dayStatus.dayType, locale, contentPack);
-      return aliases[0] ?? celebration.title;
-    }
-
-    return themeDayDisplayTitle;
-  }, [celebration, contentPack, dayStatus.dayType, locale, themeDayDisplayTitle]);
-  const celebrationSubtitle = celebration?.subtitle ?? null;
-  const mainTitle = celebration
-    ? celebration.title
-    : hasThemeDays
-      ? `${themeDayDisplayTitle}. ${themeDayTitleEnding}`
-      : getOrdinaryTitle(locale, mood);
-  const hasLongWordTitle = hasLongTitleWord(themeDayDisplayTitle ?? mainTitle);
+  }, [
+    aiBundle,
+    aiRequestKey,
+    celebration,
+    dayStatus.dayType,
+    isAiBundleLoading,
+    locale,
+    mood,
+    resolvedAiRequestKey,
+    selectedDateObject,
+    themeDayBlurbs,
+  ]);
 
   useEffect(() => {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
@@ -340,55 +411,21 @@ function App({
 
   useEffect(() => {
     const controller = new AbortController();
-    const fallbackTitleEnding = getOrdinaryThemeDayTitleEndings(locale, mood)[0];
-    const fallbackCardNote = getOrdinaryThemeDayCardNotes(locale, mood)[0];
-    const fallbackBlurbs = celebration
-      ? celebration.blurbs
-      : themeDayBlurbs
-        ? themeDayBlurbs
-        : dayStatus.dayType === 'ordinary'
-          ? getOrdinaryDayBlurbs(
-              locale,
-              selectedDateObject.getDay() === 0 || selectedDateObject.getDay() === 6,
-              mood
-            )
-          : [];
-
-    const kind = celebration ? 'celebration' : hasThemeDays ? 'themeDay' : 'ordinary';
-    const request = {
-      locale,
-      contentPack,
-      kind,
-      mood,
-      date: selectedDate,
-      dateLabel: dayStatus.dateLabel,
-      dayType: dayStatus.dayType,
-      title: celebration ? celebration.title : themeDayDisplayTitle ?? getOrdinaryTitle(locale, mood),
-      subtitle: celebration?.subtitle,
-      kicker,
-      fallbackTitleEnding,
-      fallbackCardNote,
-      fallbackBlurbs,
-      themeDays: displayThemeDays,
-      extraThemeDays: extraDisplayThemeDays,
-      seasonalTitles: seasonalNotes.map((item) => item.title),
-      upcomingTitles: upcomingNotables.map((item) => item.title),
-      upcomingHolidayName: upcomingHolidayName ?? undefined,
-      nationalDaySummary: nationalDayPanel?.summary,
-      allowHumor: true,
-    } as const;
-
     setAiBundle(null);
     setAiBundleState('loading');
+    setResolvedAiRequestKey(null);
 
-    Promise.resolve(fetchAiBlurbBundle(request, controller.signal))
+    Promise.resolve(fetchAiBlurbBundle(aiRequest, controller.signal))
       .then((bundle) => {
         if (bundle === null) {
+          setAiBundle(null);
+          setResolvedAiRequestKey(aiRequestKey);
           setAiBundleState('fallback');
           return;
         }
 
         setAiBundle(bundle);
+        setResolvedAiRequestKey(aiRequestKey);
         setAiBundleState('ready');
       })
       .catch(() => {
@@ -397,6 +434,7 @@ function App({
         }
 
         setAiBundle(null);
+        setResolvedAiRequestKey(aiRequestKey);
         setAiBundleState('fallback');
       });
 
@@ -404,24 +442,8 @@ function App({
       controller.abort();
     };
   }, [
-    celebration,
-    contentPack,
-    dayStatus.dateLabel,
-    dayStatus.dayType,
-    displayThemeDays,
-    extraDisplayThemeDays,
-    hasThemeDays,
-    kicker,
-    locale,
-    mood,
-    nationalDayPanel,
-    selectedDate,
-    selectedDateObject,
-    seasonalNotes,
-    themeDayBlurbs,
-    themeDayDisplayTitle,
-    upcomingHolidayName,
-    upcomingNotables,
+    aiRequest,
+    aiRequestKey,
   ]);
 
   useEffect(() => {
@@ -763,7 +785,9 @@ function App({
               }`}
             >
               {themeDayDisplayTitle}.
-              <span className="celebration-title-subline">{themeDayTitleEnding}</span>
+              <span className="celebration-title-subline">
+                {isAiBundleLoading ? text.blurbLoading : themeDayTitleEnding}
+              </span>
             </h2>
           ) : celebrationSubtitle ? (
             <h2
@@ -866,7 +890,9 @@ function App({
                 {hasThemeDays ? text.todayThemeDays : text.noHit}
               </span>
               <p>
-                {hasThemeDays
+                {hasThemeDays && isAiBundleLoading
+                  ? text.blurbLoading
+                  : hasThemeDays
                   ? getOrdinaryThemeDayLead(
                       locale,
                       mood,

--- a/fredagskoll-frontend/src/buildInfo.generated.ts
+++ b/fredagskoll-frontend/src/buildInfo.generated.ts
@@ -1,6 +1,6 @@
 export const buildInfo = {
-  "version": "0.1.10",
-  "gitSha": "6c0da4e",
-  "buildRef": "6c0da4e",
-  "builtAt": "2026-03-15T08:22:43.774Z"
+  "version": "0.1.11",
+  "gitSha": "7f9e2ba",
+  "buildRef": "7f9e2ba",
+  "builtAt": "2026-03-15T08:46:43.296Z"
 } as const;


### PR DESCRIPTION
## Summary
The previous loading fix removed the obvious fallback swap, but there was still a smaller race left in the UI. When the user changed the date or mood, the app could briefly keep showing the previously resolved AI copy until the new request effect ran and flipped the loading state. That made it look like the app was still pulling text from nowhere and then changing its mind once the correct response arrived.

The root cause was that the frontend treated the presence of any resolved AI bundle as globally valid state instead of tying it to the specific request that produced it. A new selection could therefore render once with stale AI text from the prior request before the new fetch cycle fully took over.

This change keys the AI text state to the active request payload. Any change to the selected date, tone, or other AI-driving context now invalidates the previously resolved bundle immediately. Until the matching response arrives, the app shows the shared loading copy instead of reusing old text. The loading treatment now also covers the AI-driven subheader/theme-day note surface, not just the main blurb, so the whole text block stays consistent while the request is in flight.

The release version is bumped to `0.1.11`, and the build metadata is regenerated.

## Validation
- `CI=true npm test -- --watch=false App.test.tsx`
- `npm run build`
