### PR TITLE
[codex] tighten ai variant generation and add footer changelog

### DIFF
--- a/api/blurbs/index.js
+++ b/api/blurbs/index.js
@@ -1,4 +1,5 @@
 const {
+  canGenerateVariant,
   MAX_VARIANTS_PER_KEY,
   chooseVariant,
   createVariant,
@@ -43,28 +44,12 @@ module.exports = async function blurbHandler(context, req) {
 
     let cacheState = await getCacheState(request);
     let responseSource = 'cache';
-
-    if (!cacheState) {
-      const generated = await generateBlurbBundle(request);
-      if (!generated.enabled || !generated.bundle) {
-        context.res = json(204, null);
-        return;
-      }
-
-      context.res = json(200, {
-        source: 'azure-openai',
-        titleEndings: generated.bundle.titleEndings,
-        cardNotes: generated.bundle.cardNotes,
-        blurbs: generated.bundle.blurbs,
-        model: generated.model,
-      });
-      return;
-    }
-
+    const wantsReroll = request.requestMode === 'reroll';
+    const canGenerateNow = canGenerateVariant(cacheState);
     const shouldGenerateVariant =
-      cacheState.freshVariants.length === 0 ||
-      cacheState.variants.length < MAX_VARIANTS_PER_KEY ||
-      cacheState.staleVariants.length > 0;
+      cacheState.freshVariants.length === 0
+        ? canGenerateNow
+        : wantsReroll && cacheState.variants.length < MAX_VARIANTS_PER_KEY && canGenerateNow;
 
     if (shouldGenerateVariant) {
       const generated = await tryGenerateVariant(request, cacheState);
@@ -93,9 +78,16 @@ module.exports = async function blurbHandler(context, req) {
         cacheState = {
           ...(cacheState || {}),
           variants: updatedVariants,
-          freshVariants: updatedVariants,
-          staleVariants: [],
+          freshVariants: updatedVariants.filter((variant) => {
+            const generatedAtMs = Date.parse(variant.generatedAt);
+            return !Number.isNaN(generatedAtMs) && Date.now() - generatedAtMs <= 15 * 60 * 1000;
+          }),
+          staleVariants: updatedVariants.filter((variant) => {
+            const generatedAtMs = Date.parse(variant.generatedAt);
+            return Number.isNaN(generatedAtMs) || Date.now() - generatedAtMs > 15 * 60 * 1000;
+          }),
           createdAt: cacheState?.createdAt || generatedVariant.createdAt,
+          lastGeneratedAt: generatedVariant.generatedAt,
         };
         responseSource = 'azure-openai';
       }

--- a/api/shared/blurbSchema.js
+++ b/api/shared/blurbSchema.js
@@ -2,6 +2,7 @@ const SUPPORTED_LOCALES = new Set(['sv', 'en', 'pt-BR']);
 const SUPPORTED_PACKS = new Set(['public', 'team']);
 const SUPPORTED_KINDS = new Set(['celebration', 'themeDay', 'ordinary']);
 const SUPPORTED_MOODS = new Set(['dry', 'cheerful', 'chaotic', 'formal', 'absurd', 'warm']);
+const SUPPORTED_REQUEST_MODES = new Set(['default', 'reroll']);
 
 function coerceString(value, fallback = '') {
   return typeof value === 'string' ? value.trim() : fallback;
@@ -28,12 +29,16 @@ function normalizeRequestBody(body) {
   const contentPack = SUPPORTED_PACKS.has(source.contentPack) ? source.contentPack : 'public';
   const kind = SUPPORTED_KINDS.has(source.kind) ? source.kind : 'ordinary';
   const mood = SUPPORTED_MOODS.has(source.mood) ? source.mood : 'dry';
+  const requestMode = SUPPORTED_REQUEST_MODES.has(source.requestMode)
+    ? source.requestMode
+    : 'default';
 
   return {
     locale,
     contentPack,
     kind,
     mood,
+    requestMode,
     date: coerceString(source.date),
     dateLabel: coerceString(source.dateLabel),
     dayType: coerceString(source.dayType, 'ordinary'),

--- a/api/shared/cache.js
+++ b/api/shared/cache.js
@@ -3,6 +3,7 @@ const crypto = require('crypto');
 const CACHE_TABLE_NAME = 'blurbcache';
 const LIBRARY_TABLE_NAME = 'blurblibrary';
 const CACHE_MAX_AGE_MS = 15 * 60 * 1000;
+const GENERATION_COOLDOWN_MS = 15 * 60 * 1000;
 const MAX_VARIANTS_PER_KEY = 3;
 
 function loadTableClient() {
@@ -337,6 +338,14 @@ function buildCacheStateFromHotEntity(hotEntity, variants, requestHash) {
       typeof hotEntity.createdAt === 'string' && hotEntity.createdAt.length > 0
         ? hotEntity.createdAt
         : null,
+    lastGeneratedAt:
+      typeof hotEntity.lastGeneratedAt === 'string' && hotEntity.lastGeneratedAt.length > 0
+        ? hotEntity.lastGeneratedAt
+        : variants
+            .map((variant) => variant.generatedAt)
+            .filter((value) => typeof value === 'string' && value.length > 0)
+            .sort()
+            .at(-1) || null,
   };
 }
 
@@ -374,6 +383,7 @@ async function getCacheState(request) {
         lastUsedAt: null,
         lastBundleId: null,
         createdAt: null,
+        lastGeneratedAt: null,
       };
     }
 
@@ -397,6 +407,14 @@ async function saveCacheState(request, state) {
   const nowIso = new Date().toISOString();
   const createdAt =
     typeof state.createdAt === 'string' && state.createdAt.length > 0 ? state.createdAt : nowIso;
+  const lastGeneratedAt =
+    typeof state.lastGeneratedAt === 'string' && state.lastGeneratedAt.length > 0
+      ? state.lastGeneratedAt
+      : variants
+          .map((variant) => variant.generatedAt)
+          .filter((value) => typeof value === 'string' && value.length > 0)
+          .sort()
+          .at(-1) || null;
 
   for (const variant of variants) {
     variant.requestHash = requestHash;
@@ -428,6 +446,7 @@ async function saveCacheState(request, state) {
     kicker: request.kicker || null,
     createdAt,
     updatedAt: nowIso,
+    lastGeneratedAt,
     lastUsedAt:
       typeof state.lastUsedAt === 'string' && state.lastUsedAt.length > 0 ? state.lastUsedAt : null,
     useCount: Number.isFinite(state.useCount) ? Number(state.useCount) : 0,
@@ -468,10 +487,25 @@ function recordVariantUsage(state, variant, usedAt = new Date().toISOString()) {
   };
 }
 
+function canGenerateVariant(state, nowMs = Date.now()) {
+  if (!state || !state.lastGeneratedAt) {
+    return true;
+  }
+
+  const generatedAtMs = Date.parse(state.lastGeneratedAt);
+  if (Number.isNaN(generatedAtMs)) {
+    return true;
+  }
+
+  return nowMs - generatedAtMs >= GENERATION_COOLDOWN_MS;
+}
+
 module.exports = {
   CACHE_MAX_AGE_MS,
+  GENERATION_COOLDOWN_MS,
   MAX_VARIANTS_PER_KEY,
   buildRequestHash,
+  canGenerateVariant,
   chooseVariant,
   createVariant,
   getCacheState,

--- a/docs/application-flow.md
+++ b/docs/application-flow.md
@@ -35,7 +35,7 @@ flowchart TD
     M --> M6[fallback blurbs and theme-day support text]
     M --> M7[seasonal, upcoming, and national-day context]
 
-    M --> N[POST to Azure Function /api/blurbs]
+    M --> N[POST to same-origin managed API /api/blurbs]
     N --> O[normalizeRequestBody validates and trims request]
     O --> P[buildRequestHash creates request key]
     P --> Q[Lookup hot row in blurbcache]
@@ -74,9 +74,10 @@ flowchart TD
 
     N -. request pending .-> AF[While waiting, frontend hides AI-driven text and shows loading copy]
 
-    AG[GitHub Actions deploy-static-apps.yml] --> AH[Build public variant]
-    AG --> AI[Build team variant]
+    AG[GitHub Actions deploy-static-apps.yml] --> AH[Build public variant plus managed API]
+    AG --> AI[Build team variant plus managed API]
     AH --> AJ[Azure Static Web App public site]
     AI --> AK[Azure Static Web App team site]
-    N --> AL[Dedicated Azure Function App]
+    AJ --> AL[Managed API runtime for public site]
+    AK --> AM[Managed API runtime for team site]
 ```

--- a/fredagskoll-frontend/package-lock.json
+++ b/fredagskoll-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vadkanmanfira-frontend",
-  "version": "0.1.3",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vadkanmanfira-frontend",
-      "version": "0.1.3",
+      "version": "0.1.15",
       "dependencies": {
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",

--- a/fredagskoll-frontend/package.json
+++ b/fredagskoll-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vadkanmanfira-frontend",
-  "version": "0.1.12",
+  "version": "0.1.15",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/fredagskoll-frontend/src/App.css
+++ b/fredagskoll-frontend/src/App.css
@@ -1011,9 +1011,70 @@
 .intro-footer {
   margin-top: auto;
   padding-top: 0.35rem;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.intro-footer-links {
   display: flex;
   flex-wrap: wrap;
   gap: 0.8rem 1rem;
+  align-items: center;
+}
+
+.release-note-card {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.9rem 1rem;
+  border-radius: 18px;
+  background:
+    linear-gradient(135deg, var(--mood-panel-tint), transparent 75%),
+    rgba(255, 255, 255, 0.34);
+  border: 1px solid var(--panel-border);
+}
+
+.App.dark .release-note-card {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.release-note-card--subtle {
+  padding: 0.2rem 0 0;
+  background: transparent;
+  border: 0;
+}
+
+.release-note-current,
+.release-note-version {
+  margin: 0;
+}
+
+.release-note-current {
+  color: var(--muted);
+  font-size: 0.84rem;
+  line-height: 1.45;
+  max-width: 42rem;
+}
+
+.release-note-button {
+  justify-self: start;
+  font-size: 0.82rem;
+}
+
+.release-notes-list {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.release-note-item {
+  gap: 0.2rem;
+}
+
+.release-note-version {
+  font-size: 0.84rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--tone-accent);
 }
 
 .source-link {
@@ -1036,6 +1097,10 @@
   padding: 0;
   cursor: pointer;
   font: inherit;
+  text-decoration: underline;
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.16em;
+  font-weight: 700;
 }
 
 .build-stamp {

--- a/fredagskoll-frontend/src/App.test.tsx
+++ b/fredagskoll-frontend/src/App.test.tsx
@@ -5,6 +5,7 @@ import { fetchAiBlurbBundle } from './aiBlurbs';
 import { buildInfo } from './buildInfo.generated';
 import { ContentPack } from './contentPack';
 import { MOOD_STORAGE_KEY } from './mood';
+import { getReleaseNote } from './releaseNotes';
 
 jest.mock('./aiBlurbs', () => ({
   fetchAiBlurbBundle: jest.fn().mockResolvedValue(null),
@@ -37,7 +38,8 @@ async function renderAppAt(
 
 beforeEach(() => {
   window.localStorage.clear();
-  mockedFetchAiBlurbBundle.mockClear();
+  mockedFetchAiBlurbBundle.mockReset();
+  mockedFetchAiBlurbBundle.mockResolvedValue(null);
 
   jest.spyOn(global, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
     const url = String(input);
@@ -300,6 +302,22 @@ test('renders a subtle build stamp in the footer', async () => {
   expect(screen.getByText(new RegExp(buildInfo.gitSha, 'i'))).toBeInTheDocument();
 });
 
+test('shows a simple current release note and opens the changelog history', async () => {
+  await renderAppAt(new Date(2026, 2, 14));
+
+  const currentRelease = getReleaseNote(buildInfo.version);
+  expect(currentRelease).not.toBeNull();
+  expect(screen.getByText(currentRelease!.shortSummary.sv)).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: /Visa alla ändringar/i }));
+
+  expect(
+    screen.getByRole('heading', { level: 2, name: /Det här har ändrats i appen/i })
+  ).toBeInTheDocument();
+  expect(screen.getByText(currentRelease!.summary.sv)).toBeInTheDocument();
+  expect(screen.getByText(/v0\.1\.12/i)).toBeInTheDocument();
+});
+
 test('renders public image credits when opening the credits dialog', async () => {
   await renderAppAt(new Date(2026, 2, 25));
 
@@ -338,7 +356,7 @@ test('allows collapsing the upcoming panel', async () => {
   fireEvent.click(screen.getByRole('button', { name: /Dölj/i }));
 
   expect(screen.queryByText(/^Valborg$/i)).not.toBeInTheDocument();
-  expect(screen.getByRole('button', { name: /Visa/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /^Visa$/i })).toBeInTheDocument();
 });
 
 test('renders bokrean as a seasonal sidebar note during the sale window', async () => {
@@ -523,5 +541,37 @@ test('sends the selected mood in ai blurb requests', async () => {
       expect.objectContaining({ mood: 'warm' }),
       expect.any(AbortSignal)
     )
+  );
+});
+
+test('only asks for another ai variant when reroll is clicked', async () => {
+  mockedFetchAiBlurbBundle
+    .mockResolvedValueOnce({
+      source: 'cache',
+      titleEndings: [],
+      cardNotes: [],
+      blurbs: ['Första ai-texten.'],
+    })
+    .mockResolvedValueOnce({
+      source: 'azure-openai',
+      titleEndings: [],
+      cardNotes: [],
+      blurbs: ['Ny ai-text efter reroll.'],
+    });
+
+  await renderAppAt(new Date(2026, 2, 14));
+
+  mockedFetchAiBlurbBundle.mockClear();
+
+  fireEvent.click(screen.getByRole('button', { name: /Ny ursäkt/i }));
+
+  await waitFor(() =>
+    expect(mockedFetchAiBlurbBundle).toHaveBeenLastCalledWith(
+      expect.objectContaining({ requestMode: 'reroll' }),
+      undefined
+    )
+  );
+  await waitFor(() =>
+    expect(screen.getByText(/Ny ai-text efter reroll\./i)).toBeInTheDocument()
   );
 });

--- a/fredagskoll-frontend/src/App.tsx
+++ b/fredagskoll-frontend/src/App.tsx
@@ -55,6 +55,7 @@ import {
   MOOD_STORAGE_KEY,
   Mood,
 } from './mood';
+import { getReleaseNote, releaseNotes } from './releaseNotes';
 import { buildThemeDayBlurbs, filterThemeDays, joinWithAnd } from './themeDayBlurbs';
 import { getThemeDaysForDate } from './temadagar';
 import { getUpcomingNotables } from './upcomingNotables';
@@ -170,6 +171,7 @@ function App({
   const [darkMode, setDarkMode] = useState(false);
   const [showLanguageMenu, setShowLanguageMenu] = useState(false);
   const [showImageCredits, setShowImageCredits] = useState(false);
+  const [showReleaseNotes, setShowReleaseNotes] = useState(false);
   const [isMobileLayout, setIsMobileLayout] = useState(getInitialMobileLayout);
   const [mood, setMood] = useState<Mood>(getInitialMood);
   const [showUpcoming, setShowUpcoming] = useState(true);
@@ -188,6 +190,7 @@ function App({
   const [aiBundle, setAiBundle] = useState<AiBlurbBundle | null>(null);
   const [aiBundleState, setAiBundleState] = useState<AiBundleState>('loading');
   const [resolvedAiRequestKey, setResolvedAiRequestKey] = useState<string | null>(null);
+  const [isAiRerolling, setIsAiRerolling] = useState(false);
   const [blurb, setBlurb] = useState(getOrdinaryBlurb(getInitialLocale(), getInitialMood()));
   const [themeDayTitleEnding, setThemeDayTitleEnding] = useState(
     getOrdinaryThemeDayTitleEndings(getInitialLocale(), getInitialMood())[0]
@@ -198,6 +201,7 @@ function App({
 
   const text = appText[locale];
   const buildStamp = useMemo(() => formatBuildStamp(locale), [locale]);
+  const currentReleaseNote = useMemo(() => getReleaseNote(buildInfo.version), []);
   const celebrations = useMemo(
     () => getCelebrations(locale, contentPack, mood),
     [contentPack, locale, mood]
@@ -300,6 +304,7 @@ function App({
       contentPack,
       kind: celebration ? 'celebration' : hasThemeDays ? 'themeDay' : 'ordinary',
       mood,
+      requestMode: 'default',
       date: selectedDate,
       dateLabel: dayStatus.dateLabel,
       dayType: dayStatus.dayType,
@@ -524,6 +529,48 @@ function App({
     }));
   }
 
+  async function handleReroll(): Promise<void> {
+    if (!currentBlurbs) {
+      return;
+    }
+
+    const canAskAiForAnotherVariant =
+      aiBundle !== null &&
+      resolvedAiRequestKey === aiRequestKey &&
+      aiBundleState === 'ready';
+
+    if (!canAskAiForAnotherVariant) {
+      setBlurb(getRandomItem(currentBlurbs, ordinaryBlurb, blurb));
+      return;
+    }
+
+    setIsAiRerolling(true);
+
+    try {
+      const rerolledBundle = await fetchAiBlurbBundle(
+        {
+          ...aiRequest,
+          requestMode: 'reroll',
+        },
+        undefined
+      );
+
+      if (rerolledBundle?.blurbs.length) {
+        setAiBundle(rerolledBundle);
+        setResolvedAiRequestKey(aiRequestKey);
+        setAiBundleState('ready');
+        setBlurb(getRandomItem(rerolledBundle.blurbs, ordinaryBlurb, blurb));
+        return;
+      }
+    } catch {
+      // Fall back to a local reroll when the extra AI fetch is unavailable.
+    } finally {
+      setIsAiRerolling(false);
+    }
+
+    setBlurb(getRandomItem(currentBlurbs, ordinaryBlurb, blurb));
+  }
+
   return (
     <div
       className={`App ${darkMode ? 'dark' : ''} theme-${theme} locale-${locale}`}
@@ -735,24 +782,39 @@ function App({
           ) : null}
 
           <footer className="intro-footer">
-            <button
-              type="button"
-              className="source-link source-link--button"
-              onClick={() => setShowImageCredits(true)}
-            >
-              {text.imageCredits}
-            </button>
-            <a
-              className="source-link"
-              href="https://temadagar.se/kalender/"
-              target="_blank"
-              rel="noreferrer"
-            >
-              {text.themeDaySource}
-            </a>
-            <span className="build-stamp">
-              {text.buildInfoLabel} {buildStamp}
-            </span>
+            <div className="intro-footer-links">
+              <button
+                type="button"
+                className="source-link source-link--button"
+                onClick={() => setShowImageCredits(true)}
+              >
+                {text.imageCredits}
+              </button>
+              <a
+                className="source-link"
+                href="https://temadagar.se/kalender/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                {text.themeDaySource}
+              </a>
+              <span className="build-stamp">
+                {text.buildInfoLabel} {buildStamp}
+              </span>
+            </div>
+            <div className="release-note-card release-note-card--subtle">
+              <p className="eyebrow">{text.releaseNotesLabel}</p>
+              <p className="release-note-current">
+                {currentReleaseNote?.shortSummary[locale] ?? buildStamp}
+              </p>
+              <button
+                type="button"
+                className="source-link source-link--button release-note-button"
+                onClick={() => setShowReleaseNotes(true)}
+              >
+                {text.releaseNotesOpen}
+              </button>
+            </div>
           </footer>
         </header>
 
@@ -819,7 +881,10 @@ function App({
               <button
                 type="button"
                 className="reroll-button"
-                onClick={() => setBlurb(getRandomItem(currentBlurbs, ordinaryBlurb, blurb))}
+                onClick={() => {
+                  void handleReroll();
+                }}
+                disabled={isAiRerolling}
               >
                 {text.reroll}
               </button>
@@ -1006,6 +1071,47 @@ function App({
                   {credit.note ? (
                     <p className="credits-item-note">{getImageCreditNote(credit.note, locale)}</p>
                   ) : null}
+                </article>
+              ))}
+            </div>
+          </section>
+        </div>
+      ) : null}
+
+      {showReleaseNotes ? (
+        <div
+          className="credits-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="release-notes-title"
+        >
+          <div
+            className="credits-backdrop"
+            aria-hidden="true"
+            onClick={() => setShowReleaseNotes(false)}
+          />
+          <section className="credits-panel">
+            <div className="credits-header">
+              <div>
+                <p className="eyebrow">{text.releaseNotesLabel}</p>
+                <h2 id="release-notes-title" className="credits-title">
+                  {text.releaseNotesTitle}
+                </h2>
+              </div>
+              <button
+                type="button"
+                className="theme-toggle credits-close"
+                onClick={() => setShowReleaseNotes(false)}
+              >
+                {text.close}
+              </button>
+            </div>
+
+            <div className="release-notes-list">
+              {releaseNotes.map((note) => (
+                <article key={note.version} className="credits-item release-note-item">
+                  <p className="release-note-version">v{note.version}</p>
+                  <p className="credits-item-meta">{note.summary[locale]}</p>
                 </article>
               ))}
             </div>

--- a/fredagskoll-frontend/src/aiBlurbs.test.ts
+++ b/fredagskoll-frontend/src/aiBlurbs.test.ts
@@ -1,0 +1,51 @@
+import { fetchAiBlurbBundle, type AiBlurbRequest } from './aiBlurbs';
+
+const request: AiBlurbRequest = {
+  locale: 'sv',
+  contentPack: 'public',
+  kind: 'ordinary',
+  mood: 'dry',
+  date: '2026-03-15',
+  dateLabel: '15 mars 2026',
+  dayType: 'ordinary',
+  title: 'Vanlig dag',
+  subtitle: 'Sondag',
+  kicker: 'En helt vanlig sondag',
+  fallbackTitleEnding: 'fortfarande bara sondag',
+  fallbackCardNote: 'Det har ar inte en officiell svensk helgdag.',
+  fallbackBlurbs: ['En vanlig dag.'],
+  themeDays: [],
+  extraThemeDays: [],
+  seasonalTitles: [],
+  upcomingTitles: [],
+  allowHumor: true,
+};
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('posts ai blurb requests to the same-origin managed api path', async () => {
+  const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      source: 'cache',
+      titleEndings: [],
+      cardNotes: [],
+      blurbs: ['AI text'],
+    }),
+  } as Response);
+
+  await fetchAiBlurbBundle(request);
+
+  expect(fetchSpy).toHaveBeenCalledWith(
+    '/api/blurbs',
+    expect.objectContaining({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+  );
+});

--- a/fredagskoll-frontend/src/aiBlurbs.ts
+++ b/fredagskoll-frontend/src/aiBlurbs.ts
@@ -7,6 +7,7 @@ export type AiBlurbRequest = {
   contentPack: ContentPack;
   kind: 'celebration' | 'themeDay' | 'ordinary';
   mood: Mood;
+  requestMode?: 'default' | 'reroll';
   date: string;
   dateLabel: string;
   dayType: string;
@@ -33,20 +34,11 @@ export type AiBlurbBundle = {
   model?: string | null;
 };
 
-function getAiBlurbsEndpoint(): string {
-  const configuredBaseUrl = process.env.REACT_APP_AI_API_BASE_URL?.trim();
-  if (!configuredBaseUrl) {
-    return '/api/blurbs';
-  }
-
-  return `${configuredBaseUrl.replace(/\/+$/, '')}/api/blurbs`;
-}
-
 export async function fetchAiBlurbBundle(
   request: AiBlurbRequest,
   signal?: AbortSignal
 ): Promise<AiBlurbBundle | null> {
-  const response = await fetch(getAiBlurbsEndpoint(), {
+  const response = await fetch('/api/blurbs', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/fredagskoll-frontend/src/appText.ts
+++ b/fredagskoll-frontend/src/appText.ts
@@ -95,6 +95,9 @@ export const appText: Record<
     worldNationalDaysBadge: string;
     worldNationalDaysMore: (count: number) => string;
     buildInfoLabel: string;
+    releaseNotesLabel: string;
+    releaseNotesTitle: string;
+    releaseNotesOpen: string;
     imageCredits: string;
     themeDaySource: string;
     previousDay: string;
@@ -160,6 +163,9 @@ export const appText: Record<
     worldNationalDaysBadge: 'Också idag',
     worldNationalDaysMore: (count: number) => `Och ${count} till.`,
     buildInfoLabel: 'Bygge',
+    releaseNotesLabel: 'Nytt i versionen',
+    releaseNotesTitle: 'Det här har ändrats i appen',
+    releaseNotesOpen: 'Visa alla ändringar',
     imageCredits: 'Bildkällor',
     themeDaySource: 'Temadagar inspirerade av temadagar.se',
     previousDay: 'Föregående dag',
@@ -229,6 +235,9 @@ export const appText: Record<
     worldNationalDaysBadge: 'Also today',
     worldNationalDaysMore: (count: number) => `And ${count} more.`,
     buildInfoLabel: 'Build',
+    releaseNotesLabel: 'New in this version',
+    releaseNotesTitle: 'What changed in the app',
+    releaseNotesOpen: 'Show all changes',
     imageCredits: 'Image credits',
     themeDaySource: 'Theme days inspired by temadagar.se',
     previousDay: 'Previous day',
@@ -298,6 +307,9 @@ export const appText: Record<
     worldNationalDaysBadge: 'Também hoje',
     worldNationalDaysMore: (count: number) => `E mais ${count}.`,
     buildInfoLabel: 'Build',
+    releaseNotesLabel: 'Novo nesta versão',
+    releaseNotesTitle: 'O que mudou no app',
+    releaseNotesOpen: 'Mostrar todas as mudanças',
     imageCredits: 'Créditos das imagens',
     themeDaySource: 'Datas temáticas inspiradas em temadagar.se',
     previousDay: 'Dia anterior',

--- a/fredagskoll-frontend/src/buildInfo.generated.ts
+++ b/fredagskoll-frontend/src/buildInfo.generated.ts
@@ -1,6 +1,6 @@
 export const buildInfo = {
-  "version": "0.1.12",
-  "gitSha": "c017bc7",
-  "buildRef": "c017bc7",
-  "builtAt": "2026-03-15T09:36:01.693Z"
+  "version": "0.1.15",
+  "gitSha": "8e45449",
+  "buildRef": "8e45449",
+  "builtAt": "2026-03-15T10:21:06.046Z"
 } as const;

--- a/fredagskoll-frontend/src/releaseNotes.ts
+++ b/fredagskoll-frontend/src/releaseNotes.ts
@@ -1,0 +1,209 @@
+import { Locale } from './locale';
+
+export type ReleaseNote = {
+  version: string;
+  shortSummary: Record<Locale, string>;
+  summary: Record<Locale, string>;
+};
+
+export const releaseNotes: ReleaseNote[] = [
+  {
+    version: '0.1.15',
+    shortSummary: {
+      sv: 'AI-varianter fylls nu lugnare och bara på riktig reroll.',
+      en: 'AI variants now grow more slowly and only on real rerolls.',
+      'pt-BR': 'As variantes de IA agora crescem mais devagar e só em rerolls de verdade.',
+    },
+    summary: {
+      sv: 'Appen bygger inte längre upp flera AI-varianter automatiskt bara för att någon laddar samma dag flera gånger. Först sparas en variant, och fler skapas bara när du faktiskt trycker på Ny ursäkt. Det minskar onödiga AI-anrop och ger bättre kontroll över kvoten.',
+      en: 'The app no longer builds multiple AI variants automatically just because the same day is loaded several times. It stores one variant first, and more are created only when you actually press New excuse. That cuts unnecessary AI calls and gives better quota control.',
+      'pt-BR': 'O app não cria mais várias variantes de IA automaticamente só porque o mesmo dia foi carregado várias vezes. Primeiro ele salva uma variante, e novas só são criadas quando você realmente clica em Nova desculpa. Isso reduz chamadas desnecessárias à IA e dá mais controle sobre a cota.',
+    },
+  },
+  {
+    version: '0.1.14',
+    shortSummary: {
+      sv: 'Footer med versionsnytt och tydligare Bildkällor.',
+      en: 'Footer release note and clearer Image credits.',
+      'pt-BR': 'Resumo da versão no rodapé e Créditos das imagens mais claro.',
+    },
+    summary: {
+      sv: 'Footern visar nu vad den senaste versionen faktiskt innehåller, och du kan öppna en historik över tidigare uppdateringar. Bildkällor ser också tydligare klickbar ut.',
+      en: 'The footer now explains what the latest version actually contains, and you can open a history of earlier updates. Image credits also looks more clearly clickable.',
+      'pt-BR': 'O rodapé agora explica o que a versão atual realmente traz e permite abrir um histórico de atualizações anteriores. Créditos das imagens também parece mais claramente clicável.',
+    },
+  },
+  {
+    version: '0.1.13',
+    shortSummary: {
+      sv: 'Gamla separata AI-funktionen är borttagen.',
+      en: 'The old separate AI function is gone.',
+      'pt-BR': 'A antiga função separada de IA foi removida.',
+    },
+    summary: {
+      sv: 'Appen använder nu bara sin egen /api-väg för AI-texten. Den gamla separata Azure-funktionen är bortstädad, och dokumentationen följer den nya lösningen.',
+      en: 'The app now uses only its own /api route for AI text. The old separate Azure function has been removed, and the docs now match the new setup.',
+      'pt-BR': 'O app agora usa apenas sua própria rota /api para o texto de IA. A antiga função separada no Azure foi removida e a documentação foi ajustada ao novo caminho.',
+    },
+  },
+  {
+    version: '0.1.12',
+    shortSummary: {
+      sv: 'AI-texten går nu via appens egen Azure-väg.',
+      en: 'AI text now uses the app’s own Azure route.',
+      'pt-BR': 'O texto de IA agora usa a própria rota Azure do app.',
+    },
+    summary: {
+      sv: 'AI-texten går nu via appens egen Azure-väg i stället för en separat publik funktionsadress. Det gör lösningen enklare och minskar beroendet av en fristående backendadress.',
+      en: 'AI text now goes through the app’s own Azure route instead of a separate public function URL. That makes the setup simpler and reduces the app’s dependence on a standalone backend address.',
+      'pt-BR': 'O texto de IA agora passa pela própria rota Azure do app em vez de uma URL pública separada. Isso deixa a solução mais simples e reduz a dependência de um endereço externo de backend.',
+    },
+  },
+  {
+    version: '0.1.11',
+    shortSummary: {
+      sv: 'Gammal AI-text försvinner direkt vid datum- eller tonbyte.',
+      en: 'Old AI text disappears right away on date or tone change.',
+      'pt-BR': 'O texto antigo da IA some na hora ao trocar data ou tom.',
+    },
+    summary: {
+      sv: 'När datum eller ton ändras försvinner gammal AI-text direkt. Appen väntar nu på rätt svar i stället för att visa text som hör till ett annat läge.',
+      en: 'When the date or tone changes, old AI text disappears right away. The app now waits for the correct response instead of showing text from the wrong state.',
+      'pt-BR': 'Quando a data ou o tom mudam, o texto antigo da IA some na hora. O app agora espera a resposta certa em vez de mostrar texto do estado anterior.',
+    },
+  },
+  {
+    version: '0.1.10',
+    shortSummary: {
+      sv: 'Ingen tillfällig reservtext innan rätt blurb finns.',
+      en: 'No temporary fallback text before the right blurb is ready.',
+      'pt-BR': 'Sem texto provisório antes da blurb certa ficar pronta.',
+    },
+    summary: {
+      sv: 'Appen visar inte längre en tillfällig reservtext som sedan byts ut när AI-svaret kommer. Den väntar i stället på rätt dagsblurb, så innehållet känns lugnare och mindre ryckigt.',
+      en: 'The app no longer shows a temporary fallback text and then swaps it out when the AI response arrives. It now waits for the right daily blurb, which makes the content feel calmer and less jumpy.',
+      'pt-BR': 'O app não mostra mais um texto provisório de reserva para depois trocá-lo quando a IA responde. Agora ele espera pela blurb certa do dia, o que deixa a experiência mais calma e menos brusca.',
+    },
+  },
+  {
+    version: '0.1.9',
+    shortSummary: {
+      sv: 'Svenska landsnamn och tydligare helgdagsförklaring.',
+      en: 'Swedish country names and a clearer holiday explanation.',
+      'pt-BR': 'Nomes de países em sueco e explicação mais clara sobre feriado.',
+    },
+    summary: {
+      sv: 'Nationaldagar visas nu med svenska landsnamn i den svenska versionen. Texten förtydligar också att det inte handlar om en officiell svensk helgdag.',
+      en: 'National days now show Swedish country names in the Swedish version. The text also makes clear that this is not an official Swedish holiday.',
+      'pt-BR': 'As datas nacionais agora mostram nomes de países em sueco na versão sueca. O texto também deixa claro que isso não é um feriado oficial sueco.',
+    },
+  },
+  {
+    version: '0.1.8',
+    shortSummary: {
+      sv: 'Ton märks nu också i färg, form och rörelse.',
+      en: 'Tone now also shows up in color, shape, and motion.',
+      'pt-BR': 'O tom agora também aparece em cor, forma e movimento.',
+    },
+    summary: {
+      sv: 'Den valda tonen märks nu bättre genom färg, form och rörelse i appen, inte bara i texten. Kort, paneler och detaljer har blivit tydligare kopplade till den stämning du valt.',
+      en: 'The selected tone now shows up more clearly through color, shape, and motion in the app, not only in the text. Cards, panels, and details now match the mood more clearly.',
+      'pt-BR': 'O tom escolhido agora aparece melhor por cor, forma e movimento no app, e não só no texto. Cartões, painéis e detalhes agora combinam melhor com o clima escolhido.',
+    },
+  },
+  {
+    version: '0.1.7',
+    shortSummary: {
+      sv: 'Du kan nu välja ton i appen.',
+      en: 'You can now choose the app’s tone.',
+      'pt-BR': 'Agora você pode escolher o tom do app.',
+    },
+    summary: {
+      sv: 'Du kan nu välja ton för appens texter. Det påverkar både AI-texter och fler av appens egna formuleringar, så upplevelsen känns mer sammanhållen.',
+      en: 'You can now choose a tone for the app’s writing. It affects both AI text and more of the app’s own copy, so the experience feels more consistent.',
+      'pt-BR': 'Agora você pode escolher o tom dos textos do app. Isso afeta tanto o texto da IA quanto mais partes do próprio conteúdo do app, deixando a experiência mais coesa.',
+    },
+  },
+  {
+    version: '0.1.6',
+    shortSummary: {
+      sv: 'Frontend kopplades till AI-tjänsten.',
+      en: 'The frontend was connected to the AI service.',
+      'pt-BR': 'O frontend foi ligado ao serviço de IA.',
+    },
+    summary: {
+      sv: 'Frontend kopplades till AI-tjänsten så att datum kan få smartare blurbar. Det här var steget där AI började påverka det som faktiskt visas i appen.',
+      en: 'The frontend was connected to the AI service so dates can get smarter blurbs. This was the step where AI started affecting what the app actually shows.',
+      'pt-BR': 'O frontend foi ligado ao serviço de IA para que as datas possam receber blurbs mais inteligentes. Foi aqui que a IA começou a afetar o que realmente aparece no app.',
+    },
+  },
+  {
+    version: '0.1.5',
+    shortSummary: {
+      sv: 'AI-flödet blev stabilare i drift.',
+      en: 'The AI flow became more stable in production.',
+      'pt-BR': 'O fluxo de IA ficou mais estável em produção.',
+    },
+    summary: {
+      sv: 'AI-flödet fick en live-fix så att startproblem och konstiga tecken inte ställer till det. Kort sagt: mindre strul, färre märkliga tecken och bättre stabilitet.',
+      en: 'The AI flow got a live fix so startup problems and odd text encoding do not get in the way. In short: less breakage, fewer weird characters, and better stability.',
+      'pt-BR': 'O fluxo de IA recebeu uma correção em produção para que problemas na inicialização e textos estranhos não atrapalhem. Em resumo: menos falhas, menos caracteres esquisitos e mais estabilidade.',
+    },
+  },
+  {
+    version: '0.1.4',
+    shortSummary: {
+      sv: 'AI-blurbar började använda cache.',
+      en: 'AI blurbs started using cache.',
+      'pt-BR': 'As blurbs de IA passaram a usar cache.',
+    },
+    summary: {
+      sv: 'AI-blurbar med cache började användas, så appen kan återanvända bra texter i stället för att skriva om allt varje gång. Det gjorde svaren snabbare och öppnade för en växande blurbbank.',
+      en: 'Cached AI blurbs started being used, so the app can reuse good text instead of writing everything again every time. That made responses faster and opened the door to a growing blurb library.',
+      'pt-BR': 'Blurbs de IA com cache começaram a ser usados, para o app reaproveitar bons textos em vez de gerar tudo de novo toda vez. Isso deixou as respostas mais rápidas e abriu caminho para uma biblioteca maior de blurbs.',
+    },
+  },
+  {
+    version: '0.1.3',
+    shortSummary: {
+      sv: 'Första versionen av AI-blurbar lades till.',
+      en: 'The first version of AI blurbs was added.',
+      'pt-BR': 'A primeira versão das blurbs de IA foi adicionada.',
+    },
+    summary: {
+      sv: 'Första versionen av AI-blurbar lades till som ett nytt lager ovanpå de vanliga texterna. Appen kunde därmed börja skriva friare dagsformuleringar i stället för att bara använda fasta texter.',
+      en: 'The first version of AI blurbs was added as a new layer on top of the regular text. The app could now start writing looser daily copy instead of relying only on fixed text.',
+      'pt-BR': 'A primeira versão das blurbs de IA foi adicionada como uma nova camada por cima dos textos normais. O app passou a poder escrever textos mais livres para o dia, em vez de depender só de frases fixas.',
+    },
+  },
+  {
+    version: '0.1.2',
+    shortSummary: {
+      sv: 'Public och team fick egna ikoner.',
+      en: 'Public and team got their own icons.',
+      'pt-BR': 'Public e team ganharam seus próprios ícones.',
+    },
+    summary: {
+      sv: 'Varje innehållspaket fick egna ikoner så att public och team känns tydligare åtskilda redan i webbläsaren. Det gjorde varianterna enklare att känna igen direkt.',
+      en: 'Each content pack got its own icons so public and team feel more clearly separated right in the browser. That made the two variants easier to recognize at a glance.',
+      'pt-BR': 'Cada pacote de conteúdo ganhou seus próprios ícones, para separar melhor as versões pública e de equipe já no navegador. Isso deixou as duas variantes mais fáceis de reconhecer de imediato.',
+    },
+  },
+  {
+    version: '0.1.1',
+    shortSummary: {
+      sv: 'Portugisiska nationaldagsrutan blev tydligare.',
+      en: 'The Portuguese national-day panel became clearer.',
+      'pt-BR': 'O painel de datas nacionais em português ficou mais claro.',
+    },
+    summary: {
+      sv: 'Nationaldagsrutan förbättrades för portugisiska och blev tydligare även där. Det var en mindre ändring, men viktig för att språkvyn skulle kännas mindre halvfärdig.',
+      en: 'The national-day panel was improved for Portuguese and became clearer there too. It was a smaller change, but important for making that language view feel less half-finished.',
+      'pt-BR': 'O painel de datas nacionais foi melhorado em português e ficou mais claro também. Foi uma mudança menor, mas importante para a visão em português parecer menos incompleta.',
+    },
+  },
+];
+
+export function getReleaseNote(version: string): ReleaseNote | null {
+  return releaseNotes.find((note) => note.version === version) ?? null;
+}


### PR DESCRIPTION
## What changed
This PR finishes the cleanup after moving the app to managed Static Web Apps APIs and also tightens how AI variants are generated.

The app no longer tries to grow a three-variant AI pool automatically just because the same date gets loaded repeatedly. It now stores one AI variant by default, only asks for extra variants on an explicit `Ny urs�kt` reroll, and keeps a real generation cooldown per request key. That reduces unnecessary Azure OpenAI calls while preserving the ability to get variety when a user actually asks for it.

The frontend footer also now includes a human-readable release note for the current version plus a simple changelog dialog with backfilled version entries. The latest entry is short in the footer and more detailed in the dialog so the app can explain what changed without dumping technical noise into the UI.

Finally, this removes the last app-side dependency on the old separate Function App host, updates the detailed architecture doc to match the managed API setup, and aligns tests with the current request flow.

## Why this was needed
The old cache behavior had a bad quota profile. With six moods and three auto-filled variants per key, the system could keep creating new AI variants far more aggressively than the actual user experience justified. The app also had no good user-facing way to explain recent changes, even though we have been shipping a lot of visible behavior updates.

## User impact
Users still get AI text and rerolls, but AI generation is calmer and tied to real intent. The footer now shows a plain-language note for the current version, the changelog history is easy to open, and `Bildk�llor` reads clearly as something clickable.

## Validation
I ran:
- `npm test -- --watch=false aiBlurbs.test.ts App.test.tsx`
- `npm run build`
- `node -e "require('./api/blurbs'); require('./api/shared/cache'); require('./api/shared/blurbSchema'); console.log('api-ok')"`

I also deleted the old Azure Function App resource `vkmf-blurbs-api` earlier in this cleanup flow after verifying the managed API path was serving requests and cache behavior correctly.
