### PR TITLE
[codex] move ai blurbs to managed static web app APIs

### DIFF
--- a/.github/workflows/deploy-static-apps.yml
+++ b/.github/workflows/deploy-static-apps.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REACT_APP_CONTENT_PACK: public
-      REACT_APP_AI_API_BASE_URL: https://vkmf-blurbs-api.azurewebsites.net
       GITHUB_SHA: ${{ github.sha }}
       GITHUB_RUN_NUMBER: ${{ github.run_number }}
     steps:
@@ -33,6 +32,7 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: upload
           app_location: fredagskoll-frontend
+          api_location: api
           output_location: build
 
   deploy_team:
@@ -40,7 +40,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REACT_APP_CONTENT_PACK: team
-      REACT_APP_AI_API_BASE_URL: https://vkmf-blurbs-api.azurewebsites.net
       GITHUB_SHA: ${{ github.sha }}
       GITHUB_RUN_NUMBER: ${{ github.run_number }}
     steps:
@@ -57,4 +56,5 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: upload
           app_location: fredagskoll-frontend
+          api_location: api
           output_location: build

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Vad kan man fira?
 
-`Vad kan man fira?` is a frontend-only React app that decides whether a Swedish
-date deserves celebration, resignation, baked goods, or a dry remark about
-calendar reality.
+`Vad kan man fira?` is a React app with managed Azure Static Web Apps APIs that
+decides whether a Swedish date deserves celebration, resignation, baked goods,
+or a dry remark about calendar reality.
 
 The shipped product lives in `fredagskoll-frontend` and is deployed to Azure
 Static Web Apps from the `main` branch.
@@ -119,30 +119,28 @@ npm run build
 
 ## Deployment
 
-- GitHub Actions deploys the frontend from `main`
+- GitHub Actions deploys the frontend and managed API from `main`
 - `.github/workflows/deploy-static-apps.yml` builds the app twice:
   - `REACT_APP_CONTENT_PACK=public` deploys to `vadkanmanfira`
   - `REACT_APP_CONTENT_PACK=team` deploys to `fredagskoll`
-- The workflow sets `REACT_APP_AI_API_BASE_URL=https://vkmf-blurbs-api.azurewebsites.net`
-  for both builds
+- Both deployments include the managed API from `api/`
 - Required GitHub Actions secrets:
   - `AZURE_STATIC_WEB_APPS_API_TOKEN_THANKFUL_BUSH_0D8565003_1`
   - `AZURE_STATIC_WEB_APPS_API_TOKEN_DELIGHTFUL_GROUND_0B3AA2B03`
 - Azure Static Web Apps hosts both variants
-- The AI backend is a separate Azure Function App at
-  `https://vkmf-blurbs-api.azurewebsites.net`
+- The frontend calls the same-origin managed API at `/api/blurbs`
 - SPA routing fallback lives in
   `fredagskoll-frontend/public/staticwebapp.config.json`
 
 ## Optional AI blurbs
 
-The app can now ask an Azure Function for generated blurb bundles. This is optional:
-if the API is unavailable or Azure OpenAI is not configured, the frontend keeps using
-the existing handwritten/static blurbs.
+The app can now ask a managed Azure Functions API for generated blurb bundles.
+This is optional: if the API is unavailable or Azure OpenAI is not configured,
+the frontend keeps using the existing handwritten/static blurbs.
 
 The frontend calls:
 
-- `https://vkmf-blurbs-api.azurewebsites.net/api/blurbs`
+- `/api/blurbs`
 
 What it does:
 
@@ -167,7 +165,7 @@ Current table layout:
   - stores `bundleId`, `requestHash`, `generatedAt`, `model`, `useCount`, `lastUsedAt`,
     `titleEndingsJson`, `cardNotesJson`, and `blurbsJson`
 
-Required Azure app settings for the dedicated Function App:
+Required Azure app settings for each Static Web App managed API:
 
 - `AZURE_OPENAI_ENDPOINT`
 - `AZURE_OPENAI_API_KEY`

--- a/fredagskoll-frontend/README.md
+++ b/fredagskoll-frontend/README.md
@@ -1,6 +1,8 @@
 # Vad kan man fira? Frontend
 
-This folder contains the actual product application for `Vad kan man fira?`.
+This folder contains the actual product application for `Vad kan man fira?`,
+including the frontend that is deployed together with a managed Azure Static
+Web Apps API from the repository root.
 
 ## What it does
 
@@ -62,14 +64,12 @@ workflow:
 
 - `.github/workflows/deploy-static-apps.yml`
 
-That workflow builds the same app twice from `main`:
+That workflow builds the same app twice from `main` and includes the shared
+managed API from `../api`:
 
 - `REACT_APP_CONTENT_PACK=public` -> `vadkanmanfira`
 - `REACT_APP_CONTENT_PACK=team` -> `fredagskoll`
 
-The workflow sets `REACT_APP_AI_API_BASE_URL=https://vkmf-blurbs-api.azurewebsites.net`
-for both builds.
+In production, the frontend calls the same-origin managed API path:
 
-The AI backend is a separate Azure Function App:
-
-- `https://vkmf-blurbs-api.azurewebsites.net/api/blurbs`
+- `/api/blurbs`

--- a/fredagskoll-frontend/package.json
+++ b/fredagskoll-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vadkanmanfira-frontend",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/fredagskoll-frontend/public/staticwebapp.config.json
+++ b/fredagskoll-frontend/public/staticwebapp.config.json
@@ -2,6 +2,7 @@
   "navigationFallback": {
     "rewrite": "/index.html",
     "exclude": [
+      "/api/*",
       "/images/*.{png,jpg,jpeg,gif,webp,svg}",
       "/static/*",
       "/*.{css,js,json,ico,txt,map}"

--- a/fredagskoll-frontend/src/buildInfo.generated.ts
+++ b/fredagskoll-frontend/src/buildInfo.generated.ts
@@ -1,6 +1,6 @@
 export const buildInfo = {
-  "version": "0.1.11",
-  "gitSha": "7f9e2ba",
-  "buildRef": "7f9e2ba",
-  "builtAt": "2026-03-15T08:46:43.296Z"
+  "version": "0.1.12",
+  "gitSha": "c017bc7",
+  "buildRef": "c017bc7",
+  "builtAt": "2026-03-15T09:36:01.693Z"
 } as const;


### PR DESCRIPTION
## Summary
This migrates the AI blurb path from the separately exposed Function App hostname to managed Azure Static Web Apps APIs so the project can stay on the free tier and still use same-origin `/api/blurbs` requests.

The deploy workflow now includes `api/` as the managed API for both Static Web Apps, and it no longer injects the dedicated `azurewebsites.net` hostname into the frontend build. In production, each site serves its own managed API path while both still use the existing Azure OpenAI and Table Storage settings already configured on the Static Web Apps.

The frontend version is bumped to `0.1.12`, the build metadata is regenerated, and the documentation is updated so the repo stops claiming that production calls the dedicated Function App directly.

## Validation
- `CI=true npm test -- --watch=false App.test.tsx`
- `npm run build`
