### PR TITLE
[codex] update docs for reroll cache flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,10 @@ What it does:
 - receives a structured date context from the frontend
 - computes a deterministic request hash
 - checks a hot cache row in Azure Table Storage first
-- rotates between multiple cached AI bundles for the same request when available
-- refreshes stale bundles older than 15 minutes one slot at a time
+- auto-generates one AI bundle for a new request key and serves cache after that
+- can store up to 3 variants for the same request key, but only creates extra variants on explicit reroll
+- enforces a real generation cooldown per request key before Azure OpenAI is called again
+- rotates between cached variants when more than one already exists
 - stores generated bundles in a separate bundle library table for reuse and tracking
 - returns multiple options for:
   - `blurbs`
@@ -159,7 +161,7 @@ Current table layout:
 
 - `blurbcache`
   - one hot row per request key
-  - stores request metadata, `useCount`, `lastUsedAt`, `lastBundleId`, and `bundleIdsJson`
+  - stores request metadata, `useCount`, `lastUsedAt`, `lastGeneratedAt`, `lastBundleId`, and `bundleIdsJson`
 - `blurblibrary`
   - one row per generated bundle
   - stores `bundleId`, `requestHash`, `generatedAt`, `model`, `useCount`, `lastUsedAt`,

--- a/docs/application-flow.md
+++ b/docs/application-flow.md
@@ -35,25 +35,29 @@ flowchart TD
     M --> M6[fallback blurbs and theme-day support text]
     M --> M7[seasonal, upcoming, and national-day context]
 
-    M --> N[POST to same-origin managed API /api/blurbs]
+    M --> M8[requestMode default or reroll]
+    M8 --> N[POST to same-origin managed API /api/blurbs]
     N --> O[normalizeRequestBody validates and trims request]
     O --> P[buildRequestHash creates request key]
     P --> Q[Lookup hot row in blurbcache]
 
-    Q --> R{Fresh bundle variants available for this exact request key?}
+    Q --> Q1[Check lastGeneratedAt cooldown for this request key]
+    Q1 --> R{Fresh bundle variants available for this exact request key?}
     R -->|Yes| S[Select a cached variant]
     S --> S1[Avoid immediately repeating the last-served variant]
     S1 --> S2[Update useCount and lastUsedAt]
     S2 --> T[Return source cache]
 
-    R -->|No| U[Build Azure OpenAI prompt]
+    R -->|No| R1{Cooldown allows generation?}
+    R1 -->|No| R2[Return 204 or fallback to existing local copy]
+    R1 -->|Yes| U[Build Azure OpenAI prompt]
     U --> U1[Prompt includes tone, fallback text, theme-day context, and page context]
     U1 --> V[Call Azure OpenAI deployment]
     V --> W{Generation succeeded?}
 
     W -->|Yes| X[Write bundle row to blurblibrary]
     X --> Y[Update hot row in blurbcache]
-    Y --> Y1[Store request metadata, mood, bundleIdsJson, useCount, lastBundleId]
+    Y --> Y1[Store request metadata, mood, bundleIdsJson, useCount, lastBundleId, lastGeneratedAt]
     Y1 --> Z[Return source azure-openai]
 
     W -->|No| AA[Return no AI bundle]
@@ -61,6 +65,7 @@ flowchart TD
     T --> AB[Frontend accepts bundle only if it matches current request key]
     Z --> AB
     AA --> AC[Frontend falls back to local static copy]
+    R2 --> AC
 
     AB --> AD[Render final visible text]
     AC --> AD
@@ -69,7 +74,7 @@ flowchart TD
     AE --> AE1[headline]
     AE --> AE2[subheader / theme-day title ending]
     AE --> AE3[main blurb]
-    AE --> AE4[reroll button when multiple blurbs exist]
+    AE --> AE4[reroll button can ask for another AI variant]
     AE --> AE5[mood-specific visual styling and motion]
 
     N -. request pending .-> AF[While waiting, frontend hides AI-driven text and shows loading copy]


### PR DESCRIPTION
## What changed
This PR updates the README and the detailed Mermaid flow diagram so they match the current AI request logic.

The docs had fallen behind the code. They still described the AI path as if the app freely rotated and refilled multiple cached variants on its own. That is no longer true. The code now creates one automatic AI variant first, only adds extra variants on explicit reroll, and uses a real generation cooldown per request key before Azure OpenAI can be called again.

## Why this was needed
The documentation was describing a more aggressive cache and generation strategy than the app actually uses now. That makes future maintenance harder and gives the wrong mental model to anyone trying to understand quota behavior or debug the AI flow.

## User impact
No runtime behavior changes. This is documentation-only.

## Validation
I compared the docs directly against the current implementation in `api/blurbs/index.js` and updated both the README prose and `docs/application-flow.md` to reflect the real flow.
