### PR TITLE
[codex] simplify the readme flow diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,31 +56,15 @@ flow. The version below is the short, human-readable overview.
 
 ```mermaid
 flowchart TD
-    A[User picks date, language, tone, and content pack] --> B[Frontend classifies the date]
-    B --> C{Built-in celebration?}
-    C -->|Yes| D[Show celebration content]
-    C -->|No| E{Theme days found?}
-    E -->|Yes| F[Show theme-day based content]
-    E -->|No| G[Show ordinary-day content]
-
-    D --> H[Load sidebar context]
-    F --> H
-    G --> H
-
-    H --> I[Optionally request AI blurbs from Azure Function]
-    I --> J{Cache hit for this exact request?}
-    J -->|Yes| K[Return cached bundle]
-    J -->|No| L[Generate a new bundle with Azure OpenAI and store it]
-
-    K --> M[Frontend accepts result only for the active request]
-    L --> M
-    I -. pending .-> N[Show loading text instead of visible AI copy]
-
-    M --> O[Render headline, subheader, blurbs, reroll options, and mood styling]
-
-    P[GitHub Actions] --> Q[Build public and team variants]
-    Q --> R[Deploy frontend to Azure Static Web Apps]
-    I --> S[Dedicated Azure Function App]
+    A[User picks a date] --> B[Frontend checks what kind of day it is]
+    B --> C{Celebration, theme day, or ordinary day?}
+    C --> D[Build the page content]
+    D --> E[Load extra context like name day and upcoming dates]
+    E --> F[Optionally ask the AI API for better blurbs]
+    F --> G[Use cached or newly generated AI text when available]
+    F --> H[Otherwise keep local built-in text]
+    G --> I[Render the final card]
+    H --> I[Render the final card]
 ```
 
 ## Built-in celebration rules


### PR DESCRIPTION
## Summary
The README flowchart was still more detailed than it needed to be for a top-level overview. It was technically correct, but it was still asking the reader to parse more of the system than a README front page should demand.

This trims the README Mermaid diagram down to a very broad product flow. The detailed reference diagram remains in `docs/application-flow.md`; the README now only shows the main sequence from choosing a date to rendering the final card.

This is documentation only, so there is no version bump.
