### PR TITLE
[codex] Curate theme day priorities with AI review

### DIFF
--- a/docs/theme-day-priority-suggestions.json
+++ b/docs/theme-day-priority-suggestions.json
@@ -1,0 +1,9307 @@
+{
+  "generatedAt": "2026-03-15T11:33:54.167Z",
+  "model": "gpt-4.1-mini",
+  "itemCount": 216,
+  "suggestions": [
+    {
+      "date": "06-21",
+      "candidateCount": 9,
+      "themeDays": [
+        "Giraffens dag",
+        "Internationella ALS-dagen",
+        "Internationella selfiedagen",
+        "Internationella yogadagen",
+        "Långsamhetens dag",
+        "Musikens dag",
+        "Sommarsolståndet",
+        "Världshumanistdagen",
+        "Världsmusikdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Sommarsolståndet",
+        "backupThemeDays": [
+          "Musikens dag",
+          "Internationella yogadagen"
+        ],
+        "reasoning": "Sommarsolståndet is a culturally significant and seasonally relevant event in Sweden, marking the longest day of the year and the start of summer celebrations. It has strong cultural resonance and widespread recognition. Musikens dag is a meaningful and socially engaging backup, celebrating music which is universally appreciated. Internationella yogadagen offers a socially valuable and health-oriented theme with growing popularity.",
+        "scores": [
+          {
+            "themeDay": "Sommarsolståndet",
+            "audienceAppeal": 9,
+            "culturalRelevance": 10,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Highly relevant seasonally and culturally in Sweden, widely celebrated."
+          },
+          {
+            "themeDay": "Musikens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Music is universally appealing and socially engaging."
+          },
+          {
+            "themeDay": "Internationella yogadagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 6,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Growing interest in yoga and wellness, socially valuable."
+          },
+          {
+            "themeDay": "Giraffens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 3,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Fun but niche animal day with limited cultural relevance."
+          },
+          {
+            "themeDay": "Internationella ALS-dagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 8,
+            "novelty": 4,
+            "notes": "Important health awareness day but less widely recognized."
+          },
+          {
+            "themeDay": "Internationella selfiedagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Popular social media theme but less socially valuable."
+          },
+          {
+            "themeDay": "Långsamhetens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Promotes mindfulness and slowing down, socially valuable."
+          },
+          {
+            "themeDay": "Världshumanistdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "Relevant to humanist communities but niche."
+          },
+          {
+            "themeDay": "Världsmusikdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Celebrates global music diversity, socially engaging."
+          }
+        ]
+      }
+    },
+    {
+      "date": "03-21",
+      "candidateCount": 8,
+      "themeDays": [
+        "Internationella dagen för Nowruz",
+        "Internationella dockteaterdagen",
+        "Internationella Downs syndrom-dagen",
+        "Internationella färgdagen",
+        "Internationella skogsdagen",
+        "Internationella Tiramisudagen",
+        "Rocka sockorna-dagen",
+        "Världspoesidagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Rocka sockorna-dagen",
+        "backupThemeDays": [
+          "Internationella Downs syndrom-dagen",
+          "Världspoesidagen"
+        ],
+        "reasoning": "Rocka sockorna-dagen is widely recognized and celebrated in Sweden as a fun and meaningful day promoting awareness and acceptance of people with Down syndrome. It has strong cultural relevance and social value in Sweden, making it the best primary theme day. Internationella Downs syndrom-dagen is closely related and important for awareness, serving as a strong backup. Världspoesidagen is also well-known and culturally enriching, providing a creative and accessible alternative.",
+        "scores": [
+          {
+            "themeDay": "Rocka sockorna-dagen",
+            "audienceAppeal": 9,
+            "culturalRelevance": 10,
+            "socialValue": 10,
+            "novelty": 7,
+            "notes": "Strongly recognized in Sweden, promotes inclusion and awareness, fun and engaging."
+          },
+          {
+            "themeDay": "Internationella Downs syndrom-dagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Important awareness day closely related to Rocka sockorna-dagen, high social value."
+          },
+          {
+            "themeDay": "Världspoesidagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 7,
+            "novelty": 7,
+            "notes": "Culturally enriching and accessible, promotes literature and creativity."
+          },
+          {
+            "themeDay": "Internationella dagen för Nowruz",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 7,
+            "notes": "Recognized by some communities, but less widespread in Sweden."
+          },
+          {
+            "themeDay": "Internationella skogsdagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Relevant for environmental awareness but less distinctive on this date."
+          },
+          {
+            "themeDay": "Internationella dockteaterdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "Niche cultural observance, less broad appeal."
+          },
+          {
+            "themeDay": "Internationella färgdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 4,
+            "novelty": 6,
+            "notes": "Less known and less socially impactful."
+          },
+          {
+            "themeDay": "Internationella Tiramisudagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 3,
+            "socialValue": 3,
+            "novelty": 5,
+            "notes": "Fun but niche and less relevant culturally."
+          }
+        ]
+      }
+    },
+    {
+      "date": "09-18",
+      "candidateCount": 8,
+      "themeDays": [
+        "4H-dagen",
+        "E-bokens dag",
+        "Internationella Batman-dagen",
+        "Internationella röd panda-dagen",
+        "Software freedom day",
+        "Strandens dag",
+        "Surkålens dag",
+        "Worldwide spin in public day"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Strandens dag",
+        "backupThemeDays": [
+          "Surkålens dag",
+          "4H-dagen"
+        ],
+        "reasoning": "Strandens dag (Beach Day) is seasonally relevant in Sweden during September as many Swedes enjoy outdoor activities and nature. It has broad appeal across age groups and promotes social and environmental engagement. Surkålens dag (Sauerkraut Day) is culturally relevant due to traditional Swedish cuisine, and 4H-dagen connects to youth and community development, making them good backups. Other days like International Batman Day or Software Freedom Day have niche appeal or less cultural resonance in Sweden.",
+        "scores": [
+          {
+            "themeDay": "Strandens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Seasonally relevant, promotes outdoor activity and nature appreciation."
+          },
+          {
+            "themeDay": "Surkålens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 8,
+            "socialValue": 5,
+            "novelty": 4,
+            "notes": "Strong cultural food tradition, less broad appeal."
+          },
+          {
+            "themeDay": "4H-dagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 4,
+            "notes": "Youth and community focus, meaningful but smaller audience."
+          },
+          {
+            "themeDay": "E-bokens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 4,
+            "notes": "Relevant to readers but niche."
+          },
+          {
+            "themeDay": "Internationella Batman-dagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 3,
+            "socialValue": 2,
+            "novelty": 6,
+            "notes": "Pop culture niche, less cultural relevance."
+          },
+          {
+            "themeDay": "Internationella röd panda-dagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 6,
+            "novelty": 6,
+            "notes": "Animal awareness day, moderate appeal."
+          },
+          {
+            "themeDay": "Software freedom day",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "Tech niche, socially valuable but limited audience."
+          },
+          {
+            "themeDay": "Worldwide spin in public day",
+            "audienceAppeal": 3,
+            "culturalRelevance": 2,
+            "socialValue": 3,
+            "novelty": 7,
+            "notes": "Novelty day, low cultural relevance."
+          }
+        ]
+      }
+    },
+    {
+      "date": "09-23",
+      "candidateCount": 8,
+      "themeDays": [
+        "BeActiveDay - Rörelsens dag",
+        "Bisexualitetens dag",
+        "D-vitaminens dag",
+        "Hjälpmedelsdagen",
+        "Höstdagjämningen",
+        "Internationella dagen för teckenspråken i världen",
+        "Trappans dag",
+        "Upphandlarens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Höstdagjämningen",
+        "backupThemeDays": [
+          "BeActiveDay - Rörelsens dag",
+          "Internationella dagen för teckenspråken i världen"
+        ],
+        "reasoning": "Höstdagjämningen (Autumn Equinox) is a widely recognized seasonal event marking the change of seasons, which resonates broadly with the general public in Sweden. It has natural cultural significance and is relevant to many people's daily lives as it signals the transition into autumn. BeActiveDay promotes health and movement, which is socially valuable and relevant, especially as the weather cools. The International Day of Sign Languages raises awareness about an important social issue and inclusivity, making it a meaningful backup choice.",
+        "scores": [
+          {
+            "themeDay": "Höstdagjämningen",
+            "audienceAppeal": 9,
+            "culturalRelevance": 9,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Strong seasonal and cultural relevance, broadly recognized and meaningful."
+          },
+          {
+            "themeDay": "BeActiveDay - Rörelsens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 6,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Encourages healthy lifestyle, socially valuable and seasonally relevant."
+          },
+          {
+            "themeDay": "Internationella dagen för teckenspråken i världen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Important for social inclusion and awareness, meaningful but less widely known."
+          }
+        ]
+      }
+    },
+    {
+      "date": "09-29",
+      "candidateCount": 8,
+      "themeDays": [
+        "Alla soffpotatisars dag",
+        "Återvinningens dag",
+        "Internationella hjärtdagen",
+        "Internationella matsvinnsdagen",
+        "Internationella pussdagen",
+        "Kaffets dag",
+        "Resandefolkets dag",
+        "Skolmjölkens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella hjärtdagen",
+        "backupThemeDays": [
+          "Kaffets dag",
+          "Internationella matsvinnsdagen"
+        ],
+        "reasoning": "Internationella hjärtdagen (World Heart Day) is highly relevant for public health awareness, widely recognized internationally, and socially valuable in promoting heart health. Kaffets dag is culturally significant in Sweden given the strong coffee culture, making it a relatable and fun backup. Internationella matsvinnsdagen addresses an important environmental and social issue, aligning with growing sustainability concerns in Sweden.",
+        "scores": [
+          {
+            "themeDay": "Internationella hjärtdagen",
+            "audienceAppeal": 9,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Strong health message, widely recognized, socially impactful."
+          },
+          {
+            "themeDay": "Kaffets dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 6,
+            "novelty": 6,
+            "notes": "Popular cultural theme, fun and relatable for Swedes."
+          },
+          {
+            "themeDay": "Internationella matsvinnsdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Important sustainability theme, growing awareness in Sweden."
+          },
+          {
+            "themeDay": "Alla soffpotatisars dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Lighthearted but less socially impactful."
+          },
+          {
+            "themeDay": "Återvinningens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Relevant environmental theme but less prominent than matsvinnsdagen."
+          },
+          {
+            "themeDay": "Internationella pussdagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "Fun but less meaningful socially."
+          },
+          {
+            "themeDay": "Resandefolkets dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Important cultural recognition but niche audience."
+          },
+          {
+            "themeDay": "Skolmjölkens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 4,
+            "notes": "Niche theme with limited broad appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "10-15",
+      "candidateCount": 8,
+      "themeDays": [
+        "Alla chefers dag",
+        "Brösthälsodagen",
+        "Fetaostens dag",
+        "Internationella beröringsdagen",
+        "Internationella dagen för att tvätta händerna",
+        "Internationella landsbygdskvinnors dag",
+        "Metoo-dagen",
+        "Vita käppens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella dagen för att tvätta händerna",
+        "backupThemeDays": [
+          "Internationella landsbygdskvinnors dag",
+          "Vita käppens dag"
+        ],
+        "reasoning": "Internationella dagen för att tvätta händerna is highly relevant for public health awareness, especially in Sweden where hygiene and health are prioritized. It has broad social value and cultural relevance, encouraging a simple but impactful behavior. Internationella landsbygdskvinnors dag is a strong backup due to its focus on gender equality and rural development, important social issues in Sweden. Vita käppens dag raises awareness about blindness and visual impairment, which is socially valuable and recognized in Sweden.",
+        "scores": [
+          {
+            "themeDay": "Internationella dagen för att tvätta händerna",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "Strong public health relevance, widely applicable and socially important."
+          },
+          {
+            "themeDay": "Internationella landsbygdskvinnors dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 7,
+            "notes": "Highlights rural women's issues, important for gender equality and social inclusion."
+          },
+          {
+            "themeDay": "Vita käppens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Raises awareness about blindness, socially valuable but less broadly recognized."
+          },
+          {
+            "themeDay": "Metoo-dagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Important social movement day but can be sensitive and less celebratory."
+          },
+          {
+            "themeDay": "Brösthälsodagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Health awareness day, but less prominent than handwashing day."
+          },
+          {
+            "themeDay": "Alla chefers dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 4,
+            "notes": "Niche professional focus, less broad appeal."
+          },
+          {
+            "themeDay": "Fetaostens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 7,
+            "notes": "Fun food day but less culturally relevant in Sweden."
+          },
+          {
+            "themeDay": "Internationella beröringsdagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Promotes human connection, but less widely recognized."
+          }
+        ]
+      }
+    },
+    {
+      "date": "06-06",
+      "candidateCount": 7,
+      "themeDays": [
+        "Dagen-D",
+        "Den stora lupinbekämpardagen",
+        "Färskpotatisens dag",
+        "Fruktens dag",
+        "Motorhistoriska dagen",
+        "Sillens dag",
+        "Sveriges nationaldag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Sveriges nationaldag",
+        "backupThemeDays": [
+          "Sillens dag",
+          "Färskpotatisens dag"
+        ],
+        "reasoning": "Sveriges nationaldag is the most significant and widely recognized theme day on June 6th in Sweden, celebrating national identity and unity. It has high cultural relevance and social value, making it the best choice for a general audience. Sillens dag and Färskpotatisens dag are popular food-related days that are seasonally relevant and socially enjoyable, serving as good backups.",
+        "scores": [
+          {
+            "themeDay": "Sveriges nationaldag",
+            "audienceAppeal": 10,
+            "culturalRelevance": 10,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Most important national celebration, widely recognized and celebrated across Sweden."
+          },
+          {
+            "themeDay": "Sillens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 6,
+            "novelty": 6,
+            "notes": "Popular traditional food day, seasonally relevant and socially enjoyable."
+          },
+          {
+            "themeDay": "Färskpotatisens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 6,
+            "socialValue": 6,
+            "novelty": 6,
+            "notes": "Seasonal food celebration, culturally relevant in Sweden during early summer."
+          },
+          {
+            "themeDay": "Dagen-D",
+            "audienceAppeal": 4,
+            "culturalRelevance": 3,
+            "socialValue": 3,
+            "novelty": 7,
+            "notes": "Less known theme day, niche interest."
+          },
+          {
+            "themeDay": "Den stora lupinbekämpardagen",
+            "audienceAppeal": 3,
+            "culturalRelevance": 4,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Niche environmental theme, less broad appeal."
+          },
+          {
+            "themeDay": "Fruktens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 5,
+            "notes": "General fruit day, moderate appeal but less specific to Sweden."
+          },
+          {
+            "themeDay": "Motorhistoriska dagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 6,
+            "notes": "Appeals to motor history enthusiasts, niche interest."
+          }
+        ]
+      }
+    },
+    {
+      "date": "10-04",
+      "candidateCount": 7,
+      "themeDays": [
+        "Alla djurhelgons dag",
+        "Djurens dag",
+        "Internationella dagen för boende- och bebyggelsefrågor",
+        "Internationella Tacodagen",
+        "Internationella vodkadagen",
+        "Kanelbullens dag",
+        "Skolfotografiets dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Kanelbullens dag",
+        "backupThemeDays": [
+          "Djurens dag",
+          "Alla djurhelgons dag"
+        ],
+        "reasoning": "Kanelbullens dag is widely celebrated in Sweden with strong cultural relevance and social value, as it involves a beloved traditional pastry and social fika gatherings. It has broad audience appeal and is seasonally relevant in early October. Djurens dag and Alla djurhelgons dag are meaningful backups due to their focus on animals and remembrance, respectively, but have slightly less widespread celebration.",
+        "scores": [
+          {
+            "themeDay": "Kanelbullens dag",
+            "audienceAppeal": 9,
+            "culturalRelevance": 10,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Highly popular Swedish tradition with strong cultural roots and social engagement."
+          },
+          {
+            "themeDay": "Djurens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Important for animal welfare awareness, moderately celebrated."
+          },
+          {
+            "themeDay": "Alla djurhelgons dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 4,
+            "notes": "Religious and cultural significance related to animals, less widely observed."
+          },
+          {
+            "themeDay": "Internationella Tacodagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Fun food day but less culturally rooted in Sweden."
+          },
+          {
+            "themeDay": "Internationella vodkadagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 4,
+            "novelty": 6,
+            "notes": "Vodka is known but day is niche and less socially valuable."
+          },
+          {
+            "themeDay": "Internationella dagen för boende- och bebyggelsefrågor",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 3,
+            "notes": "Important social issue but less engaging for general audience."
+          },
+          {
+            "themeDay": "Skolfotografiets dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 5,
+            "notes": "Nostalgic but niche and less widely recognized."
+          }
+        ]
+      }
+    },
+    {
+      "date": "10-16",
+      "candidateCount": 7,
+      "themeDays": [
+        "Alla broars dag",
+        "Alla kan rädda liv-dagen",
+        "Lexikonens dag",
+        "Polyneuropatidagen",
+        "Steve Jobs Day",
+        "Världshungerdagen",
+        "Världslivsmedelsdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Världshungerdagen",
+        "backupThemeDays": [
+          "Världslivsmedelsdagen",
+          "Alla kan rädda liv-dagen"
+        ],
+        "reasoning": "Världshungerdagen (World Hunger Day) is a globally recognized day with strong social value and relevance, especially in Sweden where social welfare and global humanitarian issues are significant. It raises awareness about hunger and food insecurity, which resonates well with a broad audience. Världslivsmedelsdagen (World Food Day) is closely related and also socially valuable, making it a strong backup. Alla kan rädda liv-dagen (Everyone Can Save Lives Day) has important social value and awareness but is less widely known, making it a good secondary option.",
+        "scores": [
+          {
+            "themeDay": "Världshungerdagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "Highly relevant and socially important; well-known internationally and aligns with Swedish values."
+          },
+          {
+            "themeDay": "Världslivsmedelsdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Closely related to hunger issues; promotes sustainable food systems, relevant in Sweden."
+          },
+          {
+            "themeDay": "Alla kan rädda liv-dagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Important for public health awareness but less widely recognized."
+          },
+          {
+            "themeDay": "Alla broars dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 5,
+            "notes": "Niche theme, less broad appeal."
+          },
+          {
+            "themeDay": "Lexikonens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 4,
+            "novelty": 5,
+            "notes": "Educational but less socially impactful."
+          },
+          {
+            "themeDay": "Polyneuropatidagen",
+            "audienceAppeal": 3,
+            "culturalRelevance": 4,
+            "socialValue": 5,
+            "novelty": 4,
+            "notes": "Very niche medical observance."
+          },
+          {
+            "themeDay": "Steve Jobs Day",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 3,
+            "novelty": 6,
+            "notes": "Corporate/tech focused, less socially relevant in Sweden."
+          }
+        ]
+      }
+    },
+    {
+      "date": "03-12",
+      "candidateCount": 6,
+      "themeDays": [
+        "Alla korvars dag",
+        "Kronprinsessans namnsdag",
+        "Nationella syntolkningsdagen",
+        "Republiken Jamtland",
+        "Världsdagen mot cybercensur",
+        "Världsglaukomdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Kronprinsessans namnsdag",
+        "backupThemeDays": [
+          "Världsdagen mot cybercensur",
+          "Nationella syntolkningsdagen"
+        ],
+        "reasoning": "Kronprinsessans namnsdag is culturally significant and widely recognized in Sweden, reflecting national identity and tradition. It has broad appeal and social value as it connects to the Swedish royal family, which many Swedes follow. Världsdagen mot cybercensur is globally relevant and socially important, raising awareness about digital rights. Nationella syntolkningsdagen supports accessibility, which is socially valuable and meaningful. Other options are either niche or less widely recognized.",
+        "scores": [
+          {
+            "themeDay": "Kronprinsessans namnsdag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 7,
+            "novelty": 4,
+            "notes": "Strong cultural and national relevance; widely recognized in Sweden."
+          },
+          {
+            "themeDay": "Världsdagen mot cybercensur",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Important global issue with social impact; less traditional but meaningful."
+          },
+          {
+            "themeDay": "Nationella syntolkningsdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Focuses on accessibility and inclusion; socially valuable but less known."
+          },
+          {
+            "themeDay": "Alla korvars dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 3,
+            "socialValue": 3,
+            "novelty": 7,
+            "notes": "Niche food-related day; fun but less significant."
+          },
+          {
+            "themeDay": "Republiken Jamtland",
+            "audienceAppeal": 3,
+            "culturalRelevance": 4,
+            "socialValue": 2,
+            "novelty": 6,
+            "notes": "Regional and humorous; limited broader appeal."
+          },
+          {
+            "themeDay": "Världsglaukomdagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 4,
+            "notes": "Health awareness day; important but less prominent."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-08",
+      "candidateCount": 6,
+      "themeDays": [
+        "Hantverksölets dag",
+        "Internationella dagen för rättvis handel",
+        "Internationella vikingadagen",
+        "Röda Korsets dag",
+        "Tunnbrödets dag",
+        "Tunnbrödsrullens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Röda Korsets dag",
+        "backupThemeDays": [
+          "Internationella dagen för rättvis handel",
+          "Internationella vikingadagen"
+        ],
+        "reasoning": "Röda Korsets dag is widely recognized and socially valuable in Sweden, highlighting humanitarian efforts and community support. It has strong cultural relevance and appeals broadly across demographics. The International Day for Fair Trade is also socially important and relevant, promoting ethical consumption. International Viking Day has cultural and historical significance in Sweden, appealing to national heritage interests.",
+        "scores": [
+          {
+            "themeDay": "Röda Korsets dag",
+            "audienceAppeal": 9,
+            "culturalRelevance": 8,
+            "socialValue": 10,
+            "novelty": 5,
+            "notes": "Strong humanitarian and social impact, well-known and respected day in Sweden."
+          },
+          {
+            "themeDay": "Internationella dagen för rättvis handel",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Important for social justice and ethical consumerism, growing awareness."
+          },
+          {
+            "themeDay": "Internationella vikingadagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 8,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Culturally significant, taps into Swedish heritage and tourism interest."
+          },
+          {
+            "themeDay": "Hantverksölets dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 4,
+            "novelty": 6,
+            "notes": "Niche interest in craft beer, less broad appeal."
+          },
+          {
+            "themeDay": "Tunnbrödets dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 4,
+            "novelty": 5,
+            "notes": "Traditional food day, moderate cultural relevance."
+          },
+          {
+            "themeDay": "Tunnbrödsrullens dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 3,
+            "novelty": 5,
+            "notes": "More niche food celebration, less widely recognized."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-12",
+      "candidateCount": 6,
+      "themeDays": [
+        "Automower®-dagen",
+        "Dagbokens dag",
+        "Gamla vänners dag",
+        "Internationella fibromyalgidagen",
+        "Massagens dag",
+        "ME/CFS-dagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Dagbokens dag",
+        "backupThemeDays": [
+          "Gamla vänners dag",
+          "Massagens dag"
+        ],
+        "reasoning": "Dagbokens dag (Diary Day) has broad cultural appeal in Sweden, encouraging personal reflection and writing, which resonates well with a general audience. It is socially valuable as it promotes mental health and self-expression. Gamla vänners dag (Old Friends Day) is a strong backup due to its emphasis on social connections, which is universally meaningful. Massagens dag (Massage Day) is another good backup as it promotes well-being and relaxation, relevant in any season. The other days are more niche or health-specific, which may limit general audience engagement.",
+        "scores": [
+          {
+            "themeDay": "Dagbokens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 8,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Encourages writing and reflection, culturally meaningful and broadly appealing."
+          },
+          {
+            "themeDay": "Gamla vänners dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 4,
+            "notes": "Focuses on friendship and social bonds, universally relatable."
+          },
+          {
+            "themeDay": "Massagens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Promotes health and relaxation, seasonally relevant."
+          },
+          {
+            "themeDay": "Internationella fibromyalgidagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 3,
+            "notes": "Important health awareness day but more niche."
+          },
+          {
+            "themeDay": "ME/CFS-dagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 3,
+            "notes": "Health awareness day with limited general appeal."
+          },
+          {
+            "themeDay": "Automower®-dagen",
+            "audienceAppeal": 3,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 4,
+            "notes": "Corporate branded day, less broad appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-20",
+      "candidateCount": 6,
+      "themeDays": [
+        "Förskolans dag",
+        "Internationella bi-dagen",
+        "Internationella tillgänglighetsdagen",
+        "Kulturskolans dag",
+        "Vyshyvanka-dagen",
+        "Williams syndromdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Förskolans dag",
+        "backupThemeDays": [
+          "Internationella bi-dagen",
+          "Kulturskolans dag"
+        ],
+        "reasoning": "Förskolans dag is highly relevant and meaningful in Sweden, emphasizing early childhood education which is a significant societal focus. It has broad appeal to families and educators, making it socially valuable and culturally relevant. Internationella bi-dagen is also important due to environmental awareness and biodiversity concerns, while Kulturskolans dag highlights cultural education, which is widely appreciated.",
+        "scores": [
+          {
+            "themeDay": "Förskolans dag",
+            "audienceAppeal": 9,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong societal relevance and broad appeal in Sweden, focusing on early childhood education."
+          },
+          {
+            "themeDay": "Internationella bi-dagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 8,
+            "novelty": 7,
+            "notes": "Important for environmental awareness and biodiversity, increasingly recognized."
+          },
+          {
+            "themeDay": "Internationella tillgänglighetsdagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Valuable for promoting accessibility but less widely recognized on this date."
+          },
+          {
+            "themeDay": "Kulturskolans dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Highlights cultural education, appreciated but less prominent than Förskolans dag."
+          },
+          {
+            "themeDay": "Vyshyvanka-dagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 3,
+            "socialValue": 4,
+            "novelty": 5,
+            "notes": "Specific cultural observance with limited recognition in Sweden."
+          },
+          {
+            "themeDay": "Williams syndromdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "Important for awareness but niche and less broadly recognized."
+          }
+        ]
+      }
+    },
+    {
+      "date": "06-05",
+      "candidateCount": 6,
+      "themeDays": [
+        "Alla vänners dag",
+        "Ångans dag",
+        "Barfotadagen",
+        "Int. dagen för kampen mot illegalt, orapporterat och oreglerat fiske",
+        "Internationella brädspelsdagen",
+        "Världsmiljödagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Världsmiljödagen",
+        "backupThemeDays": [
+          "Alla vänners dag",
+          "Internationella brädspelsdagen"
+        ],
+        "reasoning": "Världsmiljödagen (World Environment Day) is globally recognized and highly relevant in Sweden, a country known for its environmental awareness and sustainability efforts. It has strong cultural relevance and social value, encouraging public engagement with environmental issues. Alla vänners dag (All Friends' Day) is a warm, socially meaningful day promoting friendship, suitable as a backup. Internationella brädspelsdagen (International Board Games Day) offers a fun, inclusive social activity, making it a good secondary option.",
+        "scores": [
+          {
+            "themeDay": "Världsmiljödagen",
+            "audienceAppeal": 9,
+            "culturalRelevance": 10,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Highly relevant and widely recognized; aligns with Swedish values on environment."
+          },
+          {
+            "themeDay": "Alla vänners dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Promotes social connection and friendship, broadly appealing."
+          },
+          {
+            "themeDay": "Internationella brädspelsdagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 7,
+            "novelty": 7,
+            "notes": "Fun and inclusive, but less culturally significant than environment or friendship."
+          },
+          {
+            "themeDay": "Ångans dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 5,
+            "notes": "Niche interest in steam technology/history, limited broad appeal."
+          },
+          {
+            "themeDay": "Barfotadagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 4,
+            "novelty": 6,
+            "notes": "Seasonally relevant but less socially impactful."
+          },
+          {
+            "themeDay": "Int. dagen för kampen mot illegalt, orapporterat och oreglerat fiske",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 4,
+            "notes": "Important issue but quite specialized and less known to general public."
+          }
+        ]
+      }
+    },
+    {
+      "date": "08-21",
+      "candidateCount": 6,
+      "themeDays": [
+        "Alla pensionärers dag",
+        "Durspelets dag",
+        "Groggens dag",
+        "Hemlösa djurs dag",
+        "Internationella geocachingdagen",
+        "Världsentreprenörsdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Alla pensionärers dag",
+        "backupThemeDays": [
+          "Hemlösa djurs dag",
+          "Världsentreprenörsdagen"
+        ],
+        "reasoning": "Alla pensionärers dag is the most socially meaningful and broadly relevant theme day for a Swedish audience, honoring the elderly population which is significant in Sweden. Hemlösa djurs dag is a compassionate and socially valuable day focusing on homeless animals, which resonates well with animal welfare concerns. Världsentreprenörsdagen highlights entrepreneurship, important for economic and social development, but less universally engaging than the first two.",
+        "scores": [
+          {
+            "themeDay": "Alla pensionärers dag",
+            "audienceAppeal": 9,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Strong cultural and social relevance, widely relatable and meaningful."
+          },
+          {
+            "themeDay": "Hemlösa djurs dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Good social value and appeals to animal lovers, slightly less universal."
+          },
+          {
+            "themeDay": "Världsentreprenörsdagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Relevant for business and innovation communities, moderate general appeal."
+          },
+          {
+            "themeDay": "Internationella geocachingdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Niche outdoor activity, limited broad appeal."
+          },
+          {
+            "themeDay": "Groggens dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 6,
+            "notes": "Fun but less socially valuable, more niche."
+          },
+          {
+            "themeDay": "Durspelets dag",
+            "audienceAppeal": 3,
+            "culturalRelevance": 3,
+            "socialValue": 2,
+            "novelty": 5,
+            "notes": "Very niche, low general appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "10-01",
+      "candidateCount": 6,
+      "themeDays": [
+        "Intelligensens dag",
+        "Internationella dagen för äldre",
+        "Internationella kaffedagen",
+        "Reflexens dag",
+        "Svenska flaskans dag",
+        "Vegetariska världsdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella dagen för äldre",
+        "backupThemeDays": [
+          "Vegetariska världsdagen",
+          "Reflexens dag"
+        ],
+        "reasoning": "Internationella dagen för äldre is highly relevant socially and culturally in Sweden, emphasizing respect and awareness for the elderly population, which resonates well with a broad audience. Vegetariska världsdagen is seasonally relevant and aligns with growing interest in vegetarianism and sustainability. Reflexens dag promotes safety, which is socially valuable especially during darker months. Other options like Intelligensens dag and Svenska flaskans dag are less widely recognized or impactful.",
+        "scores": [
+          {
+            "themeDay": "Internationella dagen för äldre",
+            "audienceAppeal": 9,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "Strong social and cultural relevance, widely recognized internationally and locally."
+          },
+          {
+            "themeDay": "Vegetariska världsdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 8,
+            "novelty": 7,
+            "notes": "Growing interest in vegetarianism and sustainability makes this relevant and engaging."
+          },
+          {
+            "themeDay": "Reflexens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Important for public safety, especially in Sweden's darker seasons."
+          },
+          {
+            "themeDay": "Internationella kaffedagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "Popular culturally but less socially impactful."
+          },
+          {
+            "themeDay": "Intelligensens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Niche and less recognized theme."
+          },
+          {
+            "themeDay": "Svenska flaskans dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 3,
+            "novelty": 5,
+            "notes": "Limited appeal and recognition."
+          }
+        ]
+      }
+    },
+    {
+      "date": "10-27",
+      "candidateCount": 6,
+      "themeDays": [
+        "Alla svärmödrars dag",
+        "Arbetsterapins dag",
+        "Internationella nalledagen",
+        "Internationella religionsfrihetsdagen",
+        "Internationella skolbiblioteksdagen",
+        "Världsdagen för audiovisuellt kulturarv"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella religionsfrihetsdagen",
+        "backupThemeDays": [
+          "Internationella skolbiblioteksdagen",
+          "Världsdagen för audiovisuellt kulturarv"
+        ],
+        "reasoning": "Internationella religionsfrihetsdagen is the most meaningful and socially relevant theme day for a broad Swedish audience, highlighting an important human rights issue that resonates with Sweden's values of tolerance and diversity. Internationella skolbiblioteksdagen and Världsdagen för audiovisuellt kulturarv are strong backups due to their cultural and educational significance, appealing to a wide audience and promoting awareness of heritage and learning resources.",
+        "scores": [
+          {
+            "themeDay": "Internationella religionsfrihetsdagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong social and cultural relevance; promotes important values of freedom and tolerance."
+          },
+          {
+            "themeDay": "Internationella skolbiblioteksdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Educational focus with broad appeal, supporting literacy and learning."
+          },
+          {
+            "themeDay": "Världsdagen för audiovisuellt kulturarv",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Highlights cultural heritage preservation, relevant but somewhat niche."
+          },
+          {
+            "themeDay": "Alla svärmödrars dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 4,
+            "notes": "Lighthearted but less socially impactful or widely recognized."
+          },
+          {
+            "themeDay": "Arbetsterapins dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 3,
+            "notes": "Important for health professionals but niche for general public."
+          },
+          {
+            "themeDay": "Internationella nalledagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 3,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Fun and novel but less meaningful for broad audience."
+          }
+        ]
+      }
+    },
+    {
+      "date": "11-11",
+      "candidateCount": 6,
+      "themeDays": [
+        "Alla singlars dag",
+        "Användbarhetsdagen",
+        "Chokladens dag",
+        "Hållbarhetsdagen för barn & unga",
+        "Nordiska klimatdagen",
+        "World Quality Day"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Alla singlars dag",
+        "backupThemeDays": [
+          "Chokladens dag",
+          "Nordiska klimatdagen"
+        ],
+        "reasoning": "Alla singlars dag is a socially engaging and widely relatable theme day in Sweden, appealing to a broad audience with its focus on single individuals, which resonates culturally and socially. Chokladens dag is a fun and popular theme that has broad appeal and is seasonally relevant as it falls in November, a time when people enjoy comfort foods. Nordiska klimatdagen has strong cultural and social value given the increasing focus on climate issues in the Nordic region, making it a meaningful backup.",
+        "scores": [
+          {
+            "themeDay": "Alla singlars dag",
+            "audienceAppeal": 9,
+            "culturalRelevance": 8,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Widely recognized and socially engaging, appeals to many singles and those interested in social themes."
+          },
+          {
+            "themeDay": "Chokladens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 5,
+            "notes": "Popular and fun, good seasonal relevance, appeals to food lovers."
+          },
+          {
+            "themeDay": "Nordiska klimatdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Strong cultural and social relevance due to climate focus, important for Nordic audiences."
+          },
+          {
+            "themeDay": "Användbarhetsdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 5,
+            "notes": "More niche, less broad appeal."
+          },
+          {
+            "themeDay": "Hållbarhetsdagen för barn & unga",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Good social value but more targeted to specific groups."
+          },
+          {
+            "themeDay": "World Quality Day",
+            "audienceAppeal": 4,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 4,
+            "notes": "Low general appeal, more corporate/technical."
+          }
+        ]
+      }
+    },
+    {
+      "date": "02-02",
+      "candidateCount": 5,
+      "themeDays": [
+        "Internationella tvillingdagen",
+        "Internationella våtmarksdagen",
+        "Kyndelsmässodagen",
+        "Murmeldjursdagen",
+        "Smoothiens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella våtmarksdagen",
+        "backupThemeDays": [
+          "Kyndelsmässodagen",
+          "Internationella tvillingdagen"
+        ],
+        "reasoning": "Internationella våtmarksdagen (World Wetlands Day) is globally recognized and aligns well with environmental awareness, which is socially valuable and culturally relevant in Sweden given its strong environmental focus. Kyndelsmässodagen is a traditional Swedish day with cultural significance, and Internationella tvillingdagen has broad appeal but is less socially impactful. The other days are more niche or novelty-focused.",
+        "scores": [
+          {
+            "themeDay": "Internationella våtmarksdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong environmental relevance and global recognition; aligns with Swedish values on nature conservation."
+          },
+          {
+            "themeDay": "Kyndelsmässodagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Traditional Swedish day with cultural and historical significance, less known internationally."
+          },
+          {
+            "themeDay": "Internationella tvillingdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "Fun and relatable but less socially impactful or culturally deep."
+          },
+          {
+            "themeDay": "Murmeldjursdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "More of a novelty day, limited cultural or social value in Sweden."
+          },
+          {
+            "themeDay": "Smoothiens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 3,
+            "socialValue": 4,
+            "novelty": 6,
+            "notes": "Light and fun but low cultural and social relevance."
+          }
+        ]
+      }
+    },
+    {
+      "date": "03-20",
+      "candidateCount": 5,
+      "themeDays": [
+        "Internationella glädjedagen",
+        "Internationella munhälsodagen",
+        "Vårdagjämningen",
+        "Världsberättardagen",
+        "World Salad Day"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Vårdagjämningen",
+        "backupThemeDays": [
+          "Internationella glädjedagen",
+          "Världsberättardagen"
+        ],
+        "reasoning": "Vårdagjämningen (the Spring Equinox) is highly relevant and culturally significant in Sweden as it marks the transition to spring, a season celebrated widely with various traditions. It has strong seasonal relevance and broad audience appeal. Internationella glädjedagen (International Day of Happiness) is a positive, socially valuable theme with wide recognition, making it a good backup. Världsberättardagen (World Storytelling Day) also has cultural value and is engaging, suitable as a secondary option. Other candidates like Internationella munhälsodagen and World Salad Day have lower cultural relevance and appeal in the Swedish context.",
+        "scores": [
+          {
+            "themeDay": "Vårdagjämningen",
+            "audienceAppeal": 9,
+            "culturalRelevance": 9,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Strong seasonal and cultural significance in Sweden; widely recognized as the start of spring."
+          },
+          {
+            "themeDay": "Internationella glädjedagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 7,
+            "notes": "Positive, uplifting theme with broad appeal and social value."
+          },
+          {
+            "themeDay": "Världsberättardagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Culturally enriching and engaging, promotes storytelling traditions."
+          },
+          {
+            "themeDay": "Internationella munhälsodagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "Health-related but less culturally resonant or seasonally relevant."
+          },
+          {
+            "themeDay": "World Salad Day",
+            "audienceAppeal": 4,
+            "culturalRelevance": 3,
+            "socialValue": 4,
+            "novelty": 6,
+            "notes": "Niche food-related day with limited cultural relevance in Sweden."
+          }
+        ]
+      }
+    },
+    {
+      "date": "04-24",
+      "candidateCount": 5,
+      "themeDays": [
+        "Alla barns dag",
+        "Den lokala handelns dag",
+        "Försöksdjurens dag",
+        "Int. dagen för multilateralism och diplomati för fred",
+        "Internationella veterinärdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Alla barns dag",
+        "backupThemeDays": [
+          "Internationella veterinärdagen",
+          "Int. dagen för multilateralism och diplomati för fred"
+        ],
+        "reasoning": "Alla barns dag is highly relevant and socially valuable in Sweden, emphasizing children's rights and well-being, which resonates broadly with families and society. It has strong cultural significance and is widely recognized. Internationella veterinärdagen is a meaningful backup due to Sweden's strong animal welfare culture. The international day for multilateralism and diplomacy is important but less directly engaging for a general audience.",
+        "scores": [
+          {
+            "themeDay": "Alla barns dag",
+            "audienceAppeal": 9,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "Widely recognized and socially important, appeals to families and general public."
+          },
+          {
+            "themeDay": "Internationella veterinärdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Relevant due to animal welfare focus, respected profession, but less broad appeal."
+          },
+          {
+            "themeDay": "Int. dagen för multilateralism och diplomati för fred",
+            "audienceAppeal": 6,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Important global theme but less immediate connection for general public."
+          },
+          {
+            "themeDay": "Den lokala handelns dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 4,
+            "notes": "Supports local economy but less emotionally engaging."
+          },
+          {
+            "themeDay": "Försöksdjurens dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "Important ethical topic but niche and potentially sensitive."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-02",
+      "candidateCount": 5,
+      "themeDays": [
+        "Harry potter-dagen",
+        "Internationella barfotalöpningsdagen",
+        "Nässlans dag",
+        "Världsdagen för tonfisk",
+        "Världsskrattdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Världsskrattdagen",
+        "backupThemeDays": [
+          "Harry potter-dagen",
+          "Internationella barfotalöpningsdagen"
+        ],
+        "reasoning": "Världsskrattdagen (World Laughter Day) is a positive, universally appealing theme that promotes well-being and social connection, making it highly relevant and engaging for a broad Swedish audience. Harry Potter Day has cultural recognition but is more niche, while International Barefoot Running Day is less widely known but still interesting. The other days are either too niche or less impactful socially.",
+        "scores": [
+          {
+            "themeDay": "Världsskrattdagen",
+            "audienceAppeal": 9,
+            "culturalRelevance": 7,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Universally positive and promotes social well-being; broadly appealing."
+          },
+          {
+            "themeDay": "Harry potter-dagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Popular cultural reference with a dedicated fan base but more niche."
+          },
+          {
+            "themeDay": "Internationella barfotalöpningsdagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 7,
+            "notes": "Interesting niche sport day, less known but promotes health and nature."
+          },
+          {
+            "themeDay": "Nässlans dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 5,
+            "notes": "Very niche, related to a specific plant, limited broad appeal."
+          },
+          {
+            "themeDay": "Världsdagen för tonfisk",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 4,
+            "novelty": 5,
+            "notes": "Environmental and food-related, but less directly relevant to general public."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-05",
+      "candidateCount": 5,
+      "themeDays": [
+        "Internationella barnmorskedagen",
+        "Internationella handhygiendagen",
+        "Internationella kebabdagen",
+        "Internationella Ragdolldagen",
+        "Kristi himmelsfärdsafton"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Kristi himmelsfärdsafton",
+        "backupThemeDays": [
+          "Internationella barnmorskedagen",
+          "Internationella handhygiendagen"
+        ],
+        "reasoning": "Kristi himmelsfärdsafton is a widely recognized and culturally significant day in Sweden, marking Ascension Day Eve, often associated with public holidays and traditional activities. It has strong cultural relevance and social value, making it the most meaningful choice for a general Swedish audience. Internationella barnmorskedagen and Internationella handhygiendagen are socially valuable and relevant but less culturally prominent. The other options are either niche or less recognized.",
+        "scores": [
+          {
+            "themeDay": "Kristi himmelsfärdsafton",
+            "audienceAppeal": 9,
+            "culturalRelevance": 10,
+            "socialValue": 8,
+            "novelty": 4,
+            "notes": "Strong cultural and social significance, widely observed in Sweden."
+          },
+          {
+            "themeDay": "Internationella barnmorskedagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 6,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Important for healthcare awareness, moderate recognition."
+          },
+          {
+            "themeDay": "Internationella handhygiendagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 9,
+            "novelty": 4,
+            "notes": "High social value for health, but less culturally prominent."
+          },
+          {
+            "themeDay": "Internationella kebabdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 3,
+            "socialValue": 3,
+            "novelty": 6,
+            "notes": "Fun and novel but niche and less socially impactful."
+          },
+          {
+            "themeDay": "Internationella Ragdolldagen",
+            "audienceAppeal": 3,
+            "culturalRelevance": 2,
+            "socialValue": 2,
+            "novelty": 5,
+            "notes": "Very niche, low cultural and social relevance."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-06",
+      "candidateCount": 5,
+      "themeDays": [
+        "Dragspelets dag",
+        "Folknykterhetens dag",
+        "Första metardagen",
+        "Hembakatdagen",
+        "Regnbågsfamiljers dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Regnbågsfamiljers dag",
+        "backupThemeDays": [
+          "Folknykterhetens dag",
+          "Hembakatdagen"
+        ],
+        "reasoning": "Regnbågsfamiljers dag (Rainbow Families Day) is socially meaningful and culturally relevant in Sweden, reflecting inclusivity and diversity, which resonates well with a broad audience. It promotes awareness and acceptance of diverse family structures, aligning with contemporary social values. Folknykterhetens dag (Sobriety Day) has historical and social importance, promoting health and well-being. Hembakatdagen (Home Baking Day) is seasonally relevant and fun, appealing to a wide audience with a positive, engaging theme.",
+        "scores": [
+          {
+            "themeDay": "Regnbågsfamiljers dag",
+            "audienceAppeal": 9,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 7,
+            "notes": "Strong social message, widely relevant, promotes inclusivity."
+          },
+          {
+            "themeDay": "Folknykterhetens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Important social health theme, recognized but less engaging."
+          },
+          {
+            "themeDay": "Hembakatdagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 7,
+            "notes": "Fun and seasonally relevant, appeals to family and hobbyists."
+          },
+          {
+            "themeDay": "Dragspelets dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 6,
+            "notes": "Niche musical interest, less broad appeal."
+          },
+          {
+            "themeDay": "Första metardagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "Seasonal outdoor activity, moderate appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-11",
+      "candidateCount": 5,
+      "themeDays": [
+        "Chokladbollens dag",
+        "Fritidshemmens dag",
+        "Internationella strokedagen",
+        "Nämndemännens dag",
+        "Skolidrottsföreningens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella strokedagen",
+        "backupThemeDays": [
+          "Chokladbollens dag",
+          "Fritidshemmens dag"
+        ],
+        "reasoning": "Internationella strokedagen is the most socially valuable and culturally relevant theme day among the candidates, raising awareness about stroke prevention and health, which is important for the general public. Chokladbollens dag is a popular and fun Swedish food-related day with broad appeal, making it a good backup. Fritidshemmens dag is relevant to families and education but less widely recognized nationally. The other days are more niche or less impactful for a general audience.",
+        "scores": [
+          {
+            "themeDay": "Internationella strokedagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "High social importance and awareness; relevant to all ages."
+          },
+          {
+            "themeDay": "Chokladbollens dag",
+            "audienceAppeal": 9,
+            "culturalRelevance": 7,
+            "socialValue": 6,
+            "novelty": 7,
+            "notes": "Popular Swedish treat day; fun and widely recognized."
+          },
+          {
+            "themeDay": "Fritidshemmens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Relevant to families and schools but less broadly known."
+          },
+          {
+            "themeDay": "Nämndemännens dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 4,
+            "notes": "Niche legal/civic theme; lower general appeal."
+          },
+          {
+            "themeDay": "Skolidrottsföreningens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "School sports day; moderate appeal but less prominent."
+          }
+        ]
+      }
+    },
+    {
+      "date": "08-08",
+      "candidateCount": 5,
+      "themeDays": [
+        "Drottningens namnsdag",
+        "Internationella kattdagen",
+        "Internationella orgasmdagen",
+        "Kräftpremiären",
+        "Lyckans dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Kräftpremiären",
+        "backupThemeDays": [
+          "Internationella kattdagen",
+          "Drottningens namnsdag"
+        ],
+        "reasoning": "Kräftpremiären is a culturally significant and widely celebrated event in Sweden marking the start of the crayfish season, making it highly relevant and socially engaging for a broad Swedish audience. Internationella kattdagen is popular and fun, appealing to animal lovers, while Drottningens namnsdag has traditional cultural value. Internationella orgasmdagen is less mainstream and potentially sensitive, and Lyckans dag is less recognized.",
+        "scores": [
+          {
+            "themeDay": "Kräftpremiären",
+            "audienceAppeal": 9,
+            "culturalRelevance": 10,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong cultural tradition with widespread celebration in Sweden."
+          },
+          {
+            "themeDay": "Internationella kattdagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 7,
+            "notes": "Popular internationally and among pet owners, fun and lighthearted."
+          },
+          {
+            "themeDay": "Drottningens namnsdag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 5,
+            "novelty": 5,
+            "notes": "Traditional name day with moderate cultural relevance."
+          },
+          {
+            "themeDay": "Internationella orgasmdagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 3,
+            "socialValue": 4,
+            "novelty": 8,
+            "notes": "Niche and potentially sensitive, less suitable for broad public app."
+          },
+          {
+            "themeDay": "Lyckans dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "Less widely recognized or celebrated."
+          }
+        ]
+      }
+    },
+    {
+      "date": "09-04",
+      "candidateCount": 5,
+      "themeDays": [
+        "Dagen för ungas psykiska hälsa",
+        "Hemslöjdens dag",
+        "Ostronets dag",
+        "Scooterns dag",
+        "Skäggets dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Dagen för ungas psykiska hälsa",
+        "backupThemeDays": [
+          "Hemslöjdens dag",
+          "Skäggets dag"
+        ],
+        "reasoning": "Dagen för ungas psykiska hälsa is the most socially valuable and culturally relevant theme day, addressing an important and timely issue in Sweden. It has broad appeal across age groups and promotes awareness and support for youth mental health. Hemslöjdens dag is a good backup due to its cultural significance and promotion of traditional crafts, which resonates well in Sweden. Skäggets dag is a fun and recognizable day with moderate appeal but less social impact.",
+        "scores": [
+          {
+            "themeDay": "Dagen för ungas psykiska hälsa",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "Highly relevant social issue with broad appeal and strong cultural importance."
+          },
+          {
+            "themeDay": "Hemslöjdens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Celebrates Swedish handicrafts, culturally significant and seasonally relevant."
+          },
+          {
+            "themeDay": "Skäggets dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Fun and quirky, moderate social value, less impactful than primary choice."
+          },
+          {
+            "themeDay": "Ostronets dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 6,
+            "notes": "Niche food celebration, less broad appeal."
+          },
+          {
+            "themeDay": "Scooterns dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 3,
+            "socialValue": 3,
+            "novelty": 5,
+            "notes": "Low cultural relevance and social value."
+          }
+        ]
+      }
+    },
+    {
+      "date": "10-10",
+      "candidateCount": 5,
+      "themeDays": [
+        "Grötens dag",
+        "Internationella hemlöshetsdagen",
+        "Nordiska afasidagen",
+        "Tacksägelsedagen",
+        "Världsdagen för mental hälsa"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Världsdagen för mental hälsa",
+        "backupThemeDays": [
+          "Internationella hemlöshetsdagen",
+          "Grötens dag"
+        ],
+        "reasoning": "Världsdagen för mental hälsa is highly relevant and socially important in Sweden, where mental health awareness is a significant public concern. It has broad cultural relevance and social value, encouraging conversations and support around mental well-being. Internationella hemlöshetsdagen is also socially important but less widely recognized by the general public. Grötens dag is culturally familiar and seasonally relevant but less impactful socially compared to mental health awareness.",
+        "scores": [
+          {
+            "themeDay": "Världsdagen för mental hälsa",
+            "audienceAppeal": 9,
+            "culturalRelevance": 8,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "Strong social importance and broad recognition; aligns with public health priorities."
+          },
+          {
+            "themeDay": "Internationella hemlöshetsdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Important social issue but less mainstream awareness."
+          },
+          {
+            "themeDay": "Grötens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Culturally familiar and seasonally relevant but lower social impact."
+          },
+          {
+            "themeDay": "Nordiska afasidagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "More niche awareness, less broad appeal."
+          },
+          {
+            "themeDay": "Tacksägelsedagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "Less culturally prominent in Sweden, more US-centric tradition."
+          }
+        ]
+      }
+    },
+    {
+      "date": "10-31",
+      "candidateCount": 5,
+      "themeDays": [
+        "Grannens dag",
+        "Halloween",
+        "Magins dag",
+        "Världsdagen för städer",
+        "Världsspardagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Halloween",
+        "backupThemeDays": [
+          "Grannens dag",
+          "Världsdagen för städer"
+        ],
+        "reasoning": "Halloween is widely recognized and celebrated in Sweden, especially among younger audiences and families, making it the most socially engaging and seasonally relevant theme for October 31. Grannens dag (Neighbor's Day) is a meaningful social observance promoting community spirit, and Världsdagen för städer (World Cities Day) has cultural and social relevance but less public engagement. The other options are less known or less seasonally fitting.",
+        "scores": [
+          {
+            "themeDay": "Halloween",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "Popular seasonal event with broad appeal, especially among families and youth."
+          },
+          {
+            "themeDay": "Grannens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 6,
+            "socialValue": 8,
+            "novelty": 4,
+            "notes": "Promotes neighborly relations, socially valuable but less widely celebrated."
+          },
+          {
+            "themeDay": "Världsdagen för städer",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Important for urban awareness but less engaging for general public."
+          },
+          {
+            "themeDay": "Magins dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 3,
+            "socialValue": 3,
+            "novelty": 6,
+            "notes": "Niche theme with limited recognition."
+          },
+          {
+            "themeDay": "Världsspardagen",
+            "audienceAppeal": 3,
+            "culturalRelevance": 4,
+            "socialValue": 5,
+            "novelty": 3,
+            "notes": "Financial theme, less engaging for general audience."
+          }
+        ]
+      }
+    },
+    {
+      "date": "11-30",
+      "candidateCount": 5,
+      "themeDays": [
+        "Andersdagen",
+        "Giving Tuesday",
+        "Guldsmedens dag",
+        "Kåldolmens dag",
+        "Mustaschens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Andersdagen",
+        "backupThemeDays": [
+          "Giving Tuesday",
+          "Mustaschens dag"
+        ],
+        "reasoning": "Andersdagen is a traditional and culturally significant day in Sweden, marking the name day for Anders, which is widely recognized and celebrated. It has stable cultural relevance and is seasonally appropriate as it falls at the end of November. Giving Tuesday is a globally recognized day promoting charity and social good, which has growing relevance in Sweden and strong social value. Mustaschens dag, focusing on men's health awareness, is also socially valuable and recognized in Sweden, making it a good backup option. The other options are more niche or less widely celebrated.",
+        "scores": [
+          {
+            "themeDay": "Andersdagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "Strong traditional and cultural significance in Sweden, widely recognized name day."
+          },
+          {
+            "themeDay": "Giving Tuesday",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "International day promoting charity, growing in Sweden, high social value."
+          },
+          {
+            "themeDay": "Mustaschens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 6,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Men's health awareness day, socially important and recognized in Sweden."
+          },
+          {
+            "themeDay": "Guldsmedens dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 5,
+            "notes": "Niche day related to goldsmiths, limited general appeal."
+          },
+          {
+            "themeDay": "Kåldolmens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 6,
+            "notes": "Food-related day, somewhat fun but less culturally significant."
+          }
+        ]
+      }
+    },
+    {
+      "date": "02-06",
+      "candidateCount": 4,
+      "themeDays": [
+        "Int. dagen för nolltolerans mot kvinnlig könsstympning",
+        "Löpningens dag",
+        "Samernas nationaldag",
+        "Semikolonets dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Samernas nationaldag",
+        "backupThemeDays": [
+          "Int. dagen för nolltolerans mot kvinnlig könsstympning",
+          "Löpningens dag"
+        ],
+        "reasoning": "Samernas nationaldag is a significant cultural and historical day in Sweden, recognizing the indigenous Sami people and their heritage. It has strong cultural relevance and social value within Sweden, making it the most meaningful and recognizable theme day for a general Swedish audience on June 2nd. The international day against female genital mutilation is important but less directly connected to Swedish cultural identity. Löpningens dag is fun and socially engaging but less culturally significant than Samernas nationaldag. Semikolonets dag is niche and less relevant to a broad audience.",
+        "scores": [
+          {
+            "themeDay": "Samernas nationaldag",
+            "audienceAppeal": 9,
+            "culturalRelevance": 10,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Highly relevant culturally and socially in Sweden; widely recognized."
+          },
+          {
+            "themeDay": "Int. dagen för nolltolerans mot kvinnlig könsstympning",
+            "audienceAppeal": 7,
+            "culturalRelevance": 6,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Important social issue with global relevance but less tied to Swedish identity."
+          },
+          {
+            "themeDay": "Löpningens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 5,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Popular activity day, promotes health and social engagement."
+          },
+          {
+            "themeDay": "Semikolonets dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 3,
+            "socialValue": 3,
+            "novelty": 7,
+            "notes": "Niche interest, less broadly appealing."
+          }
+        ]
+      }
+    },
+    {
+      "date": "02-28",
+      "candidateCount": 4,
+      "themeDays": [
+        "Internationella musarmsdagen",
+        "Kalevaladagen",
+        "Kälkåkningens dag",
+        "Myggholkens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Kälkåkningens dag",
+        "backupThemeDays": [
+          "Internationella musarmsdagen",
+          "Myggholkens dag"
+        ],
+        "reasoning": "Kälkåkningens dag (Sledding Day) is seasonally relevant and culturally resonant in Sweden during late February, a time when winter activities are still popular. It appeals broadly across age groups and encourages outdoor physical activity, which is socially valuable. Internationella musarmsdagen (International Mouse Arm Day) has niche appeal related to ergonomics and office health, while Myggholkens dag (Mosquito Nest Day) is less known and less seasonally relevant at this time. Kalevaladagen is more Finnish cultural and less recognized in Sweden.",
+        "scores": [
+          {
+            "themeDay": "Kälkåkningens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Strong seasonal and cultural relevance; promotes outdoor activity."
+          },
+          {
+            "themeDay": "Internationella musarmsdagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Relevant for workplace health but niche and less engaging."
+          },
+          {
+            "themeDay": "Myggholkens dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 5,
+            "notes": "Low recognition and less relevant in late winter."
+          },
+          {
+            "themeDay": "Kalevaladagen",
+            "audienceAppeal": 3,
+            "culturalRelevance": 3,
+            "socialValue": 2,
+            "novelty": 4,
+            "notes": "More Finnish cultural significance; less known in Sweden."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-15",
+      "candidateCount": 4,
+      "themeDays": [
+        "Internationella familjedagen",
+        "Internationella whiskydagen",
+        "Kardemummabullens dag",
+        "Pingstafton"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella familjedagen",
+        "backupThemeDays": [
+          "Pingstafton",
+          "Kardemummabullens dag"
+        ],
+        "reasoning": "Internationella familjedagen is the most meaningful and socially relevant theme day for a broad Swedish audience, emphasizing family values and togetherness, which resonates well culturally. Pingstafton is a significant traditional holiday in Sweden with religious and cultural importance, making it a strong backup. Kardemummabullens dag is a fun and popular food-related day, appealing to Swedish culinary culture, suitable as a secondary option. Internationella whiskydagen is more niche and less socially impactful for the general public.",
+        "scores": [
+          {
+            "themeDay": "Internationella familjedagen",
+            "audienceAppeal": 9,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "Strong family focus, widely relatable and socially valuable."
+          },
+          {
+            "themeDay": "Pingstafton",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Traditional and culturally significant holiday, less universal but important."
+          },
+          {
+            "themeDay": "Kardemummabullens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 6,
+            "novelty": 7,
+            "notes": "Popular food day, fun and culturally relevant but less socially impactful."
+          },
+          {
+            "themeDay": "Internationella whiskydagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 7,
+            "notes": "Niche interest, less broadly relevant or socially valuable."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-28",
+      "candidateCount": 4,
+      "themeDays": [
+        "Den stressfria dagen",
+        "Internationella burgardagen",
+        "Internationella krama en musiker-dagen",
+        "Internationella onanidagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Den stressfria dagen",
+        "backupThemeDays": [
+          "Internationella burgardagen",
+          "Internationella krama en musiker-dagen"
+        ],
+        "reasoning": "Den stressfria dagen is the most meaningful and socially valuable theme for a broad Swedish audience, promoting mental health and well-being which is universally relevant. Internationella burgardagen is a fun and widely relatable food-themed day, appealing to many. Internationella krama en musiker-dagen is more niche but still positive and socially engaging. Internationella onanidagen is less suitable for a general public app due to its sensitive nature.",
+        "scores": [
+          {
+            "themeDay": "Den stressfria dagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Promotes well-being and stress relief, broadly relevant and positive."
+          },
+          {
+            "themeDay": "Internationella burgardagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Fun food day, widely relatable and enjoyable."
+          },
+          {
+            "themeDay": "Internationella krama en musiker-dagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 6,
+            "notes": "Niche but positive social interaction theme."
+          },
+          {
+            "themeDay": "Internationella onanidagen",
+            "audienceAppeal": 3,
+            "culturalRelevance": 4,
+            "socialValue": 2,
+            "novelty": 5,
+            "notes": "Sensitive topic, less suitable for general public app."
+          }
+        ]
+      }
+    },
+    {
+      "date": "06-18",
+      "candidateCount": 4,
+      "themeDays": [
+        "Internationella dagen för hållbar gastronomi",
+        "Internationella picknickdagen",
+        "Internationella sushidagen",
+        "Pionens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella dagen för hållbar gastronomi",
+        "backupThemeDays": [
+          "Internationella picknickdagen",
+          "Pionens dag"
+        ],
+        "reasoning": "Internationella dagen för hållbar gastronomi is the most meaningful and socially relevant theme day for a Swedish audience, emphasizing sustainability and food culture, which aligns well with current societal values. Internationella picknickdagen is a fun and seasonally relevant backup, suitable for summer activities in Sweden. Pionens dag is culturally recognizable as the peony is a popular flower in Sweden, making it a pleasant but less impactful choice. Internationella sushidagen is more niche and less culturally significant in Sweden compared to the others.",
+        "scores": [
+          {
+            "themeDay": "Internationella dagen för hållbar gastronomi",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong social and cultural relevance with sustainability focus."
+          },
+          {
+            "themeDay": "Internationella picknickdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 7,
+            "notes": "Seasonally appropriate and fun, good for summer engagement."
+          },
+          {
+            "themeDay": "Pionens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "Culturally recognizable flower day, pleasant but less impactful."
+          },
+          {
+            "themeDay": "Internationella sushidagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 4,
+            "novelty": 6,
+            "notes": "Niche food day, less culturally significant in Sweden."
+          }
+        ]
+      }
+    },
+    {
+      "date": "06-19",
+      "candidateCount": 4,
+      "themeDays": [
+        "Frisörens dag",
+        "Husbilens dag",
+        "Internationella flanerardagen",
+        "Naturismens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Frisörens dag",
+        "backupThemeDays": [
+          "Naturismens dag",
+          "Internationella flanerardagen"
+        ],
+        "reasoning": "Frisörens dag (Hairdresser's Day) is the most relatable and widely appreciated theme day among the options, as hairdressers play a significant role in everyday life and personal care, making it socially relevant and recognizable. Naturismens dag (Naturism Day) is more niche but still has cultural relevance and can be seasonally appropriate in summer. Internationella flanerardagen (International Flâneur Day) is interesting but less known and less socially impactful. Husbilens dag (Motorhome Day) is more niche and less universally engaging.",
+        "scores": [
+          {
+            "themeDay": "Frisörens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Widely relatable, socially relevant, and recognized profession."
+          },
+          {
+            "themeDay": "Naturismens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Niche but seasonally relevant and culturally recognized in Sweden."
+          },
+          {
+            "themeDay": "Internationella flanerardagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 6,
+            "notes": "Interesting concept but less known and less socially impactful."
+          },
+          {
+            "themeDay": "Husbilens dag",
+            "audienceAppeal": 3,
+            "culturalRelevance": 3,
+            "socialValue": 2,
+            "novelty": 4,
+            "notes": "Niche interest, less broad appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "07-18",
+      "candidateCount": 4,
+      "themeDays": [
+        "Baddräktsfria dagen",
+        "Internationella glassdagen",
+        "Internationella Nelson Mandela-dagen",
+        "Skånska flaggans dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella glassdagen",
+        "backupThemeDays": [
+          "Internationella Nelson Mandela-dagen",
+          "Skånska flaggans dag"
+        ],
+        "reasoning": "Internationella glassdagen (International Ice Cream Day) is a fun, widely relatable, and seasonally perfect theme for mid-July in Sweden, appealing broadly to families and individuals enjoying summer. It has high cultural relevance due to the popularity of ice cream in Swedish summer culture and offers positive social value as a lighthearted celebration. Nelson Mandela Day is globally significant and socially valuable but less seasonally relevant and less directly connected to Swedish culture. Skånska flaggans dag is regionally important but less known nationally, making it a good backup.",
+        "scores": [
+          {
+            "themeDay": "Internationella glassdagen",
+            "audienceAppeal": 9,
+            "culturalRelevance": 8,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Popular summer treat, widely celebrated, very seasonally relevant in Sweden."
+          },
+          {
+            "themeDay": "Internationella Nelson Mandela-dagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 6,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Globally important day with strong social value but less directly connected to Swedish culture."
+          },
+          {
+            "themeDay": "Skånska flaggans dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 4,
+            "notes": "Regionally significant but limited national recognition."
+          },
+          {
+            "themeDay": "Baddräktsfria dagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 3,
+            "socialValue": 3,
+            "novelty": 7,
+            "notes": "Niche and potentially controversial, less broadly appealing."
+          }
+        ]
+      }
+    },
+    {
+      "date": "07-30",
+      "candidateCount": 4,
+      "themeDays": [
+        "Internationella dagen mot trafficking av personer",
+        "Pocketbokens dag",
+        "Systemadministratörens dag",
+        "Världsbroderidagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella dagen mot trafficking av personer",
+        "backupThemeDays": [
+          "Pocketbokens dag",
+          "Världsbroderidagen"
+        ],
+        "reasoning": "The International Day Against Trafficking in Persons is the most socially significant and impactful theme day among the candidates. It raises awareness about a critical human rights issue relevant globally and in Sweden. Pocket Book Day is a culturally enriching and accessible backup, promoting reading and literature. World Embroidery Day is more niche but offers a creative and cultural angle as a secondary backup. System Administrator Day is less relevant to the general public and more niche.",
+        "scores": [
+          {
+            "themeDay": "Internationella dagen mot trafficking av personer",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "Highly important social issue with broad relevance and awareness potential."
+          },
+          {
+            "themeDay": "Pocketbokens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Popular cultural theme promoting reading, accessible to many."
+          },
+          {
+            "themeDay": "Systemadministratörens dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 3,
+            "novelty": 4,
+            "notes": "Niche technical audience, less general appeal."
+          },
+          {
+            "themeDay": "Världsbroderidagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Creative and cultural, but niche interest."
+          }
+        ]
+      }
+    },
+    {
+      "date": "08-07",
+      "candidateCount": 4,
+      "themeDays": [
+        "Ängens dag",
+        "Hattens dag",
+        "Örtens dag",
+        "Senapens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Ängens dag",
+        "backupThemeDays": [
+          "Örtens dag",
+          "Senapens dag"
+        ],
+        "reasoning": "Ängens dag (Meadow Day) is the most meaningful and culturally resonant theme for a Swedish audience, highlighting nature and biodiversity during summer, which aligns well with Swedish values and seasonal relevance. Örtens dag (Herb Day) and Senapens dag (Mustard Day) are good backups due to their culinary and cultural connections but are less broadly appealing than Ängens dag. Hattens dag (Hat Day) is less culturally significant and less seasonally relevant.",
+        "scores": [
+          {
+            "themeDay": "Ängens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Strong connection to nature and Swedish summer traditions, broadly appealing."
+          },
+          {
+            "themeDay": "Örtens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "Relevant to culinary and herbal traditions, moderately appealing."
+          },
+          {
+            "themeDay": "Senapens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 5,
+            "notes": "Culinary relevance but more niche."
+          },
+          {
+            "themeDay": "Hattens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 7,
+            "notes": "Less culturally significant, novelty is moderate but less meaningful."
+          }
+        ]
+      }
+    },
+    {
+      "date": "08-19",
+      "candidateCount": 4,
+      "themeDays": [
+        "Internationella dagen för humanitärt arbete",
+        "Internationella orangutangdagen",
+        "Luftfartsdagen",
+        "Världsfotografidagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella dagen för humanitärt arbete",
+        "backupThemeDays": [
+          "Världsfotografidagen",
+          "Internationella orangutangdagen"
+        ],
+        "reasoning": "Internationella dagen för humanitärt arbete has the highest social value and cultural relevance in Sweden, emphasizing global solidarity and humanitarian efforts, which resonate well with Swedish societal values. Världsfotografidagen is a strong backup due to its broad appeal and cultural relevance, celebrating photography as an art form. Internationella orangutangdagen is also meaningful but slightly less culturally relevant in Sweden compared to the humanitarian day and photography day. Luftfartsdagen scores lower in social value and cultural relevance for the general public.",
+        "scores": [
+          {
+            "themeDay": "Internationella dagen för humanitärt arbete",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "Strong social and cultural relevance, aligns with Swedish humanitarian values."
+          },
+          {
+            "themeDay": "Världsfotografidagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 7,
+            "novelty": 7,
+            "notes": "Popular cultural theme with broad appeal."
+          },
+          {
+            "themeDay": "Internationella orangutangdagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 6,
+            "socialValue": 8,
+            "novelty": 7,
+            "notes": "Good for environmental awareness but less central to Swedish culture."
+          },
+          {
+            "themeDay": "Luftfartsdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "More niche interest, less social impact."
+          }
+        ]
+      }
+    },
+    {
+      "date": "08-24",
+      "candidateCount": 4,
+      "themeDays": [
+        "Alla vägräckens dag",
+        "Årsdagen av Plutos degradering",
+        "Bartolomeusdagen",
+        "Tandvårdsrädslans dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Bartolomeusdagen",
+        "backupThemeDays": [
+          "Alla vägräckens dag",
+          "Tandvårdsrädslans dag"
+        ],
+        "reasoning": "Bartolomeusdagen is a traditional Swedish name day with cultural and historical significance, making it more recognizable and meaningful to a general Swedish audience. Alla vägräckens dag and Tandvårdsrädslans dag are more niche and less widely celebrated, while the anniversary of Pluto's downgrade is more scientific and less culturally relevant in Sweden.",
+        "scores": [
+          {
+            "themeDay": "Bartolomeusdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "Traditional name day with cultural recognition in Sweden."
+          },
+          {
+            "themeDay": "Alla vägräckens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 4,
+            "notes": "Focuses on road safety, socially useful but niche."
+          },
+          {
+            "themeDay": "Tandvårdsrädslans dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "Raises awareness about dental care fears, socially valuable but less known."
+          },
+          {
+            "themeDay": "Årsdagen av Plutos degradering",
+            "audienceAppeal": 3,
+            "culturalRelevance": 3,
+            "socialValue": 2,
+            "novelty": 6,
+            "notes": "Scientific event with limited cultural relevance in Sweden."
+          }
+        ]
+      }
+    },
+    {
+      "date": "08-26",
+      "candidateCount": 4,
+      "themeDays": [
+        "Alla hundars dag",
+        "Jämställdhetsdagen",
+        "Östersjödagen",
+        "Polisens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Jämställdhetsdagen",
+        "backupThemeDays": [
+          "Alla hundars dag",
+          "Polisens dag"
+        ],
+        "reasoning": "Jämställdhetsdagen (Equality Day) is the most socially meaningful and culturally relevant theme day in Sweden, reflecting ongoing societal values and discussions about gender equality. It has broad appeal and social value, making it a strong choice for public awareness and engagement. Alla hundars dag (All Dogs Day) is a fun and light-hearted backup with wide appeal, while Polisens dag (Police Day) has social value but narrower audience appeal. Östersjödagen (Baltic Sea Day) is less prominent and has lower general recognition.",
+        "scores": [
+          {
+            "themeDay": "Jämställdhetsdagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Strong societal importance and broad cultural relevance in Sweden."
+          },
+          {
+            "themeDay": "Alla hundars dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 6,
+            "socialValue": 6,
+            "novelty": 7,
+            "notes": "Popular and fun, appeals to pet owners and general public."
+          },
+          {
+            "themeDay": "Polisens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Recognizes police service, socially valuable but less broad appeal."
+          },
+          {
+            "themeDay": "Östersjödagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 6,
+            "novelty": 6,
+            "notes": "Environmental focus but less widely recognized."
+          }
+        ]
+      }
+    },
+    {
+      "date": "09-01",
+      "candidateCount": 4,
+      "themeDays": [
+        "Däckcheckdagen",
+        "Fluortantens dag",
+        "Sveriges lärares dag",
+        "Tjejnyår"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Sveriges lärares dag",
+        "backupThemeDays": [
+          "Tjejnyår",
+          "Däckcheckdagen"
+        ],
+        "reasoning": "Sveriges lärares dag is the most meaningful and socially valuable theme day among the candidates, recognizing and appreciating teachers who play a crucial role in society. It has broad cultural relevance and positive social impact. Tjejnyår is a culturally interesting and seasonally relevant celebration marking the new year for girls, making it a good backup. Däckcheckdagen is practical and seasonally relevant given Sweden's winter conditions but less socially impactful than the others. Fluortantens dag is niche and less recognizable.",
+        "scores": [
+          {
+            "themeDay": "Sveriges lärares dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Highly meaningful and widely appreciated day honoring teachers."
+          },
+          {
+            "themeDay": "Tjejnyår",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 6,
+            "novelty": 6,
+            "notes": "Seasonally relevant and culturally interesting, celebrating girls' new year."
+          },
+          {
+            "themeDay": "Däckcheckdagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 4,
+            "notes": "Practical winter safety reminder, useful but less socially impactful."
+          },
+          {
+            "themeDay": "Fluortantens dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 3,
+            "socialValue": 3,
+            "novelty": 5,
+            "notes": "Niche observance, less broadly recognized or impactful."
+          }
+        ]
+      }
+    },
+    {
+      "date": "09-05",
+      "candidateCount": 4,
+      "themeDays": [
+        "Dansbandens dag",
+        "Hittekattens dag",
+        "Internationella dagen för välgörenhet",
+        "Svampens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella dagen för välgörenhet",
+        "backupThemeDays": [
+          "Svampens dag",
+          "Dansbandens dag"
+        ],
+        "reasoning": "Internationella dagen för välgörenhet is the most meaningful and socially valuable theme day among the candidates, promoting global awareness and charitable actions which resonate well with a broad Swedish audience. Svampens dag is seasonally relevant and popular in Sweden due to the cultural interest in mushroom foraging. Dansbandens dag has cultural relevance but is more niche compared to the others. Hittekattens dag is less prominent and has lower broad appeal.",
+        "scores": [
+          {
+            "themeDay": "Internationella dagen för välgörenhet",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong social value and broad appeal internationally and in Sweden."
+          },
+          {
+            "themeDay": "Svampens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 6,
+            "novelty": 7,
+            "notes": "Seasonally relevant and culturally significant due to Swedish mushroom foraging traditions."
+          },
+          {
+            "themeDay": "Dansbandens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 5,
+            "novelty": 5,
+            "notes": "Popular music genre in Sweden but more niche audience."
+          },
+          {
+            "themeDay": "Hittekattens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 6,
+            "notes": "Lower recognition and appeal compared to others."
+          }
+        ]
+      }
+    },
+    {
+      "date": "09-19",
+      "candidateCount": 4,
+      "themeDays": [
+        "Brunchens dag",
+        "Internationella piratdagen",
+        "Messmörets dag",
+        "Världsdagen för aortadissektion"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Brunchens dag",
+        "backupThemeDays": [
+          "Internationella piratdagen",
+          "Världsdagen för aortadissektion"
+        ],
+        "reasoning": "Brunchens dag is the most broadly appealing and socially engaging theme day, likely to resonate with a wide Swedish audience due to the popularity of brunch culture. It is seasonally relevant as September is a great time for social dining events. Internationella piratdagen offers a fun and quirky alternative with cultural interest, while Världsdagen för aortadissektion has important health awareness value but is less engaging for the general public. Messmörets dag is quite niche and less recognizable.",
+        "scores": [
+          {
+            "themeDay": "Brunchens dag",
+            "audienceAppeal": 9,
+            "culturalRelevance": 8,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Popular food-related theme with broad appeal and social engagement potential."
+          },
+          {
+            "themeDay": "Internationella piratdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 8,
+            "notes": "Fun and quirky, appeals to families and cultural enthusiasts."
+          },
+          {
+            "themeDay": "Messmörets dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 3,
+            "novelty": 5,
+            "notes": "Niche traditional food day, less known and less engaging."
+          },
+          {
+            "themeDay": "Världsdagen för aortadissektion",
+            "audienceAppeal": 5,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 4,
+            "notes": "Important health awareness day but less engaging for general audience."
+          }
+        ]
+      }
+    },
+    {
+      "date": "09-21",
+      "candidateCount": 4,
+      "themeDays": [
+        "Internationella fredsdagen",
+        "Minigolfdagen",
+        "Scouternas fredsdag",
+        "Världstacksamhetsdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella fredsdagen",
+        "backupThemeDays": [
+          "Världstacksamhetsdagen",
+          "Scouternas fredsdag"
+        ],
+        "reasoning": "Internationella fredsdagen (International Day of Peace) is globally recognized and resonates well with Swedish values of peace and social responsibility, making it the most meaningful and socially valuable theme. Världstacksamhetsdagen (World Gratitude Day) is a positive, uplifting backup that encourages reflection and social cohesion. Scouternas fredsdag (Scouts' Peace Day) is relevant but more niche, appealing primarily to the scouting community.",
+        "scores": [
+          {
+            "themeDay": "Internationella fredsdagen",
+            "audienceAppeal": 9,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "Widely recognized, aligns with Swedish peace values, strong social message."
+          },
+          {
+            "themeDay": "Världstacksamhetsdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 7,
+            "notes": "Positive and inclusive, encourages gratitude and social bonding."
+          },
+          {
+            "themeDay": "Scouternas fredsdag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Relevant to scouts, less known to general public."
+          },
+          {
+            "themeDay": "Minigolfdagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 3,
+            "socialValue": 3,
+            "novelty": 6,
+            "notes": "Fun but niche and less socially impactful."
+          }
+        ]
+      }
+    },
+    {
+      "date": "09-28",
+      "candidateCount": 4,
+      "themeDays": [
+        "Int. dagen för universell tillgång till information",
+        "Internationella dagen för säkra aborter",
+        "Internationella rabiesdagen",
+        "Neurodagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella dagen för säkra aborter",
+        "backupThemeDays": [
+          "Int. dagen för universell tillgång till information",
+          "Internationella rabiesdagen"
+        ],
+        "reasoning": "Internationella dagen för säkra aborter is highly relevant in Sweden due to ongoing social and political discussions about reproductive rights, making it socially valuable and culturally significant. Universal access to information is important but less immediately resonant, while rabies is less of a public health concern in Sweden. Neurodagen is more niche and less widely recognized.",
+        "scores": [
+          {
+            "themeDay": "Internationella dagen för säkra aborter",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong social relevance and ongoing public discourse in Sweden."
+          },
+          {
+            "themeDay": "Int. dagen för universell tillgång till information",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Important but less directly impactful day for general public."
+          },
+          {
+            "themeDay": "Internationella rabiesdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "Lower relevance in Sweden due to low rabies risk."
+          },
+          {
+            "themeDay": "Neurodagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "More specialized and less widely recognized."
+          }
+        ]
+      }
+    },
+    {
+      "date": "10-13",
+      "candidateCount": 4,
+      "themeDays": [
+        "International Suit Up Day",
+        "Internationella klarspråksdagen",
+        "No Bra day",
+        "Världstrombosdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella klarspråksdagen",
+        "backupThemeDays": [
+          "Världstrombosdagen",
+          "International Suit Up Day"
+        ],
+        "reasoning": "Internationella klarspråksdagen (International Plain Language Day) is highly relevant in Sweden, where clear communication is valued in both public and private sectors. It promotes social inclusion and accessibility, making it meaningful and socially useful. Världstrombosdagen (World Thrombosis Day) is a significant health awareness day with broad social value. International Suit Up Day is more niche and less culturally resonant in Sweden. No Bra Day, while recognized internationally, is less aligned with Swedish cultural norms and may be seen as less socially constructive.",
+        "scores": [
+          {
+            "themeDay": "Internationella klarspråksdagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong cultural relevance and social value due to Sweden's emphasis on clear communication."
+          },
+          {
+            "themeDay": "Världstrombosdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Important health awareness day with good social value but less broad appeal."
+          },
+          {
+            "themeDay": "International Suit Up Day",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 4,
+            "novelty": 6,
+            "notes": "More niche and less culturally significant in Sweden."
+          },
+          {
+            "themeDay": "No Bra day",
+            "audienceAppeal": 4,
+            "culturalRelevance": 3,
+            "socialValue": 3,
+            "novelty": 7,
+            "notes": "Less aligned with Swedish social norms and less constructive."
+          }
+        ]
+      }
+    },
+    {
+      "date": "10-14",
+      "candidateCount": 4,
+      "themeDays": [
+        "Räkmackans dag",
+        "Världsdagen för synskadade",
+        "Världssyndagen",
+        "World Standards Day"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Räkmackans dag",
+        "backupThemeDays": [
+          "Världsdagen för synskadade",
+          "World Standards Day"
+        ],
+        "reasoning": "Räkmackans dag is a culturally unique and beloved Swedish food celebration that resonates well with a broad audience, making it a fun and engaging theme day. Världsdagen för synskadade is socially valuable and raises awareness about visual impairments, which is important but less widely recognized. World Standards Day has global relevance and importance but is more technical and less engaging for a general audience. Världssyndagen is less known and less relevant in the Swedish context.",
+        "scores": [
+          {
+            "themeDay": "Räkmackans dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 6,
+            "novelty": 7,
+            "notes": "Popular Swedish food day, fun and culturally relevant."
+          },
+          {
+            "themeDay": "Världsdagen för synskadade",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Important social awareness day but less widely celebrated."
+          },
+          {
+            "themeDay": "Världssyndagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 3,
+            "socialValue": 5,
+            "novelty": 4,
+            "notes": "Less known and less relevant in Sweden."
+          },
+          {
+            "themeDay": "World Standards Day",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 7,
+            "novelty": 4,
+            "notes": "Globally important but more technical and niche."
+          }
+        ]
+      }
+    },
+    {
+      "date": "10-24",
+      "candidateCount": 4,
+      "themeDays": [
+        "FN-dagen",
+        "Montessorilärardagen",
+        "Raggsockans dag",
+        "Världsdagen för information om utvecklingsfrågor"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "FN-dagen",
+        "backupThemeDays": [
+          "Raggsockans dag",
+          "Världsdagen för information om utvecklingsfrågor"
+        ],
+        "reasoning": "FN-dagen (United Nations Day) is widely recognized and celebrated in Sweden, reflecting global awareness and international cooperation, which resonates well with the Swedish public. It has strong cultural relevance and social value, promoting peace and human rights. Raggsockans dag is a cozy, culturally unique day that appeals to Swedish traditions and comfort, making it a good backup. Världsdagen för information om utvecklingsfrågor is socially valuable but less known, suitable as a secondary option. Montessorilärardagen is more niche and less broadly engaging.",
+        "scores": [
+          {
+            "themeDay": "FN-dagen",
+            "audienceAppeal": 9,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Highly recognized, globally significant, strong social message."
+          },
+          {
+            "themeDay": "Raggsockans dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 6,
+            "novelty": 6,
+            "notes": "Popular cozy cultural day, appeals to Swedish traditions."
+          },
+          {
+            "themeDay": "Världsdagen för information om utvecklingsfrågor",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Important social theme but less known."
+          },
+          {
+            "themeDay": "Montessorilärardagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 4,
+            "socialValue": 5,
+            "novelty": 4,
+            "notes": "Niche educational observance, limited general appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "11-13",
+      "candidateCount": 4,
+      "themeDays": [
+        "Arkivens dag",
+        "Bäskens Dag",
+        "Internationella vänlighetsdagen",
+        "Smörgåstårtans dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella vänlighetsdagen",
+        "backupThemeDays": [
+          "Arkivens dag",
+          "Smörgåstårtans dag"
+        ],
+        "reasoning": "Internationella vänlighetsdagen (International Day of Kindness) is widely recognized and promotes positive social values that resonate broadly with the public. It encourages kindness and community spirit, which are universally appreciated and seasonally relevant as a meaningful mid-November observance. Arkivens dag is culturally significant in Sweden, highlighting archives and heritage, making it a strong backup. Smörgåstårtans dag is a fun, uniquely Swedish food celebration that appeals to cultural identity and enjoyment, suitable as a secondary option. Bäskens Dag, while culturally specific, is less broadly recognized and has lower general appeal.",
+        "scores": [
+          {
+            "themeDay": "Internationella vänlighetsdagen",
+            "audienceAppeal": 9,
+            "culturalRelevance": 7,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "Strong universal appeal and social positivity make it the best primary choice."
+          },
+          {
+            "themeDay": "Arkivens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 8,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Important cultural day with educational value, good backup."
+          },
+          {
+            "themeDay": "Smörgåstårtans dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 6,
+            "novelty": 7,
+            "notes": "Fun and culturally unique food day, good secondary option."
+          },
+          {
+            "themeDay": "Bäskens Dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 6,
+            "socialValue": 4,
+            "novelty": 5,
+            "notes": "More niche and less widely known, lower priority."
+          }
+        ]
+      }
+    },
+    {
+      "date": "11-17",
+      "candidateCount": 4,
+      "themeDays": [
+        "De prestigelösas dag",
+        "Internationella elevdagen",
+        "Internationella GIS-dagen",
+        "Napoleonbakelsens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "De prestigelösas dag",
+        "backupThemeDays": [
+          "Internationella elevdagen",
+          "Napoleonbakelsens dag"
+        ],
+        "reasoning": "De prestigelösas dag promotes values of humility and equality, which resonate well with broad social values in Sweden and can engage a wide audience meaningfully. Internationella elevdagen is relevant for students and education, appealing to families and schools. Napoleonbakelsens dag offers a fun, culturally light-hearted theme that can attract food enthusiasts. Internationella GIS-dagen is more niche and technical, less likely to engage the general public.",
+        "scores": [
+          {
+            "themeDay": "De prestigelösas dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong social values and broad appeal in Swedish society."
+          },
+          {
+            "themeDay": "Internationella elevdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Relevant to education and youth, moderately broad appeal."
+          },
+          {
+            "themeDay": "Napoleonbakelsens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Fun and light-hearted, appeals to food lovers but less socially impactful."
+          },
+          {
+            "themeDay": "Internationella GIS-dagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 5,
+            "notes": "Technical and niche, limited general public interest."
+          }
+        ]
+      }
+    },
+    {
+      "date": "12-10",
+      "candidateCount": 4,
+      "themeDays": [
+        "Internationella djurrättsdagen",
+        "Mänskliga rättigheternas dag",
+        "Nobeldagen",
+        "Terra Madre day"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Mänskliga rättigheternas dag",
+        "backupThemeDays": [
+          "Nobeldagen",
+          "Internationella djurrättsdagen"
+        ],
+        "reasoning": "Mänskliga rättigheternas dag (Human Rights Day) is globally recognized and deeply meaningful, resonating strongly with Swedish values of equality and justice. It has broad cultural relevance and social importance, making it the best choice for a general audience. Nobeldagen is also highly significant in Sweden due to the Nobel Prize tradition, offering strong cultural relevance. Internationella djurrättsdagen is socially valuable but less prominent than the other two. Terra Madre day is less known and less relevant in the Swedish context.",
+        "scores": [
+          {
+            "themeDay": "Mänskliga rättigheternas dag",
+            "audienceAppeal": 9,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "Highly meaningful and socially important, widely recognized in Sweden."
+          },
+          {
+            "themeDay": "Nobeldagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 10,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Strong cultural significance due to Nobel Prize tradition, very recognizable in Sweden."
+          },
+          {
+            "themeDay": "Internationella djurrättsdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Important social cause but less prominent than human rights or Nobel Day."
+          },
+          {
+            "themeDay": "Terra Madre day",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 6,
+            "novelty": 7,
+            "notes": "Less known and less culturally relevant in Sweden."
+          }
+        ]
+      }
+    },
+    {
+      "date": "01-18",
+      "candidateCount": 3,
+      "themeDays": [
+        "Blue Monday",
+        "Internationella Nalle Puh-dagen",
+        "Martin Luther King-dagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Martin Luther King-dagen",
+        "backupThemeDays": [
+          "Internationella Nalle Puh-dagen",
+          "Blue Monday"
+        ],
+        "reasoning": "Martin Luther King Day is globally recognized and socially significant, promoting values of equality and justice which resonate well in Sweden. It has strong cultural relevance and social value. Internationella Nalle Puh-dagen is a beloved cultural reference with broad appeal, especially among families and children. Blue Monday, while known as the 'most depressing day,' has less positive social value and is less culturally significant in Sweden.",
+        "scores": [
+          {
+            "themeDay": "Martin Luther King-dagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong social and cultural significance, widely respected figure, promotes important values."
+          },
+          {
+            "themeDay": "Internationella Nalle Puh-dagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 6,
+            "novelty": 7,
+            "notes": "Popular cultural character, appeals to families and children, lighthearted and fun."
+          },
+          {
+            "themeDay": "Blue Monday",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 6,
+            "notes": "Known concept but less positive and less culturally embedded in Sweden."
+          }
+        ]
+      }
+    },
+    {
+      "date": "01-19",
+      "candidateCount": 3,
+      "themeDays": [
+        "Henriksdagen",
+        "Internationella popcorndagen",
+        "Sten Stures ben"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella popcorndagen",
+        "backupThemeDays": [
+          "Henriksdagen",
+          "Sten Stures ben"
+        ],
+        "reasoning": "Internationella popcorndagen is a fun, lighthearted day that has broad appeal and is easy for a general Swedish audience to engage with. It is seasonally relevant as it falls in winter when indoor activities like watching movies and eating popcorn are popular. Henriksdagen and Sten Stures ben are more niche and historically specific, with less immediate cultural resonance or social value for a broad audience.",
+        "scores": [
+          {
+            "themeDay": "Internationella popcorndagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Widely relatable and fun, good for social media and public engagement."
+          },
+          {
+            "themeDay": "Henriksdagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 5,
+            "notes": "Historically significant but less known and less engaging for general public."
+          },
+          {
+            "themeDay": "Sten Stures ben",
+            "audienceAppeal": 3,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 4,
+            "notes": "Very niche historical reference, limited broad appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "01-28",
+      "candidateCount": 3,
+      "themeDays": [
+        "Dataskyddsdagen",
+        "Internationella LEGO-dagen",
+        "Konungens namnsdag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Konungens namnsdag",
+        "backupThemeDays": [
+          "Dataskyddsdagen",
+          "Internationella LEGO-dagen"
+        ],
+        "reasoning": "Konungens namnsdag is a traditional and culturally significant observance in Sweden, recognized widely and tied to national identity. It resonates well with a broad audience and has stable cultural relevance. Dataskyddsdagen (Data Protection Day) is socially important and relevant in the digital age, making it a strong backup. Internationella LEGO-dagen is fun and internationally recognized but more niche and less culturally central in Sweden compared to the other two.",
+        "scores": [
+          {
+            "themeDay": "Konungens namnsdag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Strong cultural tradition and national recognition."
+          },
+          {
+            "themeDay": "Dataskyddsdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Important for digital awareness, growing relevance."
+          },
+          {
+            "themeDay": "Internationella LEGO-dagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Fun and playful but more niche and less culturally central."
+          }
+        ]
+      }
+    },
+    {
+      "date": "02-07",
+      "candidateCount": 3,
+      "themeDays": [
+        "Fastlagssöndagen",
+        "Tankens dag",
+        "Trafiklärarens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Fastlagssöndagen",
+        "backupThemeDays": [
+          "Tankens dag",
+          "Trafiklärarens dag"
+        ],
+        "reasoning": "Fastlagssöndagen is a culturally significant and widely recognized day in Sweden, marking the start of the traditional Lent period with festive customs like eating semlor. It has strong cultural relevance and social value, especially in Swedish society. Tankens dag and Trafiklärarens dag are more niche and less broadly celebrated, making them suitable backups but less impactful as primary themes.",
+        "scores": [
+          {
+            "themeDay": "Fastlagssöndagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Widely recognized traditional day with festive customs, strong cultural roots."
+          },
+          {
+            "themeDay": "Tankens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "Day celebrating thought and reflection, less widely known but meaningful."
+          },
+          {
+            "themeDay": "Trafiklärarens dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 4,
+            "notes": "Niche professional day, limited general public appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "02-20",
+      "candidateCount": 3,
+      "themeDays": [
+        "Internationella piprökardagen",
+        "Slarvighetens dag",
+        "Världsdagen för social rättvisa"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Världsdagen för social rättvisa",
+        "backupThemeDays": [
+          "Internationella piprökardagen",
+          "Slarvighetens dag"
+        ],
+        "reasoning": "Världsdagen för social rättvisa is the most meaningful and socially relevant theme day among the candidates. It aligns with global awareness and promotes important discussions on equality and fairness, which resonates well with a broad Swedish audience. Internationella piprökardagen is more niche and less socially impactful, while Slarvighetens dag is lighthearted but less significant in terms of social value.",
+        "scores": [
+          {
+            "themeDay": "Världsdagen för social rättvisa",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "Highly relevant socially and culturally, promotes important values."
+          },
+          {
+            "themeDay": "Internationella piprökardagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 5,
+            "notes": "Niche interest, limited social impact."
+          },
+          {
+            "themeDay": "Slarvighetens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Fun and lighthearted but less meaningful."
+          }
+        ]
+      }
+    },
+    {
+      "date": "03-03",
+      "candidateCount": 3,
+      "themeDays": [
+        "Dagen för musikalisk frihet",
+        "Mandelkubbens dag",
+        "Världsdagen för natur- och djurliv"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Världsdagen för natur- och djurliv",
+        "backupThemeDays": [
+          "Dagen för musikalisk frihet",
+          "Mandelkubbens dag"
+        ],
+        "reasoning": "Världsdagen för natur- och djurliv has the highest cultural relevance and social value in Sweden, a country known for its strong connection to nature and wildlife conservation. It appeals broadly across demographics and encourages environmental awareness, making it highly meaningful and socially useful. Dagen för musikalisk frihet is a good backup due to its cultural and artistic appeal, while Mandelkubbens dag is more niche and culinary-focused, suitable as a secondary option.",
+        "scores": [
+          {
+            "themeDay": "Världsdagen för natur- och djurliv",
+            "audienceAppeal": 9,
+            "culturalRelevance": 10,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "Strong national and global relevance, promotes environmental awareness."
+          },
+          {
+            "themeDay": "Dagen för musikalisk frihet",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 7,
+            "notes": "Appeals to music lovers and cultural audiences, moderate social impact."
+          },
+          {
+            "themeDay": "Mandelkubbens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 6,
+            "notes": "Niche culinary celebration, less broad appeal but fun and seasonally relevant."
+          }
+        ]
+      }
+    },
+    {
+      "date": "03-14",
+      "candidateCount": 3,
+      "themeDays": [
+        "Matematikens dag",
+        "Pi-dagen",
+        "Steak and BJ day"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Pi-dagen",
+        "backupThemeDays": [
+          "Matematikens dag"
+        ],
+        "reasoning": "Pi-dagen (March 14) is widely recognized internationally and resonates well with both educational and general audiences in Sweden. It is fun, educational, and seasonally relevant. Matematikens dag is a good backup as it aligns with the educational theme but is less universally known. Steak and BJ day is inappropriate for a public-facing calendar app due to its adult content and low cultural relevance.",
+        "scores": [
+          {
+            "themeDay": "Pi-dagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Popular math-related day, fun and educational, broadly recognized."
+          },
+          {
+            "themeDay": "Matematikens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Educational and relevant but less known than Pi-dagen."
+          },
+          {
+            "themeDay": "Steak and BJ day",
+            "audienceAppeal": 2,
+            "culturalRelevance": 1,
+            "socialValue": 1,
+            "novelty": 4,
+            "notes": "Adult-themed, inappropriate for general audience, low cultural relevance."
+          }
+        ]
+      }
+    },
+    {
+      "date": "03-17",
+      "candidateCount": 3,
+      "themeDays": [
+        "Hallongrottans dag",
+        "Kollektivavtalets dag",
+        "Saint Patrick's day"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Saint Patrick's day",
+        "backupThemeDays": [
+          "Hallongrottans dag",
+          "Kollektivavtalets dag"
+        ],
+        "reasoning": "Saint Patrick's Day is internationally recognized and widely celebrated, including in Sweden, with social events and cultural activities that appeal to a broad audience. Hallongrottans dag, while culturally specific and charming, has a narrower appeal. Kollektivavtalets dag is important socially but less engaging for a general public calendar due to its technical and labor-specific nature.",
+        "scores": [
+          {
+            "themeDay": "Saint Patrick's day",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "Widely recognized and celebrated in Sweden with social events; good mix of cultural and fun appeal."
+          },
+          {
+            "themeDay": "Hallongrottans dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "A charming Swedish food-related day, appealing to local culture and culinary interest."
+          },
+          {
+            "themeDay": "Kollektivavtalets dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 3,
+            "notes": "Important for labor rights awareness but less engaging for general public and seasonal fun."
+          }
+        ]
+      }
+    },
+    {
+      "date": "03-23",
+      "candidateCount": 3,
+      "themeDays": [
+        "Matlådans dag",
+        "Nordens dag",
+        "Världsmeteorologidagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Nordens dag",
+        "backupThemeDays": [
+          "Världsmeteorologidagen",
+          "Matlådans dag"
+        ],
+        "reasoning": "Nordens dag is a well-recognized and culturally significant day in Sweden and the Nordic countries, celebrating Nordic cooperation and heritage. It has broad appeal and social value, fostering regional identity and unity. Världsmeteorologidagen is globally relevant and seasonally appropriate as spring approaches, while Matlådans dag is more niche but relatable for everyday life and sustainability.",
+        "scores": [
+          {
+            "themeDay": "Nordens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Strong cultural and regional significance, widely recognized in Sweden and Nordic countries."
+          },
+          {
+            "themeDay": "Världsmeteorologidagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Relevant to environmental awareness and weather, important but less culturally specific."
+          },
+          {
+            "themeDay": "Matlådans dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 4,
+            "notes": "Relatable for daily life and sustainability but less prominent and niche."
+          }
+        ]
+      }
+    },
+    {
+      "date": "03-25",
+      "candidateCount": 3,
+      "themeDays": [
+        "Tolkien reading day",
+        "Trandagen",
+        "Våffeldagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Våffeldagen",
+        "backupThemeDays": [
+          "Trandagen",
+          "Tolkien reading day"
+        ],
+        "reasoning": "Våffeldagen (Waffle Day) is widely celebrated in Sweden on March 25th and is a beloved cultural tradition involving enjoying waffles. It has strong cultural relevance, social value as a fun food-related day, and broad audience appeal. Trandagen (Crane Day) is also culturally relevant but less widely celebrated, and Tolkien Reading Day, while interesting, is more niche and less socially significant in Sweden.",
+        "scores": [
+          {
+            "themeDay": "Våffeldagen",
+            "audienceAppeal": 9,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Popular food tradition with broad appeal and strong cultural roots."
+          },
+          {
+            "themeDay": "Trandagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "Recognizes crane migration, relevant to nature lovers but less mainstream."
+          },
+          {
+            "themeDay": "Tolkien reading day",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Niche literary observance with limited general appeal in Sweden."
+          }
+        ]
+      }
+    },
+    {
+      "date": "04-06",
+      "candidateCount": 3,
+      "themeDays": [
+        "Internationella Carbonara-dagen",
+        "Internationella sportdagen för utveckling och fred",
+        "Pingisens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella sportdagen för utveckling och fred",
+        "backupThemeDays": [
+          "Pingisens dag",
+          "Internationella Carbonara-dagen"
+        ],
+        "reasoning": "Internationella sportdagen för utveckling och fred has the highest social value and cultural relevance, promoting peace and development through sports, which resonates well with Swedish values. Pingisens dag is a fun and recognizable sports-related day, appealing to a broad audience. Internationella Carbonara-dagen, while fun, is more niche and less socially impactful.",
+        "scores": [
+          {
+            "themeDay": "Internationella sportdagen för utveckling och fred",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "Strong social message and aligns with Swedish interest in peace and development."
+          },
+          {
+            "themeDay": "Pingisens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 7,
+            "notes": "Popular sport in Sweden, fun and engaging."
+          },
+          {
+            "themeDay": "Internationella Carbonara-dagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 8,
+            "notes": "Food-related day, enjoyable but less socially impactful."
+          }
+        ]
+      }
+    },
+    {
+      "date": "04-10",
+      "candidateCount": 3,
+      "themeDays": [
+        "Bulle med bullens-dag",
+        "Internationella syskondagen",
+        "Surdegsdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella syskondagen",
+        "backupThemeDays": [
+          "Surdegsdagen",
+          "Bulle med bullens-dag"
+        ],
+        "reasoning": "Internationella syskondagen (International Siblings Day) has broad social appeal and cultural relevance as it celebrates family relationships, which resonates widely across Swedish society. It promotes social values of family bonding and appreciation, making it meaningful and inclusive. Surdegsdagen (Sourdough Day) is seasonally relevant and popular due to Sweden's strong baking culture, especially in autumn. Bulle med bullens-dag, while fun and culturally specific, is more niche and less socially impactful compared to the others.",
+        "scores": [
+          {
+            "themeDay": "Internationella syskondagen",
+            "audienceAppeal": 9,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong family theme with wide appeal and social importance."
+          },
+          {
+            "themeDay": "Surdegsdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 6,
+            "novelty": 7,
+            "notes": "Popular baking theme, seasonally fitting and culturally relevant."
+          },
+          {
+            "themeDay": "Bulle med bullens-dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 8,
+            "notes": "Fun and quirky but more niche and less socially meaningful."
+          }
+        ]
+      }
+    },
+    {
+      "date": "04-12",
+      "candidateCount": 3,
+      "themeDays": [
+        "Internationella dagen för bemannade rymdfärder",
+        "Lakritsdagen",
+        "Linssoppans dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Lakritsdagen",
+        "backupThemeDays": [
+          "Linssoppans dag",
+          "Internationella dagen för bemannade rymdfärder"
+        ],
+        "reasoning": "Lakritsdagen is a popular and widely recognized food-related theme day in Sweden, appealing to a broad audience due to the cultural love for licorice. It has strong cultural relevance and social value as a fun, tasty celebration. Linssoppans dag is a good backup as it highlights a traditional Swedish dish, promoting local cuisine and healthy eating. Internationella dagen för bemannade rymdfärder is less culturally resonant and more niche, making it a lower priority despite its international significance.",
+        "scores": [
+          {
+            "themeDay": "Lakritsdagen",
+            "audienceAppeal": 9,
+            "culturalRelevance": 8,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Popular Swedish food day with broad appeal and cultural significance."
+          },
+          {
+            "themeDay": "Linssoppans dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Promotes traditional Swedish cuisine and healthy eating habits."
+          },
+          {
+            "themeDay": "Internationella dagen för bemannade rymdfärder",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Interesting international theme but niche and less connected to Swedish culture."
+          }
+        ]
+      }
+    },
+    {
+      "date": "04-14",
+      "candidateCount": 3,
+      "themeDays": [
+        "Cultural Unity Day",
+        "Mahl Language Day",
+        "Volvons dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Cultural Unity Day",
+        "backupThemeDays": [
+          "Volvons dag",
+          "Mahl Language Day"
+        ],
+        "reasoning": "Cultural Unity Day is the most meaningful and socially valuable theme for a general Swedish audience, promoting inclusiveness and shared cultural identity. Volvons dag is a recognizable and fun theme related to a beloved Swedish car brand, appealing to nostalgia and national pride. Mahl Language Day is more niche, focusing on a specific linguistic group, which may have limited broader appeal.",
+        "scores": [
+          {
+            "themeDay": "Cultural Unity Day",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong social and cultural relevance, widely meaningful."
+          },
+          {
+            "themeDay": "Volvons dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 6,
+            "novelty": 7,
+            "notes": "Popular cultural icon, fun and nostalgic."
+          },
+          {
+            "themeDay": "Mahl Language Day",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "Niche linguistic focus, less broad appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "04-21",
+      "candidateCount": 3,
+      "themeDays": [
+        "Internationella sekreterardagen",
+        "Terrakottakrukans dag",
+        "Världsdagen för kreativitet och innovation"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Världsdagen för kreativitet och innovation",
+        "backupThemeDays": [
+          "Internationella sekreterardagen",
+          "Terrakottakrukans dag"
+        ],
+        "reasoning": "Världsdagen för kreativitet och innovation is the most meaningful and socially valuable theme day among the candidates. It resonates broadly with audiences interested in progress, ideas, and positive societal impact, making it seasonally and culturally relevant in Sweden. Internationella sekreterardagen is more niche and workplace-specific, while Terrakottakrukans dag is quite niche and less socially impactful.",
+        "scores": [
+          {
+            "themeDay": "Världsdagen för kreativitet och innovation",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Broad appeal and positive social message; relevant to many sectors and individuals."
+          },
+          {
+            "themeDay": "Internationella sekreterardagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 4,
+            "notes": "Relevant to office workers and administrative professionals but limited broader appeal."
+          },
+          {
+            "themeDay": "Terrakottakrukans dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 3,
+            "socialValue": 3,
+            "novelty": 5,
+            "notes": "Niche interest in gardening or pottery; less social impact and cultural relevance."
+          }
+        ]
+      }
+    },
+    {
+      "date": "04-26",
+      "candidateCount": 3,
+      "themeDays": [
+        "Alien-dagen",
+        "Promenadens dag",
+        "Världsdagen för intellektuell äganderätt"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Promenadens dag",
+        "backupThemeDays": [
+          "Alien-dagen",
+          "Världsdagen för intellektuell äganderätt"
+        ],
+        "reasoning": "Promenadens dag (Walk Day) is the most relatable and socially beneficial theme for a broad Swedish audience, encouraging outdoor activity and health, which aligns well with Swedish cultural values around nature and wellness. Alien-dagen is more niche and playful but less socially impactful. Världsdagen för intellektuell äganderätt is important but more technical and less engaging for the general public.",
+        "scores": [
+          {
+            "themeDay": "Promenadens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Encourages healthy lifestyle and outdoor activity, very relevant in Sweden."
+          },
+          {
+            "themeDay": "Alien-dagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Fun and quirky but less meaningful or socially impactful."
+          },
+          {
+            "themeDay": "Världsdagen för intellektuell äganderätt",
+            "audienceAppeal": 4,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 5,
+            "notes": "Important topic but more niche and less engaging for general public."
+          }
+        ]
+      }
+    },
+    {
+      "date": "04-28",
+      "candidateCount": 3,
+      "themeDays": [
+        "Arbetsmiljödagen",
+        "Ledarhundens dag",
+        "Möteskulturdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Arbetsmiljödagen",
+        "backupThemeDays": [
+          "Ledarhundens dag",
+          "Möteskulturdagen"
+        ],
+        "reasoning": "Arbetsmiljödagen (Work Environment Day) is the most meaningful and socially valuable theme day among the candidates, as it promotes awareness about workplace safety and well-being, which is relevant to a broad Swedish audience. Ledarhundens dag (Guide Dog Day) is a strong backup due to its social importance and recognition, while Möteskulturdagen (Meeting Culture Day) is more niche and less widely recognized.",
+        "scores": [
+          {
+            "themeDay": "Arbetsmiljödagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Highly relevant to many workers; promotes health and safety."
+          },
+          {
+            "themeDay": "Ledarhundens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Raises awareness about guide dogs and accessibility."
+          },
+          {
+            "themeDay": "Möteskulturdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Focuses on improving meeting culture; more niche and less broadly impactful."
+          }
+        ]
+      }
+    },
+    {
+      "date": "04-30",
+      "candidateCount": 3,
+      "themeDays": [
+        "Internationella jazzdagen",
+        "Konungens födelsedag",
+        "Valborgsmässoafton"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Valborgsmässoafton",
+        "backupThemeDays": [
+          "Konungens födelsedag",
+          "Internationella jazzdagen"
+        ],
+        "reasoning": "Valborgsmässoafton is a widely celebrated traditional spring festival in Sweden, marked by bonfires and community gatherings, making it highly culturally relevant and socially engaging. Konungens födelsedag is significant but less publicly celebrated compared to Valborg. Internationella jazzdagen, while internationally recognized, has less cultural resonance in Sweden on this date.",
+        "scores": [
+          {
+            "themeDay": "Valborgsmässoafton",
+            "audienceAppeal": 9,
+            "culturalRelevance": 10,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong traditional and social significance with broad public participation."
+          },
+          {
+            "themeDay": "Konungens födelsedag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "Official royal birthday with national importance but lower public festivity."
+          },
+          {
+            "themeDay": "Internationella jazzdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "International observance with niche appeal in Sweden."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-01",
+      "candidateCount": 3,
+      "themeDays": [
+        "Arbetarrörelsens dag",
+        "Budapestbakelsens dag",
+        "Gratis serietidningsdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Arbetarrörelsens dag",
+        "backupThemeDays": [
+          "Gratis serietidningsdagen",
+          "Budapestbakelsens dag"
+        ],
+        "reasoning": "Arbetarrörelsens dag (Labor Movement Day) is the most culturally significant and socially relevant theme for a Swedish audience, reflecting important historical and social values tied to workers' rights and political history. It has broad recognition and meaningful impact. Gratis serietidningsdagen is a fun, accessible cultural event appealing to families and youth, making it a good backup. Budapestbakelsens dag is more niche and less widely recognized, so it ranks lower.",
+        "scores": [
+          {
+            "themeDay": "Arbetarrörelsens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Strong cultural and social significance tied to Swedish labor history and politics."
+          },
+          {
+            "themeDay": "Gratis serietidningsdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 6,
+            "socialValue": 6,
+            "novelty": 7,
+            "notes": "Fun and accessible, promotes reading and comics culture, but less socially impactful."
+          },
+          {
+            "themeDay": "Budapestbakelsens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 6,
+            "notes": "Niche food-related day, less widely known or socially meaningful."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-04",
+      "candidateCount": 3,
+      "themeDays": [
+        "Fothälsodagen",
+        "Internationella brandmännens dag",
+        "Star wars-dagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Star wars-dagen",
+        "backupThemeDays": [
+          "Internationella brandmännens dag",
+          "Fothälsodagen"
+        ],
+        "reasoning": "Star Wars Day (May the 4th) is widely recognized and celebrated internationally, including in Sweden, making it highly engaging and fun for a broad audience. It has strong cultural relevance due to the global popularity of the Star Wars franchise and offers a lighthearted, socially engaging theme. Internationella brandmännens dag is socially valuable and culturally relevant in Sweden but less broadly celebrated. Fothälsodagen is important for health awareness but has lower general appeal and novelty compared to the other two.",
+        "scores": [
+          {
+            "themeDay": "Star wars-dagen",
+            "audienceAppeal": 9,
+            "culturalRelevance": 8,
+            "socialValue": 7,
+            "novelty": 7,
+            "notes": "Popular cultural event with broad appeal and fun engagement potential."
+          },
+          {
+            "themeDay": "Internationella brandmännens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Important social recognition day, respected but less widely celebrated."
+          },
+          {
+            "themeDay": "Fothälsodagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 7,
+            "novelty": 4,
+            "notes": "Health awareness day with limited general public interest."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-09",
+      "candidateCount": 3,
+      "themeDays": [
+        "Europadagen",
+        "Linderödsgrisens dag",
+        "Nedkopplingens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Europadagen",
+        "backupThemeDays": [
+          "Nedkopplingens dag",
+          "Linderödsgrisens dag"
+        ],
+        "reasoning": "Europadagen (Europe Day) is widely recognized across Sweden and Europe, celebrating peace and unity within the European Union. It has strong cultural and social relevance, especially in a Swedish context as Sweden is an EU member. Nedkopplingens dag (Disconnection Day) is socially valuable as it promotes digital wellbeing, which is increasingly important. Linderödsgrisens dag is more niche, focusing on a specific Swedish pig breed, which is less broadly engaging.",
+        "scores": [
+          {
+            "themeDay": "Europadagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Strongly recognized, culturally significant, promotes European unity."
+          },
+          {
+            "themeDay": "Nedkopplingens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 6,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Encourages digital detox, socially valuable but less established."
+          },
+          {
+            "themeDay": "Linderödsgrisens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Niche agricultural theme, interesting but limited broad appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-16",
+      "candidateCount": 3,
+      "themeDays": [
+        "Internationella celiakidagen",
+        "Internationella dagen för fredlig samlevnad",
+        "Internationella ljusdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella dagen för fredlig samlevnad",
+        "backupThemeDays": [
+          "Internationella celiakidagen",
+          "Internationella ljusdagen"
+        ],
+        "reasoning": "Internationella dagen för fredlig samlevnad has broad social value and cultural relevance, promoting peace and coexistence, which resonates well with a general Swedish audience. It is a meaningful and socially important observance that encourages reflection and positive action. Internationella celiakidagen is relevant for health awareness but more niche, while Internationella ljusdagen is less widely recognized and has lower immediate social impact.",
+        "scores": [
+          {
+            "themeDay": "Internationella dagen för fredlig samlevnad",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Strong social message, widely relevant, promotes peace and coexistence."
+          },
+          {
+            "themeDay": "Internationella celiakidagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 4,
+            "notes": "Important for health awareness but appeals to a more specific group."
+          },
+          {
+            "themeDay": "Internationella ljusdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 6,
+            "notes": "Less known, more abstract theme, lower social impact."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-17",
+      "candidateCount": 3,
+      "themeDays": [
+        "Annandag pingst",
+        "Internationella dagen mot homo- och transfobi",
+        "Internationella telekommunikationsdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella dagen mot homo- och transfobi",
+        "backupThemeDays": [
+          "Annandag pingst",
+          "Internationella telekommunikationsdagen"
+        ],
+        "reasoning": "Internationella dagen mot homo- och transfobi is highly relevant socially and culturally in Sweden, a country known for its strong support of LGBTQ+ rights and inclusion. It promotes awareness and combats discrimination, aligning well with socially valuable themes. Annandag pingst is a traditional religious holiday but has less broad social engagement today. Internationella telekommunikationsdagen is more niche and technical, less engaging for a general audience.",
+        "scores": [
+          {
+            "themeDay": "Internationella dagen mot homo- och transfobi",
+            "audienceAppeal": 9,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "Strong social and cultural relevance, promotes inclusion and awareness."
+          },
+          {
+            "themeDay": "Annandag pingst",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 5,
+            "novelty": 4,
+            "notes": "Traditional holiday with cultural roots but less social engagement."
+          },
+          {
+            "themeDay": "Internationella telekommunikationsdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 4,
+            "novelty": 5,
+            "notes": "More technical and niche, less broad appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-19",
+      "candidateCount": 3,
+      "themeDays": [
+        "Halloumiostens dag",
+        "IT-chefens dag",
+        "Nationella mag-och tarmdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Nationella mag-och tarmdagen",
+        "backupThemeDays": [
+          "Halloumiostens dag",
+          "IT-chefens dag"
+        ],
+        "reasoning": "Nationella mag-och tarmdagen is the most socially valuable and culturally relevant theme day among the candidates, as it raises awareness about digestive health, which is important for public health and resonates broadly. Halloumiostens dag is fun and food-related, appealing to many, but less socially impactful. IT-chefens dag is more niche and less likely to engage the general public.",
+        "scores": [
+          {
+            "themeDay": "Nationella mag-och tarmdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong public health relevance and broad appeal."
+          },
+          {
+            "themeDay": "Halloumiostens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Popular food theme, fun but less impactful."
+          },
+          {
+            "themeDay": "IT-chefens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 6,
+            "notes": "Niche professional focus, less general interest."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-21",
+      "candidateCount": 3,
+      "themeDays": [
+        "Internationella flytvästdagen",
+        "Internationella tedagen",
+        "Världsdagen för kulturell mångfald för dialog och utveckling"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Världsdagen för kulturell mångfald för dialog och utveckling",
+        "backupThemeDays": [
+          "Internationella flytvästdagen",
+          "Internationella tedagen"
+        ],
+        "reasoning": "Världsdagen för kulturell mångfald för dialog och utveckling is the most meaningful and socially valuable theme day among the options. It promotes awareness and appreciation of cultural diversity, which is highly relevant and important in Sweden's multicultural society. Internationella flytvästdagen is important for safety awareness, especially as summer approaches, making it a strong backup. Internationella tedagen is a lighter, more universally enjoyable theme but less socially impactful, making it a secondary backup.",
+        "scores": [
+          {
+            "themeDay": "Världsdagen för kulturell mångfald för dialog och utveckling",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Highly relevant to Sweden's diverse society and promotes important social values."
+          },
+          {
+            "themeDay": "Internationella flytvästdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Important for public safety awareness, especially relevant in Sweden with many lakes and boating activities."
+          },
+          {
+            "themeDay": "Internationella tedagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Fun and lighthearted, but less socially impactful compared to the others."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-23",
+      "candidateCount": 3,
+      "themeDays": [
+        "Internationella dagen för utrotning av obstetrisk fistula",
+        "Internationella sköldpaddsdagen",
+        "Måltidens gemenskapsdag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Måltidens gemenskapsdag",
+        "backupThemeDays": [
+          "Internationella sköldpaddsdagen",
+          "Internationella dagen för utrotning av obstetrisk fistula"
+        ],
+        "reasoning": "Måltidens gemenskapsdag is the most relatable and socially engaging theme for a general Swedish audience, emphasizing community and shared experiences around food, which resonates well culturally. Internationella sköldpaddsdagen is a recognizable environmental day with broad appeal, while Internationella dagen för utrotning av obstetrisk fistula is important but less known and less directly relevant to the general public.",
+        "scores": [
+          {
+            "themeDay": "Måltidens gemenskapsdag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Strong cultural and social relevance, promotes community and togetherness."
+          },
+          {
+            "themeDay": "Internationella sköldpaddsdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 7,
+            "notes": "Good environmental awareness day, moderately well known."
+          },
+          {
+            "themeDay": "Internationella dagen för utrotning av obstetrisk fistula",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Important health-related day but less familiar and less directly relevant to Swedish public."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-25",
+      "candidateCount": 3,
+      "themeDays": [
+        "Handduksdagen",
+        "Internationella nörddagen",
+        "Internationella sköldkörteldagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella sköldkörteldagen",
+        "backupThemeDays": [
+          "Internationella nörddagen",
+          "Handduksdagen"
+        ],
+        "reasoning": "Internationella sköldkörteldagen is the most meaningful and socially valuable theme day among the candidates, focusing on health awareness which has broad relevance. Internationella nörddagen is a fun and recognizable day that appeals to a wide audience, especially younger demographics. Handduksdagen, while quirky and fun, is less culturally significant and has lower social value compared to the others.",
+        "scores": [
+          {
+            "themeDay": "Internationella sköldkörteldagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Health awareness day with broad social importance and relevance."
+          },
+          {
+            "themeDay": "Internationella nörddagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 6,
+            "socialValue": 6,
+            "novelty": 7,
+            "notes": "Fun, widely recognized day celebrating nerd culture."
+          },
+          {
+            "themeDay": "Handduksdagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 8,
+            "notes": "Quirky and fun but less socially impactful."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-27",
+      "candidateCount": 3,
+      "themeDays": [
+        "Muffinsdagen",
+        "Ostens dag",
+        "Parfymfria dagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Ostens dag",
+        "backupThemeDays": [
+          "Muffinsdagen",
+          "Parfymfria dagen"
+        ],
+        "reasoning": "Ostens dag (Cheese Day) is a well-recognized and culturally significant food celebration in Sweden, appealing broadly due to the country's strong cheese traditions and culinary culture. It has high social value as it encourages local food appreciation and gatherings. Muffinsdagen is fun but less culturally distinctive, and Parfymfria dagen, while socially valuable for health and environmental reasons, is less widely known and celebrated.",
+        "scores": [
+          {
+            "themeDay": "Ostens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Strong cultural ties to Swedish cuisine and widely appreciated food day."
+          },
+          {
+            "themeDay": "Muffinsdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "Fun and lighthearted, but less culturally unique to Sweden."
+          },
+          {
+            "themeDay": "Parfymfria dagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 4,
+            "socialValue": 8,
+            "novelty": 7,
+            "notes": "Important social and environmental message but less mainstream recognition."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-29",
+      "candidateCount": 3,
+      "themeDays": [
+        "Internationella dagen för FN:s fredsbevarande personal",
+        "Ofrivilligt barnlösas dag",
+        "Veterandagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Veterandagen",
+        "backupThemeDays": [
+          "Internationella dagen för FN:s fredsbevarande personal",
+          "Ofrivilligt barnlösas dag"
+        ],
+        "reasoning": "Veterandagen is a significant and widely recognized day in Sweden, honoring military veterans and their contributions. It has strong cultural relevance and social value, resonating with a broad audience. The International Day of UN Peacekeepers is important but less known among the general public, while Ofrivilligt barnlösas dag is meaningful but more niche and less publicly recognized.",
+        "scores": [
+          {
+            "themeDay": "Veterandagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Widely recognized and respected day honoring veterans; strong cultural and social significance."
+          },
+          {
+            "themeDay": "Internationella dagen för FN:s fredsbevarande personal",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Important international observance but less known in Sweden; relevant to peacekeeping efforts."
+          },
+          {
+            "themeDay": "Ofrivilligt barnlösas dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 7,
+            "notes": "Important for raising awareness but more niche and less broadly recognized."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-30",
+      "candidateCount": 3,
+      "themeDays": [
+        "Fönsterrenoveringens dag",
+        "Internationella MS-dagen",
+        "Mors dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Mors dag",
+        "backupThemeDays": [
+          "Internationella MS-dagen",
+          "Fönsterrenoveringens dag"
+        ],
+        "reasoning": "Mors dag (Mother's Day) is widely celebrated in Sweden and holds strong cultural significance as a day to honor mothers and family. It is well-known, socially meaningful, and seasonally relevant in late May. Internationella MS-dagen (International MS Day) has important social value but less broad public recognition. Fönsterrenoveringens dag (Window Renovation Day) is niche and less engaging for a general audience.",
+        "scores": [
+          {
+            "themeDay": "Mors dag",
+            "audienceAppeal": 9,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 4,
+            "notes": "Widely celebrated, culturally significant, family-oriented."
+          },
+          {
+            "themeDay": "Internationella MS-dagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Important health awareness day but less broadly recognized."
+          },
+          {
+            "themeDay": "Fönsterrenoveringens dag",
+            "audienceAppeal": 3,
+            "culturalRelevance": 3,
+            "socialValue": 4,
+            "novelty": 6,
+            "notes": "Niche theme with limited general interest."
+          }
+        ]
+      }
+    },
+    {
+      "date": "06-01",
+      "candidateCount": 3,
+      "themeDays": [
+        "Globala dagen för föräldrar",
+        "Mjölkens dag",
+        "Mobilfria dagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Globala dagen för föräldrar",
+        "backupThemeDays": [
+          "Mobilfria dagen",
+          "Mjölkens dag"
+        ],
+        "reasoning": "Globala dagen för föräldrar is the most meaningful and socially valuable theme day for a general Swedish audience, highlighting the important role of parents in society. It has broad cultural relevance and appeals to a wide demographic. Mobilfria dagen is a good backup as it promotes digital wellbeing, which is increasingly relevant. Mjölkens dag is more niche and less socially impactful, making it a lower priority.",
+        "scores": [
+          {
+            "themeDay": "Globala dagen för föräldrar",
+            "audienceAppeal": 9,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong broad appeal and social importance."
+          },
+          {
+            "themeDay": "Mobilfria dagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 7,
+            "notes": "Relevant to digital health and wellbeing, growing interest."
+          },
+          {
+            "themeDay": "Mjölkens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 5,
+            "notes": "More niche, focused on dairy consumption, less broad impact."
+          }
+        ]
+      }
+    },
+    {
+      "date": "06-12",
+      "candidateCount": 3,
+      "themeDays": [
+        "Internationella dagen mot barnarbete",
+        "Nationalbastudagen",
+        "Världsstickningsdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella dagen mot barnarbete",
+        "backupThemeDays": [
+          "Nationalbastudagen",
+          "Världsstickningsdagen"
+        ],
+        "reasoning": "Internationella dagen mot barnarbete is the most socially significant and globally recognized theme day among the candidates. It raises awareness about an important human rights issue, which aligns well with public interest and social responsibility. Nationalbastudagen is culturally relevant and widely appreciated in Sweden due to the strong sauna tradition, making it a good backup. Världsstickningsdagen, while fun and creative, has less broad appeal and social impact compared to the other two.",
+        "scores": [
+          {
+            "themeDay": "Internationella dagen mot barnarbete",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "High social value and global recognition; important human rights issue."
+          },
+          {
+            "themeDay": "Nationalbastudagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 9,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "Strong cultural relevance in Sweden; promotes wellness and tradition."
+          },
+          {
+            "themeDay": "Världsstickningsdagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Fun and creative but niche; less broad social impact."
+          }
+        ]
+      }
+    },
+    {
+      "date": "06-16",
+      "candidateCount": 3,
+      "themeDays": [
+        "Bloomsday",
+        "Internationella dagen för familjeremitteringar",
+        "Redovisningskonsultens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Bloomsday",
+        "backupThemeDays": [
+          "Internationella dagen för familjeremitteringar",
+          "Redovisningskonsultens dag"
+        ],
+        "reasoning": "Bloomsday is a culturally significant day celebrated internationally, especially in literary circles, commemorating James Joyce's Ulysses. It has broader cultural appeal and recognition compared to the other two, which are more niche and less likely to engage a general Swedish audience. The International Day for Family Remittances has social value but is less known and less seasonally relevant. Redovisningskonsultens dag is very niche and primarily relevant to accounting professionals, making it the least suitable as a primary theme.",
+        "scores": [
+          {
+            "themeDay": "Bloomsday",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 6,
+            "novelty": 7,
+            "notes": "Strong literary and cultural significance, widely recognized internationally."
+          },
+          {
+            "themeDay": "Internationella dagen för familjeremitteringar",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Important social theme but less known and less engaging for general public."
+          },
+          {
+            "themeDay": "Redovisningskonsultens dag",
+            "audienceAppeal": 3,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 4,
+            "notes": "Very niche, limited appeal outside accounting professionals."
+          }
+        ]
+      }
+    },
+    {
+      "date": "06-30",
+      "candidateCount": 3,
+      "themeDays": [
+        "Internationella dagen för asteroider",
+        "Internationella dagen för parlamentarism",
+        "Pilsnerkorvens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella dagen för parlamentarism",
+        "backupThemeDays": [
+          "Internationella dagen för asteroider",
+          "Pilsnerkorvens dag"
+        ],
+        "reasoning": "Internationella dagen för parlamentarism is the most meaningful and socially relevant theme day for a general Swedish audience, highlighting democratic values important in Sweden. The asteroid day is interesting but more niche, and Pilsnerkorvens dag is fun but less culturally significant.",
+        "scores": [
+          {
+            "themeDay": "Internationella dagen för parlamentarism",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong cultural and social relevance due to Sweden's democratic traditions."
+          },
+          {
+            "themeDay": "Internationella dagen för asteroider",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Interesting scientific theme but less directly relevant to general public."
+          },
+          {
+            "themeDay": "Pilsnerkorvens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "Fun and lighthearted, but less meaningful overall."
+          }
+        ]
+      }
+    },
+    {
+      "date": "07-31",
+      "candidateCount": 3,
+      "themeDays": [
+        "Dagen för ovanliga instrument",
+        "Koloniträdgårdens dag",
+        "Världsvänskapsdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Världsvänskapsdagen",
+        "backupThemeDays": [
+          "Koloniträdgårdens dag",
+          "Dagen för ovanliga instrument"
+        ],
+        "reasoning": "Världsvänskapsdagen (World Friendship Day) has broad social appeal and cultural relevance, promoting positive social values and community connection, which resonates well with a general Swedish audience. Koloniträdgårdens dag is seasonally relevant and culturally significant in Sweden due to the popularity of allotment gardens, making it a strong backup. Dagen för ovanliga instrument is more niche and less socially impactful, suitable as a secondary option.",
+        "scores": [
+          {
+            "themeDay": "Världsvänskapsdagen",
+            "audienceAppeal": 9,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong social theme with wide appeal and positive messaging."
+          },
+          {
+            "themeDay": "Koloniträdgårdens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Seasonally relevant and culturally meaningful in Sweden, promotes outdoor activity and community."
+          },
+          {
+            "themeDay": "Dagen för ovanliga instrument",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Interesting niche theme but limited broad appeal or social impact."
+          }
+        ]
+      }
+    },
+    {
+      "date": "08-06",
+      "candidateCount": 3,
+      "themeDays": [
+        "Hiroshimadagen",
+        "Internationella dagen för frisk andedräkt",
+        "Internationella öldagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Hiroshimadagen",
+        "backupThemeDays": [
+          "Internationella öldagen",
+          "Internationella dagen för frisk andedräkt"
+        ],
+        "reasoning": "Hiroshimadagen (Hiroshima Day) is the most meaningful and socially significant observance among the candidates, commemorating the atomic bombing of Hiroshima and promoting peace and nuclear disarmament. It has strong cultural and historical relevance globally and resonates with Swedish values of peace and human rights. Internationella öldagen (International Beer Day) is a popular and fun social observance that can engage a broad audience, making it a good backup. Internationella dagen för frisk andedräkt (International Fresh Breath Day) is less culturally significant and more niche, so it ranks lowest but can still be a lighthearted backup.",
+        "scores": [
+          {
+            "themeDay": "Hiroshimadagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Highly meaningful, promotes peace and reflection, strong cultural relevance."
+          },
+          {
+            "themeDay": "Internationella öldagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Popular social theme, fun and engaging but less serious."
+          },
+          {
+            "themeDay": "Internationella dagen för frisk andedräkt",
+            "audienceAppeal": 5,
+            "culturalRelevance": 3,
+            "socialValue": 4,
+            "novelty": 6,
+            "notes": "Niche and lighthearted, less cultural or social impact."
+          }
+        ]
+      }
+    },
+    {
+      "date": "08-09",
+      "candidateCount": 3,
+      "themeDays": [
+        "Internationella dagen för världens ursprungsfolk",
+        "Mumindagen",
+        "Rulltårtans dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella dagen för världens ursprungsfolk",
+        "backupThemeDays": [
+          "Mumindagen",
+          "Rulltårtans dag"
+        ],
+        "reasoning": "Internationella dagen för världens ursprungsfolk is the most meaningful and socially important observance among the options, highlighting indigenous peoples' rights and cultures globally, which resonates with Sweden's commitment to indigenous Sami issues. Mumindagen is culturally significant and beloved in Nordic countries, providing a strong backup. Rulltårtans dag is a fun, lighthearted food-related day but less impactful socially or culturally.",
+        "scores": [
+          {
+            "themeDay": "Internationella dagen för världens ursprungsfolk",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "Highly meaningful and socially relevant, aligns with indigenous awareness in Sweden."
+          },
+          {
+            "themeDay": "Mumindagen",
+            "audienceAppeal": 9,
+            "culturalRelevance": 8,
+            "socialValue": 7,
+            "novelty": 7,
+            "notes": "Beloved cultural icon in Sweden and Finland, widely recognized and celebrated."
+          },
+          {
+            "themeDay": "Rulltårtans dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 5,
+            "notes": "Fun and lighthearted but less socially or culturally significant."
+          }
+        ]
+      }
+    },
+    {
+      "date": "08-28",
+      "candidateCount": 3,
+      "themeDays": [
+        "Snapsens dag",
+        "Squaredansens dag",
+        "Världsdagen för Turners syndrom"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Snapsens dag",
+        "backupThemeDays": [
+          "Squaredansens dag",
+          "Världsdagen för Turners syndrom"
+        ],
+        "reasoning": "Snapsens dag is a culturally significant and widely recognized day in Sweden, celebrating the traditional Swedish schnapps, which is an integral part of Swedish social and festive culture. It has broad appeal and social value, especially in late summer when many Swedes enjoy outdoor gatherings. Squaredansens dag is culturally relevant but more niche, and Världsdagen för Turners syndrom is important but less widely recognized and less seasonally relevant.",
+        "scores": [
+          {
+            "themeDay": "Snapsens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Strong cultural tradition, widely celebrated in Sweden, especially in summer."
+          },
+          {
+            "themeDay": "Squaredansens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "Niche cultural activity with moderate recognition."
+          },
+          {
+            "themeDay": "Världsdagen för Turners syndrom",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 7,
+            "novelty": 4,
+            "notes": "Important health awareness day but less known and less seasonally relevant."
+          }
+        ]
+      }
+    },
+    {
+      "date": "08-29",
+      "candidateCount": 3,
+      "themeDays": [
+        "Arkeologidagen",
+        "Internationella dagen mot kärnvapenprov",
+        "Porslinets dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Arkeologidagen",
+        "backupThemeDays": [
+          "Internationella dagen mot kärnvapenprov",
+          "Porslinets dag"
+        ],
+        "reasoning": "Arkeologidagen is the most meaningful and culturally relevant theme day for a Swedish audience, highlighting Sweden's rich archaeological heritage and promoting public interest in history and culture. The International Day Against Nuclear Tests is globally important but less directly connected to Swedish cultural identity. Porslinets dag, while unique, has more niche appeal and less broad social value.",
+        "scores": [
+          {
+            "themeDay": "Arkeologidagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Strong cultural connection and educational value in Sweden."
+          },
+          {
+            "themeDay": "Internationella dagen mot kärnvapenprov",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Important global issue but less directly tied to Swedish culture."
+          },
+          {
+            "themeDay": "Porslinets dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Niche interest, less broad appeal but unique and fun."
+          }
+        ]
+      }
+    },
+    {
+      "date": "09-11",
+      "candidateCount": 3,
+      "themeDays": [
+        "Geologins dag",
+        "Kebabens dag",
+        "Vandringens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Vandringens dag",
+        "backupThemeDays": [
+          "Geologins dag",
+          "Kebabens dag"
+        ],
+        "reasoning": "Vandringens dag (Hiking Day) is the most meaningful and socially valuable theme day for a general Swedish audience. Sweden has a strong outdoor culture and appreciation for nature, making hiking a popular and seasonally relevant activity, especially in early November when people might seek outdoor exercise before winter. Geologins dag (Geology Day) is educational and culturally relevant but less broadly engaging. Kebabens dag (Kebab Day) is fun and recognizable but more niche and less socially impactful.",
+        "scores": [
+          {
+            "themeDay": "Vandringens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Strong outdoor culture in Sweden; promotes health and nature appreciation."
+          },
+          {
+            "themeDay": "Geologins dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 5,
+            "novelty": 5,
+            "notes": "Educational and culturally relevant but less engaging for general public."
+          },
+          {
+            "themeDay": "Kebabens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Fun and food-related but niche and less socially meaningful."
+          }
+        ]
+      }
+    },
+    {
+      "date": "09-12",
+      "candidateCount": 3,
+      "themeDays": [
+        "Internationella dagen för syd-syd-samarbete",
+        "Kulturarvsdagen",
+        "TV-spelsdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Kulturarvsdagen",
+        "backupThemeDays": [
+          "TV-spelsdagen",
+          "Internationella dagen för syd-syd-samarbete"
+        ],
+        "reasoning": "Kulturarvsdagen (Heritage Day) is highly relevant and meaningful in Sweden, emphasizing cultural preservation and national identity, which resonates well with a broad audience. It has strong cultural relevance and social value, making it a stable and recognizable theme. TV-spelsdagen (Video Games Day) is a fun and popular theme, appealing especially to younger audiences, while Internationella dagen för syd-syd-samarbete (International Day for South-South Cooperation) is important but less known and less directly relevant to the general Swedish public.",
+        "scores": [
+          {
+            "themeDay": "Kulturarvsdagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Strong cultural and social relevance in Sweden, widely recognized and meaningful."
+          },
+          {
+            "themeDay": "TV-spelsdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 6,
+            "socialValue": 6,
+            "novelty": 7,
+            "notes": "Popular among younger demographics, fun and engaging but less culturally deep."
+          },
+          {
+            "themeDay": "Internationella dagen för syd-syd-samarbete",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Important international theme but less familiar and less directly relevant to Swedish general public."
+          }
+        ]
+      }
+    },
+    {
+      "date": "09-20",
+      "candidateCount": 3,
+      "themeDays": [
+        "Allemansrättens dag",
+        "Bålens dag",
+        "World Cleanup Day"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Allemansrättens dag",
+        "backupThemeDays": [
+          "World Cleanup Day",
+          "Bålens dag"
+        ],
+        "reasoning": "Allemansrättens dag is deeply rooted in Swedish culture, celebrating the unique right of public access to nature, which resonates strongly with the general public and reflects a core Swedish value. It is seasonally relevant in September when outdoor activities are still common. World Cleanup Day is globally recognized and socially valuable but less uniquely Swedish. Bålens dag is more niche and less widely celebrated.",
+        "scores": [
+          {
+            "themeDay": "Allemansrättens dag",
+            "audienceAppeal": 9,
+            "culturalRelevance": 10,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Strong cultural significance and broad appeal in Sweden."
+          },
+          {
+            "themeDay": "World Cleanup Day",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 9,
+            "novelty": 7,
+            "notes": "Global environmental relevance but less uniquely Swedish."
+          },
+          {
+            "themeDay": "Bålens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 5,
+            "notes": "More niche, focused on campfires, less broadly celebrated."
+          }
+        ]
+      }
+    },
+    {
+      "date": "09-22",
+      "candidateCount": 3,
+      "themeDays": [
+        "Hobbitdagen",
+        "Internationella bilfria dagen",
+        "Noshörningens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella bilfria dagen",
+        "backupThemeDays": [
+          "Hobbitdagen",
+          "Noshörningens dag"
+        ],
+        "reasoning": "Internationella bilfria dagen has broad social and environmental relevance, encouraging sustainable transport and urban livability, which aligns well with public interest and policy in Sweden. Hobbitdagen, while culturally recognizable due to Tolkien's popularity, is more niche and entertainment-focused. Noshörningens dag raises awareness for endangered species but has less immediate social impact compared to the car-free day.",
+        "scores": [
+          {
+            "themeDay": "Internationella bilfria dagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong social and environmental relevance; widely recognized internationally and increasingly important in Sweden."
+          },
+          {
+            "themeDay": "Hobbitdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 6,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Popular culture appeal but limited social impact; niche fandom."
+          },
+          {
+            "themeDay": "Noshörningens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Good for conservation awareness but less mainstream and less seasonally relevant."
+          }
+        ]
+      }
+    },
+    {
+      "date": "09-24",
+      "candidateCount": 3,
+      "themeDays": [
+        "Dagvattnets dag",
+        "Janssons-dagen",
+        "Skiljetecknets dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Janssons-dagen",
+        "backupThemeDays": [
+          "Dagvattnets dag",
+          "Skiljetecknets dag"
+        ],
+        "reasoning": "Janssons-dagen is a culturally significant and widely recognized day in Sweden, associated with the traditional dish Janssons frestelse, often enjoyed in late September. It has strong cultural relevance and social value as it ties into Swedish culinary traditions and seasonal gatherings. Dagvattnets dag, while important environmentally, is less known to the general public. Skiljetecknets dag (Punctuation Day) is interesting but more niche and less socially engaging for a broad audience.",
+        "scores": [
+          {
+            "themeDay": "Janssons-dagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Strong cultural tradition, widely recognized, ties to seasonal food culture."
+          },
+          {
+            "themeDay": "Dagvattnets dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Important environmental theme but less known to general public."
+          },
+          {
+            "themeDay": "Skiljetecknets dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Niche interest in language and punctuation, less broad appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "09-25",
+      "candidateCount": 3,
+      "themeDays": [
+        "Äpplets dag",
+        "Internationella farmaceutdagen",
+        "Lösgodisets dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Äpplets dag",
+        "backupThemeDays": [
+          "Lösgodisets dag",
+          "Internationella farmaceutdagen"
+        ],
+        "reasoning": "Äpplets dag is a culturally relevant and seasonally appropriate celebration in Sweden, as apple harvesting is significant in early autumn. It appeals broadly due to the popularity of apples in Swedish cuisine and traditions. Lösgodisets dag is also popular given Sweden's unique candy culture, but it is less seasonally tied. Internationella farmaceutdagen, while important, has a more niche professional focus and less broad public appeal.",
+        "scores": [
+          {
+            "themeDay": "Äpplets dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Strong seasonal and cultural connection with Swedish autumn traditions and food culture."
+          },
+          {
+            "themeDay": "Lösgodisets dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "Popular candy day reflecting Swedish candy culture, but less tied to seasonality."
+          },
+          {
+            "themeDay": "Internationella farmaceutdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 4,
+            "notes": "Professional day with limited general public engagement."
+          }
+        ]
+      }
+    },
+    {
+      "date": "09-27",
+      "candidateCount": 3,
+      "themeDays": [
+        "Hummerpremiären",
+        "Tjänstepensionens dag",
+        "Världsturismdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Hummerpremiären",
+        "backupThemeDays": [
+          "Världsturismdagen",
+          "Tjänstepensionens dag"
+        ],
+        "reasoning": "Hummerpremiären is a culturally significant and widely recognized event in Sweden marking the start of the lobster fishing season, which is eagerly anticipated and celebrated. It has strong seasonal relevance in late September and appeals broadly to the public due to its culinary and traditional importance. Världsturismdagen is globally recognized and socially valuable but less specifically tied to Swedish culture. Tjänstepensionens dag is important but more niche and less engaging for a general audience.",
+        "scores": [
+          {
+            "themeDay": "Hummerpremiären",
+            "audienceAppeal": 9,
+            "culturalRelevance": 9,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Strong cultural and seasonal relevance; widely anticipated food tradition."
+          },
+          {
+            "themeDay": "Världsturismdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 6,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Internationally recognized day promoting tourism; socially valuable but less uniquely Swedish."
+          },
+          {
+            "themeDay": "Tjänstepensionens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 4,
+            "notes": "Important for financial awareness but niche and less engaging for general public."
+          }
+        ]
+      }
+    },
+    {
+      "date": "09-30",
+      "candidateCount": 3,
+      "themeDays": [
+        "International Blasphemy Rights Day",
+        "Internationella dagen för översättning",
+        "Naprapatins dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella dagen för översättning",
+        "backupThemeDays": [
+          "International Blasphemy Rights Day",
+          "Naprapatins dag"
+        ],
+        "reasoning": "Internationella dagen för översättning is the most broadly relevant and socially constructive theme for a Swedish audience, highlighting the importance of translation in a multilingual society and global communication. It has cultural and educational value and is seasonally neutral, making it suitable for a general public calendar. International Blasphemy Rights Day, while important for free speech, is more niche and potentially sensitive. Naprapatins dag is more specialized and less widely recognized.",
+        "scores": [
+          {
+            "themeDay": "Internationella dagen för översättning",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Strong cultural and social relevance in Sweden's multilingual context."
+          },
+          {
+            "themeDay": "International Blasphemy Rights Day",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 7,
+            "notes": "Important for free speech but potentially controversial and less broadly engaging."
+          },
+          {
+            "themeDay": "Naprapatins dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 5,
+            "notes": "More niche health-related observance with limited general appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "10-03",
+      "candidateCount": 3,
+      "themeDays": [
+        "Alla pojkvänners dag",
+        "Den helige Mikaels dag",
+        "Gräddtårtans dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Gräddtårtans dag",
+        "backupThemeDays": [
+          "Alla pojkvänners dag",
+          "Den helige Mikaels dag"
+        ],
+        "reasoning": "Gräddtårtans dag (Cream Cake Day) is a fun, lighthearted food-related celebration that has broad appeal and is seasonally relevant in early October when people enjoy cozy treats. It is more universally engaging and socially shareable than the niche romantic 'Alla pojkvänners dag' (Boyfriends' Day) or the religious 'Den helige Mikaels dag' (Saint Michael's Day), which have more limited audience appeal. Food-themed days tend to perform well in public calendars due to their inclusive and festive nature.",
+        "scores": [
+          {
+            "themeDay": "Gräddtårtans dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Popular food celebration, broadly appealing and seasonally fitting."
+          },
+          {
+            "themeDay": "Alla pojkvänners dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 5,
+            "notes": "Romantic theme but less widely celebrated and more niche."
+          },
+          {
+            "themeDay": "Den helige Mikaels dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 6,
+            "socialValue": 4,
+            "novelty": 4,
+            "notes": "Religious observance with limited general public engagement."
+          }
+        ]
+      }
+    },
+    {
+      "date": "10-06",
+      "candidateCount": 3,
+      "themeDays": [
+        "HSP-dagen",
+        "Internationella CP-dagen",
+        "Nationella anhörigdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Nationella anhörigdagen",
+        "backupThemeDays": [
+          "Internationella CP-dagen",
+          "HSP-dagen"
+        ],
+        "reasoning": "Nationella anhörigdagen is the most socially valuable and culturally relevant theme day for a broad Swedish audience. It highlights the important role of caregivers and family members supporting others, which resonates widely and encourages social support and awareness. Internationella CP-dagen is also meaningful but more specific to cerebral palsy awareness, while HSP-dagen (Highly Sensitive Person day) is more niche and less widely recognized. Therefore, Nationella anhörigdagen leads with the strongest combination of audience appeal and social value.",
+        "scores": [
+          {
+            "themeDay": "Nationella anhörigdagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Broadly relevant and socially important; well recognized in Sweden."
+          },
+          {
+            "themeDay": "Internationella CP-dagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Important for disability awareness but narrower audience."
+          },
+          {
+            "themeDay": "HSP-dagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "More niche and less widely known; appeals to specific groups."
+          }
+        ]
+      }
+    },
+    {
+      "date": "10-08",
+      "candidateCount": 3,
+      "themeDays": [
+        "Äggets dag",
+        "Vägledningens dag",
+        "Världsdyslexidagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Världsdyslexidagen",
+        "backupThemeDays": [
+          "Äggets dag",
+          "Vägledningens dag"
+        ],
+        "reasoning": "Världsdyslexidagen (World Dyslexia Day) has the highest social value and cultural relevance as it raises awareness about dyslexia, a common learning difficulty affecting many people. It promotes inclusivity and understanding, which is meaningful and socially useful. Äggets dag (Egg Day) is a fun and recognizable food-related day but less impactful socially. Vägledningens dag (Guidance Day) is relevant but less widely recognized or celebrated.",
+        "scores": [
+          {
+            "themeDay": "Världsdyslexidagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "Strong social impact and awareness for a common condition; widely relevant."
+          },
+          {
+            "themeDay": "Äggets dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Fun food day, recognizable but less socially impactful."
+          },
+          {
+            "themeDay": "Vägledningens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "Relevant but niche and less widely known."
+          }
+        ]
+      }
+    },
+    {
+      "date": "10-09",
+      "candidateCount": 3,
+      "themeDays": [
+        "Finlandssvenska matkulturdagen",
+        "PANDAS/PANS Awareness Day",
+        "Världspostunionens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Finlandssvenska matkulturdagen",
+        "backupThemeDays": [
+          "Världspostunionens dag",
+          "PANDAS/PANS Awareness Day"
+        ],
+        "reasoning": "Finlandssvenska matkulturdagen is the most culturally relevant and socially engaging theme day for a Swedish audience, highlighting the unique culinary heritage of the Swedish-speaking population in Finland, which resonates well with Swedish cultural interests. Världspostunionens dag is a globally recognized day with moderate cultural relevance, while PANDAS/PANS Awareness Day, though important, is more niche and less widely recognized in Sweden.",
+        "scores": [
+          {
+            "themeDay": "Finlandssvenska matkulturdagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Strong cultural connection and interest in food culture; meaningful for Swedish-speaking audiences."
+          },
+          {
+            "themeDay": "Världspostunionens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "Globally recognized, moderate relevance to Sweden; educational value about postal services."
+          },
+          {
+            "themeDay": "PANDAS/PANS Awareness Day",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Important health awareness day but niche and less known in Sweden."
+          }
+        ]
+      }
+    },
+    {
+      "date": "10-11",
+      "candidateCount": 3,
+      "themeDays": [
+        "Äpplemustens Dag",
+        "Internationella flickdagen",
+        "Internationella komma-ut-dagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella flickdagen",
+        "backupThemeDays": [
+          "Internationella komma-ut-dagen",
+          "Äpplemustens Dag"
+        ],
+        "reasoning": "Internationella flickdagen (International Day of the Girl) is globally recognized and socially significant, promoting awareness of girls' rights and issues, which resonates well in Sweden's socially conscious culture. Internationella komma-ut-dagen (National Coming Out Day) is also important for social inclusion and LGBTQ+ visibility, making it a strong backup. Äpplemustens Dag, while culturally relevant and seasonally appropriate, has more niche appeal compared to the broader social impact of the other two.",
+        "scores": [
+          {
+            "themeDay": "Internationella flickdagen",
+            "audienceAppeal": 9,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "Widely recognized, socially impactful, aligns with Swedish values on equality and children's rights."
+          },
+          {
+            "themeDay": "Internationella komma-ut-dagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Important for LGBTQ+ visibility and acceptance, socially valuable in Sweden."
+          },
+          {
+            "themeDay": "Äpplemustens Dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Seasonally relevant and culturally specific but less broad social impact."
+          }
+        ]
+      }
+    },
+    {
+      "date": "10-12",
+      "candidateCount": 3,
+      "themeDays": [
+        "Ada Lovelace-dagen",
+        "Civilkuragets dag",
+        "Sockerfria dagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Civilkuragets dag",
+        "backupThemeDays": [
+          "Ada Lovelace-dagen",
+          "Sockerfria dagen"
+        ],
+        "reasoning": "Civilkuragets dag (Civil Courage Day) is highly relevant socially and culturally in Sweden, promoting values of bravery and standing up for others, which resonates well with a broad audience. Ada Lovelace-dagen, celebrating a pioneering woman in computing, is meaningful but more niche and technical. Sockerfria dagen (Sugar-Free Day) is health-related and seasonally relevant but less impactful socially compared to Civilkuragets dag.",
+        "scores": [
+          {
+            "themeDay": "Civilkuragets dag",
+            "audienceAppeal": 9,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong social message, widely relatable and culturally significant in Sweden."
+          },
+          {
+            "themeDay": "Ada Lovelace-dagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 6,
+            "novelty": 7,
+            "notes": "Important for promoting women in STEM but more niche and less broadly recognized."
+          },
+          {
+            "themeDay": "Sockerfria dagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 5,
+            "notes": "Health-focused day, less socially impactful but seasonally relevant."
+          }
+        ]
+      }
+    },
+    {
+      "date": "10-18",
+      "candidateCount": 3,
+      "themeDays": [
+        "Chokladmuffins dag",
+        "Internationella klimakteriedagen",
+        "Internationella slipsdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Chokladmuffins dag",
+        "backupThemeDays": [
+          "Internationella klimakteriedagen",
+          "Internationella slipsdagen"
+        ],
+        "reasoning": "Chokladmuffins dag is a fun, lighthearted theme day that appeals broadly to the general public in Sweden, especially as a seasonal treat in autumn. It is culturally relevant due to Sweden's strong fika tradition and love for baked goods. Internationella klimakteriedagen is socially valuable but less widely recognized and may not engage a broad audience as effectively. Internationella slipsdagen is niche and less culturally resonant.",
+        "scores": [
+          {
+            "themeDay": "Chokladmuffins dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "Popular food theme with broad appeal and seasonal relevance."
+          },
+          {
+            "themeDay": "Internationella klimakteriedagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Important health-related observance but less known and less engaging for general audience."
+          },
+          {
+            "themeDay": "Internationella slipsdagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 6,
+            "notes": "Niche theme with limited cultural impact and social value."
+          }
+        ]
+      }
+    },
+    {
+      "date": "10-20",
+      "candidateCount": 3,
+      "themeDays": [
+        "Internationella flygledardagen",
+        "Internationella osteoporosdagen",
+        "Världsdagen för statistik"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella osteoporosdagen",
+        "backupThemeDays": [
+          "Internationella flygledardagen",
+          "Världsdagen för statistik"
+        ],
+        "reasoning": "Internationella osteoporosdagen is the most socially valuable and broadly relevant theme day among the candidates, as it raises awareness about a common health condition affecting many, especially in aging populations like Sweden's. It has higher cultural relevance and social value compared to the more niche or technical themes of air traffic control and statistics. While the other days have their importance, osteoporosis awareness has a clearer impact on public health and personal well-being, making it the best choice for a general audience.",
+        "scores": [
+          {
+            "themeDay": "Internationella osteoporosdagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Strong public health relevance, widely relatable, important for aging population."
+          },
+          {
+            "themeDay": "Internationella flygledardagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "Niche profession, less broad appeal but interesting for aviation enthusiasts."
+          },
+          {
+            "themeDay": "Världsdagen för statistik",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "Important for data awareness but less engaging for general public."
+          }
+        ]
+      }
+    },
+    {
+      "date": "10-22",
+      "candidateCount": 3,
+      "themeDays": [
+        "INTERNATIONELLA CAPS LOCK-DAGEN",
+        "Internationella champagnedagen",
+        "Internationella stamningsdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella stamningsdagen",
+        "backupThemeDays": [
+          "Internationella champagnedagen",
+          "INTERNATIONELLA CAPS LOCK-DAGEN"
+        ],
+        "reasoning": "Internationella stamningsdagen has the highest social value and cultural relevance as it raises awareness about stuttering, a significant speech disorder affecting many people. It promotes understanding and inclusion, which aligns well with socially useful and meaningful themes. Internationella champagnedagen is a fun and recognizable celebration but less socially impactful. INTERNATIONELLA CAPS LOCK-DAGEN is more niche and novelty-focused with lower social value and cultural relevance.",
+        "scores": [
+          {
+            "themeDay": "Internationella stamningsdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "High social impact and awareness; meaningful for many."
+          },
+          {
+            "themeDay": "Internationella champagnedagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 6,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Fun and celebratory but less socially meaningful."
+          },
+          {
+            "themeDay": "INTERNATIONELLA CAPS LOCK-DAGEN",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 8,
+            "notes": "Novelty day with limited social value and cultural relevance."
+          }
+        ]
+      }
+    },
+    {
+      "date": "10-28",
+      "candidateCount": 3,
+      "themeDays": [
+        "Bilens dag",
+        "Internationella animationens dag",
+        "Veckopengens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Bilens dag",
+        "backupThemeDays": [
+          "Internationella animationens dag",
+          "Veckopengens dag"
+        ],
+        "reasoning": "Bilens dag is the most recognizable and socially relevant theme day for a general Swedish audience. Cars and transportation are significant in daily life and culture, making this day broadly appealing. Internationella animationens dag is interesting but more niche, and Veckopengens dag (pocket money day) is less widely recognized and socially impactful.",
+        "scores": [
+          {
+            "themeDay": "Bilens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 8,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Strong general appeal due to importance of cars in Sweden and everyday life."
+          },
+          {
+            "themeDay": "Internationella animationens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Appeals to animation fans and creatives but less broad cultural impact."
+          },
+          {
+            "themeDay": "Veckopengens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "Some social value in promoting financial literacy for kids but less known and celebrated."
+          }
+        ]
+      }
+    },
+    {
+      "date": "11-16",
+      "candidateCount": 3,
+      "themeDays": [
+        "Internationella dagen för tolerans",
+        "Mångkulturella matdagen",
+        "Raggmunkens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella dagen för tolerans",
+        "backupThemeDays": [
+          "Mångkulturella matdagen",
+          "Raggmunkens dag"
+        ],
+        "reasoning": "Internationella dagen för tolerans is the strongest choice due to its broad social value and cultural relevance in Sweden, a country known for its emphasis on inclusivity and diversity. It promotes awareness and acceptance, which aligns well with public interest and social cohesion. Mångkulturella matdagen is a good backup as it celebrates cultural diversity through food, which is engaging and accessible. Raggmunkens dag is more niche and culturally specific, making it less universally appealing but still relevant as a fun, traditional food day.",
+        "scores": [
+          {
+            "themeDay": "Internationella dagen för tolerans",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "Highly relevant socially and culturally; promotes important values of tolerance and inclusion."
+          },
+          {
+            "themeDay": "Mångkulturella matdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 8,
+            "novelty": 7,
+            "notes": "Celebrates diversity through food, which is engaging and accessible to a wide audience."
+          },
+          {
+            "themeDay": "Raggmunkens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 5,
+            "notes": "Traditional Swedish food day, fun but more niche and less socially impactful."
+          }
+        ]
+      }
+    },
+    {
+      "date": "11-18",
+      "candidateCount": 3,
+      "themeDays": [
+        "Adoptionernas dag",
+        "Benbuljongens dag",
+        "Världsfilosofidagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Adoptionernas dag",
+        "backupThemeDays": [
+          "Världsfilosofidagen",
+          "Benbuljongens dag"
+        ],
+        "reasoning": "Adoptionernas dag is the most meaningful and socially valuable theme day among the candidates, highlighting an important social issue with broad emotional resonance in Sweden. Världsfilosofidagen is culturally relevant and intellectually engaging but less widely recognized. Benbuljongens dag is fun and seasonally relevant but more niche and less impactful socially.",
+        "scores": [
+          {
+            "themeDay": "Adoptionernas dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong social importance and emotional connection, widely recognized in Sweden."
+          },
+          {
+            "themeDay": "Världsfilosofidagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Intellectually stimulating and culturally relevant but less mainstream."
+          },
+          {
+            "themeDay": "Benbuljongens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 6,
+            "notes": "Fun and seasonally relevant but niche and less socially impactful."
+          }
+        ]
+      }
+    },
+    {
+      "date": "11-21",
+      "candidateCount": 3,
+      "themeDays": [
+        "Musikfri dag",
+        "Världsdagen för TV",
+        "Världshejardagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Världsdagen för TV",
+        "backupThemeDays": [
+          "Världshejardagen",
+          "Musikfri dag"
+        ],
+        "reasoning": "Världsdagen för TV is the most recognizable and culturally relevant theme day for a broad Swedish audience, given the importance of television in daily life and media consumption. It has high social value as it encourages reflection on the role of TV in society. Världshejardagen is a positive social theme promoting greetings and friendliness, making it a good backup. Musikfri dag, while interesting, has less cultural impact and social value compared to the others.",
+        "scores": [
+          {
+            "themeDay": "Världsdagen för TV",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Widely recognized, culturally significant, encourages media awareness."
+          },
+          {
+            "themeDay": "Världshejardagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 6,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Promotes social friendliness and positive interaction."
+          },
+          {
+            "themeDay": "Musikfri dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Less impactful, niche appeal, novelty in promoting silence from music."
+          }
+        ]
+      }
+    },
+    {
+      "date": "11-28",
+      "candidateCount": 3,
+      "themeDays": [
+        "Flaskmatardagen",
+        "Första advent",
+        "Kattens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Första advent",
+        "backupThemeDays": [
+          "Kattens dag",
+          "Flaskmatardagen"
+        ],
+        "reasoning": "Första advent is a widely recognized and culturally significant day in Sweden, marking the beginning of the Christmas season. It has strong social value as many people participate in traditional celebrations and gatherings. Kattens dag is a popular day for cat lovers and has social appeal but is less culturally significant. Flaskmatardagen is more niche and less broadly recognized.",
+        "scores": [
+          {
+            "themeDay": "Första advent",
+            "audienceAppeal": 9,
+            "culturalRelevance": 10,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Highly recognized, marks start of Christmas season, strong cultural and social significance."
+          },
+          {
+            "themeDay": "Kattens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 6,
+            "socialValue": 6,
+            "novelty": 6,
+            "notes": "Popular among pet owners, moderate cultural relevance."
+          },
+          {
+            "themeDay": "Flaskmatardagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 3,
+            "socialValue": 3,
+            "novelty": 5,
+            "notes": "Niche observance, limited audience appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "12-09",
+      "candidateCount": 3,
+      "themeDays": [
+        "Annadagen",
+        "Läkarsekreterarens dag",
+        "Pepparkakans dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Annadagen",
+        "backupThemeDays": [
+          "Pepparkakans dag",
+          "Läkarsekreterarens dag"
+        ],
+        "reasoning": "Annadagen is a traditional and widely recognized day in Sweden, marking the day after Christmas and associated with cultural and religious significance. It has broad cultural relevance and social value during the holiday season. Pepparkakans dag (Gingerbread Day) is seasonally relevant and fun, appealing to families and festive traditions, making it a good backup. Läkarsekreterarens dag is more niche and professional, with less broad appeal.",
+        "scores": [
+          {
+            "themeDay": "Annadagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 4,
+            "notes": "Widely recognized traditional holiday with cultural and religious significance."
+          },
+          {
+            "themeDay": "Pepparkakans dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Seasonally relevant and fun, linked to popular Christmas baking traditions."
+          },
+          {
+            "themeDay": "Läkarsekreterarens dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 3,
+            "notes": "Professional day with limited general public appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "12-21",
+      "candidateCount": 3,
+      "themeDays": [
+        "Kortfilmens dag",
+        "Skumtomtens dag",
+        "Tomasdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Tomasdagen",
+        "backupThemeDays": [
+          "Kortfilmens dag",
+          "Skumtomtens dag"
+        ],
+        "reasoning": "Tomasdagen is a traditional name day in Sweden and marks an important cultural observance in the Swedish calendar, making it the most recognizable and socially relevant choice for a broad audience. Kortfilmens dag, celebrating short films, is culturally valuable but more niche, while Skumtomtens dag is fun and seasonally relevant but less formal and widely recognized. Therefore, Tomasdagen leads for cultural relevance and social value, with the other two as backups for their unique appeal.",
+        "scores": [
+          {
+            "themeDay": "Tomasdagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Strong traditional and cultural significance as a name day, widely recognized in Sweden."
+          },
+          {
+            "themeDay": "Kortfilmens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 6,
+            "novelty": 7,
+            "notes": "Celebrates short films, appealing to cultural enthusiasts but less mainstream."
+          },
+          {
+            "themeDay": "Skumtomtens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 6,
+            "notes": "Fun and seasonally relevant, tied to Christmas candy tradition, but less formal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "01-04",
+      "candidateCount": 2,
+      "themeDays": [
+        "Punktskriftens dag",
+        "Världshypnosdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Punktskriftens dag",
+        "backupThemeDays": [
+          "Världshypnosdagen"
+        ],
+        "reasoning": "Punktskriftens dag (Braille Day) is more socially valuable and culturally relevant in Sweden as it highlights accessibility and inclusion for visually impaired individuals, which resonates with broader social awareness and support. Världshypnosdagen (World Hypnosis Day) is less known and has lower social impact, making it a suitable backup but not the primary focus.",
+        "scores": [
+          {
+            "themeDay": "Punktskriftens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Strong social value and cultural relevance due to focus on accessibility and inclusion."
+          },
+          {
+            "themeDay": "Världshypnosdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 4,
+            "novelty": 6,
+            "notes": "Less known and lower social impact, but interesting as a backup theme."
+          }
+        ]
+      }
+    },
+    {
+      "date": "01-15",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella fetischdagen",
+        "Tulpanens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Tulpanens dag",
+        "backupThemeDays": [
+          "Internationella fetischdagen"
+        ],
+        "reasoning": "Tulpanens dag (Tulip Day) is a widely recognized and culturally significant day in Sweden, celebrating the beloved tulip flower which is strongly associated with Swedish spring and gardening traditions. It has broad appeal across age groups and is seasonally relevant in January as a symbol of upcoming spring. Internationella fetischdagen is more niche and less socially mainstream, making it less suitable as a primary theme for a general public calendar app.",
+        "scores": [
+          {
+            "themeDay": "Tulpanens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Strong cultural connection to Swedish gardening and spring; broadly appealing and family-friendly."
+          },
+          {
+            "themeDay": "Internationella fetischdagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 3,
+            "socialValue": 2,
+            "novelty": 7,
+            "notes": "Niche interest, limited mainstream appeal, socially sensitive topic."
+          }
+        ]
+      }
+    },
+    {
+      "date": "01-16",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella LCHF-dagen",
+        "Släktforskningens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Släktforskningens dag",
+        "backupThemeDays": [
+          "Internationella LCHF-dagen"
+        ],
+        "reasoning": "Släktforskningens dag (Genealogy Day) has broader cultural relevance and social value in Sweden, where genealogy and family history are popular interests. It appeals to a wide audience including families, history enthusiasts, and educators, making it more meaningful and socially useful. Internationella LCHF-dagen, while relevant to health-conscious individuals, is more niche and less culturally pervasive.",
+        "scores": [
+          {
+            "themeDay": "Släktforskningens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Popular interest in genealogy in Sweden; connects to cultural heritage and family history."
+          },
+          {
+            "themeDay": "Internationella LCHF-dagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "Relevant to health and diet communities but more niche and less broadly recognized."
+          }
+        ]
+      }
+    },
+    {
+      "date": "01-22",
+      "candidateCount": 2,
+      "themeDays": [
+        "Pilsnerfilmens dag",
+        "Vinets dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Vinets dag",
+        "backupThemeDays": [
+          "Pilsnerfilmens dag"
+        ],
+        "reasoning": "Vinets dag (Wine Day) is likely to have broader appeal and cultural relevance in Sweden, as wine consumption and appreciation are popular and socially significant. It also offers opportunities for social gatherings and culinary experiences, making it seasonally relevant and socially valuable. Pilsnerfilmens dag, while interesting, is more niche and less widely recognized, thus scoring lower on audience appeal and social value.",
+        "scores": [
+          {
+            "themeDay": "Vinets dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Widely appreciated theme with social and cultural significance; good for general audience engagement."
+          },
+          {
+            "themeDay": "Pilsnerfilmens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 4,
+            "novelty": 6,
+            "notes": "Niche interest related to a specific film genre; less broad appeal and social relevance."
+          }
+        ]
+      }
+    },
+    {
+      "date": "01-24",
+      "candidateCount": 2,
+      "themeDays": [
+        "Frufridagen",
+        "Världssnödagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Världssnödagen",
+        "backupThemeDays": [
+          "Frufridagen"
+        ],
+        "reasoning": "Världssnödagen (World Snow Day) is more seasonally relevant and socially engaging for a Swedish audience given the country's strong connection to winter sports and outdoor activities. It promotes outdoor activity and community engagement during winter, which aligns well with Swedish cultural values. Frufridagen, while culturally interesting, is less widely recognized and has lower social impact.",
+        "scores": [
+          {
+            "themeDay": "Världssnödagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Strong seasonal relevance and promotes outdoor activity, widely relatable in Sweden."
+          },
+          {
+            "themeDay": "Frufridagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 4,
+            "novelty": 5,
+            "notes": "More niche cultural observance, less widely known or celebrated."
+          }
+        ]
+      }
+    },
+    {
+      "date": "01-25",
+      "candidateCount": 2,
+      "themeDays": [
+        "Halvsnödagen",
+        "Paulusdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Paulusdagen",
+        "backupThemeDays": [
+          "Halvsnödagen"
+        ],
+        "reasoning": "Paulusdagen is a traditional name day in Sweden, recognized culturally and historically, making it more meaningful and widely recognizable to the general Swedish audience. Halvsnödagen, while interesting, is less known and has lower cultural resonance. Paulusdagen's connection to the calendar and name day traditions gives it higher social value and cultural relevance.",
+        "scores": [
+          {
+            "themeDay": "Paulusdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 7,
+            "novelty": 4,
+            "notes": "Traditional name day with cultural recognition in Sweden."
+          },
+          {
+            "themeDay": "Halvsnödagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 6,
+            "notes": "Less known, niche seasonal observance with limited social impact."
+          }
+        ]
+      }
+    },
+    {
+      "date": "01-29",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella pusseldagen",
+        "Veganpizza-dagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella pusseldagen",
+        "backupThemeDays": [
+          "Veganpizza-dagen"
+        ],
+        "reasoning": "Internationella pusseldagen (International Puzzle Day) has broader appeal as it encourages mental activity and family-friendly engagement, which is socially valuable and seasonally relevant during the winter months in Sweden when indoor activities are popular. Veganpizza-dagen, while fun and niche, has a narrower audience and less cultural penetration.",
+        "scores": [
+          {
+            "themeDay": "Internationella pusseldagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Widely relatable and promotes cognitive engagement; suitable for all ages."
+          },
+          {
+            "themeDay": "Veganpizza-dagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 7,
+            "notes": "Appeals to vegan and food enthusiasts but less universal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "01-31",
+      "candidateCount": 2,
+      "themeDays": [
+        "Lönekonsultens dag",
+        "Upp och hoppa-dagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Upp och hoppa-dagen",
+        "backupThemeDays": [
+          "Lönekonsultens dag"
+        ],
+        "reasoning": "Upp och hoppa-dagen is a more universally relatable and uplifting theme day that encourages activity and positivity, which can appeal broadly to the Swedish public. Lönekonsultens dag is quite niche and likely only relevant to a small professional group, making it less suitable as a primary theme for a general audience.",
+        "scores": [
+          {
+            "themeDay": "Upp och hoppa-dagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Encourages positive behavior and is seasonally relevant in winter when motivation can be low."
+          },
+          {
+            "themeDay": "Lönekonsultens dag",
+            "audienceAppeal": 3,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 5,
+            "notes": "Niche professional day with limited general public interest."
+          }
+        ]
+      }
+    },
+    {
+      "date": "02-03",
+      "candidateCount": 2,
+      "themeDays": [
+        "Andningens dag",
+        "Morotskakans dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Andningens dag",
+        "backupThemeDays": [
+          "Morotskakans dag"
+        ],
+        "reasoning": "Andningens dag (Breathing Day) is more meaningful and socially valuable as it can raise awareness about respiratory health, which is universally relevant and important. It has broader cultural and health implications compared to Morotskakans dag (Carrot Cake Day), which is more niche and primarily focused on a specific food item. Therefore, Andningens dag is more likely to engage a wider audience and provide useful information.",
+        "scores": [
+          {
+            "themeDay": "Andningens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Health-related theme with broad relevance and potential for public benefit."
+          },
+          {
+            "themeDay": "Morotskakans dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Fun and lighthearted but less socially impactful and more niche."
+          }
+        ]
+      }
+    },
+    {
+      "date": "02-05",
+      "candidateCount": 2,
+      "themeDays": [
+        "Nutelladagen",
+        "Runebergsdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Runebergsdagen",
+        "backupThemeDays": [
+          "Nutelladagen"
+        ],
+        "reasoning": "Runebergsdagen is a culturally significant day in the Nordic region, especially in Finland and Sweden, celebrating the national poet Johan Ludvig Runeberg. It has historical and literary importance, making it more meaningful and socially valuable for a Swedish audience. Nutelladagen, while fun and popular, is more of a commercial and novelty food day with less cultural depth.",
+        "scores": [
+          {
+            "themeDay": "Runebergsdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Strong cultural and historical significance, well recognized in Sweden and Finland."
+          },
+          {
+            "themeDay": "Nutelladagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 7,
+            "notes": "Fun and lighthearted food-related day, but less culturally meaningful."
+          }
+        ]
+      }
+    },
+    {
+      "date": "02-08",
+      "candidateCount": 2,
+      "themeDays": [
+        "Äggahalvans dag",
+        "Clean Out Your Computer Day"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Äggahalvans dag",
+        "backupThemeDays": [
+          "Clean Out Your Computer Day"
+        ],
+        "reasoning": "Äggahalvans dag is a culturally unique and playful Swedish theme day that resonates well with the local audience, offering a fun and light-hearted observance. Clean Out Your Computer Day, while useful, is more niche and less culturally distinctive in Sweden. Therefore, Äggahalvans dag is prioritized for its stronger cultural relevance and audience appeal.",
+        "scores": [
+          {
+            "themeDay": "Äggahalvans dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 6,
+            "novelty": 7,
+            "notes": "Strong cultural connection and fun, recognizable in Sweden."
+          },
+          {
+            "themeDay": "Clean Out Your Computer Day",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Useful for digital hygiene but less culturally specific and engaging."
+          }
+        ]
+      }
+    },
+    {
+      "date": "02-09",
+      "candidateCount": 2,
+      "themeDays": [
+        "Fettisdagen",
+        "Internationella pannkaksdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Fettisdagen",
+        "backupThemeDays": [
+          "Internationella pannkaksdagen"
+        ],
+        "reasoning": "Fettisdagen is a well-known and widely celebrated Swedish tradition involving semla buns, making it culturally significant and seasonally relevant in early February. It has strong social value as many Swedes participate in this tradition. Internationella pannkaksdagen is less prominent in Sweden and has lower cultural resonance, though it is still a fun food-related day.",
+        "scores": [
+          {
+            "themeDay": "Fettisdagen",
+            "audienceAppeal": 9,
+            "culturalRelevance": 10,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Strong Swedish tradition, widely recognized and celebrated with social gatherings."
+          },
+          {
+            "themeDay": "Internationella pannkaksdagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "International pancake day is fun but less culturally embedded in Sweden compared to Fettisdagen."
+          }
+        ]
+      }
+    },
+    {
+      "date": "02-10",
+      "candidateCount": 2,
+      "themeDays": [
+        "Askonsdagen",
+        "Baljväxtens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Askonsdagen",
+        "backupThemeDays": [
+          "Baljväxtens dag"
+        ],
+        "reasoning": "Askonsdagen (Ash Wednesday) is a significant day in the Christian liturgical calendar, marking the beginning of Lent. It has cultural and religious importance in Sweden, where many people recognize it even if not all observe it religiously. It is more widely known and socially relevant than Baljväxtens dag (Legume Day), which is more niche and focused on food or agriculture. Therefore, Askonsdagen is the stronger choice for broad audience appeal and cultural relevance.",
+        "scores": [
+          {
+            "themeDay": "Askonsdagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 7,
+            "novelty": 4,
+            "notes": "Widely recognized religious observance with cultural significance in Sweden."
+          },
+          {
+            "themeDay": "Baljväxtens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 6,
+            "novelty": 6,
+            "notes": "Niche food/agriculture theme, less broadly known but socially valuable for promoting sustainable eating."
+          }
+        ]
+      }
+    },
+    {
+      "date": "02-11",
+      "candidateCount": 2,
+      "themeDays": [
+        "Int. dagen för kvinnor och flickor inom vetenskap",
+        "Internationella 112-dagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Int. dagen för kvinnor och flickor inom vetenskap",
+        "backupThemeDays": [
+          "Internationella 112-dagen"
+        ],
+        "reasoning": "The International Day of Women and Girls in Science is highly relevant in Sweden, a country that values gender equality and scientific advancement. It promotes social value by encouraging inclusion and empowerment in STEM fields, which aligns well with Swedish societal goals. While International 112 Day is important for emergency awareness, it has less cultural resonance and public engagement compared to the focus on women in science.",
+        "scores": [
+          {
+            "themeDay": "Int. dagen för kvinnor och flickor inom vetenskap",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong cultural relevance due to Sweden's commitment to gender equality and education; socially valuable for promoting STEM inclusion."
+          },
+          {
+            "themeDay": "Internationella 112-dagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Important for public safety awareness but less engaging and culturally resonant than the women in science day."
+          }
+        ]
+      }
+    },
+    {
+      "date": "02-12",
+      "candidateCount": 2,
+      "themeDays": [
+        "Darwins födelsedag",
+        "Vintercyklingens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Darwins födelsedag",
+        "backupThemeDays": [
+          "Vintercyklingens dag"
+        ],
+        "reasoning": "Darwins födelsedag is widely recognized internationally and has strong cultural and educational significance, making it a meaningful and socially valuable theme day for a broad Swedish audience. Vintercyklingens dag is seasonally relevant and promotes healthy, sustainable habits but is more niche and less universally recognized.",
+        "scores": [
+          {
+            "themeDay": "Darwins födelsedag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Well-known historical figure with educational importance; appeals broadly."
+          },
+          {
+            "themeDay": "Vintercyklingens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Seasonally relevant and promotes sustainability but less widely known."
+          }
+        ]
+      }
+    },
+    {
+      "date": "02-13",
+      "candidateCount": 2,
+      "themeDays": [
+        "Tandborstbytardagen",
+        "Världsradiodagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Världsradiodagen",
+        "backupThemeDays": [
+          "Tandborstbytardagen"
+        ],
+        "reasoning": "Världsradiodagen (World Radio Day) has broader cultural relevance and social value as it highlights the importance of radio in communication, education, and entertainment globally, including in Sweden. It is recognized internationally and can engage a wide audience. Tandborstbytardagen (Toothbrush Replacement Day) is more niche and health-specific, with less cultural impact and social engagement potential.",
+        "scores": [
+          {
+            "themeDay": "Världsradiodagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Internationally recognized day promoting media and communication, relevant to many demographics."
+          },
+          {
+            "themeDay": "Tandborstbytardagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Health-related day encouraging good hygiene habits, but less broad appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "02-14",
+      "candidateCount": 2,
+      "themeDays": [
+        "Alla hjärtans dag",
+        "Alla hjärtebarns dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Alla hjärtans dag",
+        "backupThemeDays": [
+          "Alla hjärtebarns dag"
+        ],
+        "reasoning": "Alla hjärtans dag (Valentine's Day) is widely recognized and celebrated in Sweden as a day to express love and affection, making it highly relevant and socially engaging for a broad audience. Alla hjärtebarns dag, while important, is more niche and less widely known, focusing on children with heart conditions, which limits its general appeal. Therefore, Alla hjärtans dag is the strongest choice for leading the theme day on February 14th.",
+        "scores": [
+          {
+            "themeDay": "Alla hjärtans dag",
+            "audienceAppeal": 9,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Widely celebrated, culturally significant, and socially engaging day for expressing love."
+          },
+          {
+            "themeDay": "Alla hjärtebarns dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 4,
+            "notes": "Important awareness day but less known and with a narrower audience."
+          }
+        ]
+      }
+    },
+    {
+      "date": "02-21",
+      "candidateCount": 2,
+      "themeDays": [
+        "Fondvalsdagen",
+        "Internationella dagen för modersmål"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella dagen för modersmål",
+        "backupThemeDays": [
+          "Fondvalsdagen"
+        ],
+        "reasoning": "Internationella dagen för modersmål has broader cultural relevance and social value in Sweden, promoting linguistic diversity and awareness of minority languages, which aligns well with Swedish values of inclusion and education. Fondvalsdagen, while important in the context of personal finance and pensions, is more niche and less widely recognized by the general public.",
+        "scores": [
+          {
+            "themeDay": "Internationella dagen för modersmål",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong cultural and social relevance, widely recognized internationally and locally."
+          },
+          {
+            "themeDay": "Fondvalsdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 4,
+            "notes": "Relevant for financial awareness but niche and less engaging for a general audience."
+          }
+        ]
+      }
+    },
+    {
+      "date": "02-24",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella EBM-dagen",
+        "Sverigefinnarnas dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Sverigefinnarnas dag",
+        "backupThemeDays": [
+          "Internationella EBM-dagen"
+        ],
+        "reasoning": "Sverigefinnarnas dag is a culturally significant day in Sweden that celebrates the Finnish minority, which is an important part of Swedish society and history. It has strong cultural relevance and social value, promoting awareness and inclusion. Internationella EBM-dagen, while important in its field, is more niche and less widely recognized by the general public.",
+        "scores": [
+          {
+            "themeDay": "Sverigefinnarnas dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong cultural and social significance in Sweden, widely recognized and celebrated."
+          },
+          {
+            "themeDay": "Internationella EBM-dagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Relevant to specific professional or academic audiences but less known to the general public."
+          }
+        ]
+      }
+    },
+    {
+      "date": "02-26",
+      "candidateCount": 2,
+      "themeDays": [
+        "Husmanskostens dag",
+        "World Hobby Day"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Husmanskostens dag",
+        "backupThemeDays": [
+          "World Hobby Day"
+        ],
+        "reasoning": "Husmanskostens dag (Traditional Swedish Home Cooking Day) is more culturally relevant and socially valuable for a Swedish audience, celebrating national culinary heritage. It has higher audience appeal due to its connection to Swedish identity and food culture. World Hobby Day is more general and less tied to Swedish culture specifically, making it a suitable backup.",
+        "scores": [
+          {
+            "themeDay": "Husmanskostens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Strong cultural connection to Sweden, promotes traditional cuisine, widely relatable."
+          },
+          {
+            "themeDay": "World Hobby Day",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 6,
+            "notes": "General international observance, encourages hobbies but less specific to Sweden."
+          }
+        ]
+      }
+    },
+    {
+      "date": "02-27",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella isbjörnsdagen",
+        "Meänkielidagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Meänkielidagen",
+        "backupThemeDays": [
+          "Internationella isbjörnsdagen"
+        ],
+        "reasoning": "Meänkielidagen celebrates the Meänkieli language, an important minority language in Sweden, highlighting cultural diversity and linguistic heritage. It has strong cultural relevance and social value within Sweden, promoting awareness and pride in minority cultures. Internationella isbjörnsdagen, while globally recognized and related to environmental awareness, is less culturally specific to Sweden and has lower direct social impact for the general Swedish audience on this date.",
+        "scores": [
+          {
+            "themeDay": "Meänkielidagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Strong cultural and social significance in Sweden, promotes minority language awareness."
+          },
+          {
+            "themeDay": "Internationella isbjörnsdagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 7,
+            "notes": "Relevant to environmental concerns and wildlife, but less culturally specific to Sweden."
+          }
+        ]
+      }
+    },
+    {
+      "date": "03-01",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella dagen mot diskriminering",
+        "Krama en bibliotekarie-dagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella dagen mot diskriminering",
+        "backupThemeDays": [
+          "Krama en bibliotekarie-dagen"
+        ],
+        "reasoning": "Internationella dagen mot diskriminering is a globally recognized day with strong social value and cultural relevance in Sweden, promoting awareness and action against discrimination. It aligns well with public interest and social justice themes, making it more meaningful and impactful for a broad audience. Krama en bibliotekarie-dagen is a fun and lighthearted alternative but has less cultural weight and social impact.",
+        "scores": [
+          {
+            "themeDay": "Internationella dagen mot diskriminering",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong social message, widely relevant, promotes inclusivity and awareness."
+          },
+          {
+            "themeDay": "Krama en bibliotekarie-dagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Fun and quirky, promotes libraries and librarians but less impactful socially."
+          }
+        ]
+      }
+    },
+    {
+      "date": "03-04",
+      "candidateCount": 2,
+      "themeDays": [
+        "Bananens dag",
+        "Fössta Tossdan i Mass"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Fössta Tossdan i Mass",
+        "backupThemeDays": [
+          "Bananens dag"
+        ],
+        "reasoning": "Fössta Tossdan i Mass is a beloved and culturally significant local celebration in Småland, Sweden, recognized for its unique dialect and fun tradition of eating marzipan buns. It has strong regional cultural relevance and social value, making it more meaningful and engaging for a Swedish audience than the more generic Bananens dag.",
+        "scores": [
+          {
+            "themeDay": "Fössta Tossdan i Mass",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 7,
+            "notes": "Strong regional cultural significance and widely celebrated in Småland, making it meaningful and fun."
+          },
+          {
+            "themeDay": "Bananens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 4,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "A fun food-related day but less culturally significant and less socially impactful."
+          }
+        ]
+      }
+    },
+    {
+      "date": "03-05",
+      "candidateCount": 2,
+      "themeDays": [
+        "Ostbågens dag",
+        "Världsböndagen för fred"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Världsböndagen för fred",
+        "backupThemeDays": [
+          "Ostbågens dag"
+        ],
+        "reasoning": "Världsböndagen för fred (World Day of Prayer for Peace) carries significant cultural and social value, promoting peace and unity, which resonates broadly with the Swedish public and aligns with socially meaningful observances. Ostbågens dag, while fun and lighthearted, is more niche and less impactful on a societal level, making it a suitable backup.",
+        "scores": [
+          {
+            "themeDay": "Världsböndagen för fred",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "Strong social and cultural relevance with broad appeal due to its peace-promoting message."
+          },
+          {
+            "themeDay": "Ostbågens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Fun and quirky, but less socially impactful and more niche in appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "03-06",
+      "candidateCount": 2,
+      "themeDays": [
+        "Europeiska logopeddagen",
+        "Nolltaxedagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Europeiska logopeddagen",
+        "backupThemeDays": [
+          "Nolltaxedagen"
+        ],
+        "reasoning": "Europeiska logopeddagen (European Speech Therapist Day) is more meaningful and socially valuable as it raises awareness about speech therapy, communication disorders, and support for affected individuals, which has broad social relevance. Nolltaxedagen (Zero Tax Day) is less widely recognized and may have niche appeal related to tax policy or economics, making it less suitable as a primary theme for a general audience.",
+        "scores": [
+          {
+            "themeDay": "Europeiska logopeddagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Strong social value and cultural relevance in healthcare and education; moderately appealing to general public."
+          },
+          {
+            "themeDay": "Nolltaxedagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "Niche appeal related to tax awareness; less culturally prominent and socially engaging."
+          }
+        ]
+      }
+    },
+    {
+      "date": "03-07",
+      "candidateCount": 2,
+      "themeDays": [
+        "Podcastens dag",
+        "Punschrullens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Punschrullens dag",
+        "backupThemeDays": [
+          "Podcastens dag"
+        ],
+        "reasoning": "Punschrullens dag is a culturally significant and widely recognized day in Sweden, celebrating a beloved traditional Swedish pastry. It has strong cultural relevance and social value as it encourages community and enjoyment of Swedish culinary heritage. Podcastens dag, while modern and growing in popularity, is less established and has lower cultural resonance compared to Punschrullens dag.",
+        "scores": [
+          {
+            "themeDay": "Punschrullens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Strong cultural connection and popular traditional treat; widely celebrated in Sweden."
+          },
+          {
+            "themeDay": "Podcastens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 6,
+            "socialValue": 6,
+            "novelty": 7,
+            "notes": "Modern media celebration with growing interest but less traditional significance."
+          }
+        ]
+      }
+    },
+    {
+      "date": "03-10",
+      "candidateCount": 2,
+      "themeDays": [
+        "Super Mario-dagen",
+        "V8-motorns dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Super Mario-dagen",
+        "backupThemeDays": [
+          "V8-motorns dag"
+        ],
+        "reasoning": "Super Mario-dagen is more widely recognized and culturally relevant, especially among a broad audience including younger people and gamers. It has a fun and nostalgic appeal that can engage many users. V8-motorns dag is more niche, appealing mainly to car enthusiasts, which limits its general social value and audience appeal.",
+        "scores": [
+          {
+            "themeDay": "Super Mario-dagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "Widely recognized gaming icon with broad appeal and cultural impact."
+          },
+          {
+            "themeDay": "V8-motorns dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 4,
+            "novelty": 4,
+            "notes": "Niche interest in automotive culture, less broad appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "03-11",
+      "candidateCount": 2,
+      "themeDays": [
+        "Rörmokeriets världsdag",
+        "Världsnjurdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Världsnjurdagen",
+        "backupThemeDays": [
+          "Rörmokeriets världsdag"
+        ],
+        "reasoning": "Världsnjurdagen (World Kidney Day) has broader health and social relevance, raising awareness about kidney health which affects a significant portion of the population. It is more meaningful and recognizable to the general public compared to Rörmokeriets världsdag (World Plumbing Day), which, while important, is more niche and less directly impactful on everyday health awareness.",
+        "scores": [
+          {
+            "themeDay": "Världsnjurdagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Strong health awareness day with broad social impact and recognition."
+          },
+          {
+            "themeDay": "Rörmokeriets världsdag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 6,
+            "notes": "Important for infrastructure and hygiene awareness but less directly engaging for general public."
+          }
+        ]
+      }
+    },
+    {
+      "date": "03-13",
+      "candidateCount": 2,
+      "themeDays": [
+        "Källkritikens dag",
+        "Mazarindagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Källkritikens dag",
+        "backupThemeDays": [
+          "Mazarindagen"
+        ],
+        "reasoning": "Källkritikens dag (Source Criticism Day) is highly relevant in today's information-rich society, promoting critical thinking and media literacy, which are socially valuable and culturally significant in Sweden. Mazarindagen, while culturally recognized, is more niche and less impactful socially.",
+        "scores": [
+          {
+            "themeDay": "Källkritikens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "Promotes critical thinking and media literacy, highly relevant and socially valuable."
+          },
+          {
+            "themeDay": "Mazarindagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 5,
+            "novelty": 5,
+            "notes": "Culturally recognized but more niche and less socially impactful."
+          }
+        ]
+      }
+    },
+    {
+      "date": "03-15",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella konsumentdagen",
+        "NPF-dagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella konsumentdagen",
+        "backupThemeDays": [
+          "NPF-dagen"
+        ],
+        "reasoning": "Internationella konsumentdagen has broader appeal and relevance to the general public in Sweden, focusing on consumer rights and awareness which affects everyone. It is socially valuable and widely recognized internationally, making it seasonally and culturally relevant. NPF-dagen, while important, is more specialized and may resonate less with the general audience.",
+        "scores": [
+          {
+            "themeDay": "Internationella konsumentdagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Broadly relevant consumer rights day with international recognition."
+          },
+          {
+            "themeDay": "NPF-dagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Important for awareness of neuropsychiatric disabilities but more niche."
+          }
+        ]
+      }
+    },
+    {
+      "date": "03-22",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella vattendagen",
+        "Kennethdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella vattendagen",
+        "backupThemeDays": [
+          "Kennethdagen"
+        ],
+        "reasoning": "Internationella vattendagen (World Water Day) is globally recognized and socially important, highlighting water conservation and sustainability issues relevant to Sweden and the world. It has broad cultural relevance and social value, making it the strongest choice. Kennethdagen, while culturally recognized in Sweden, is more niche and less impactful socially or environmentally.",
+        "scores": [
+          {
+            "themeDay": "Internationella vattendagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Widely recognized international day with strong environmental and social significance."
+          },
+          {
+            "themeDay": "Kennethdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 3,
+            "novelty": 5,
+            "notes": "Name day with cultural relevance but limited social impact or broad appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "03-24",
+      "candidateCount": 2,
+      "themeDays": [
+        "Europeiska dagen för hantverksmässigt tillverkad glass",
+        "Int. dagen för rätt till sanning om grova kränkningar av de mänskliga rättigheterna..."
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Europeiska dagen för hantverksmässigt tillverkad glass",
+        "backupThemeDays": [
+          "Int. dagen för rätt till sanning om grova kränkningar av de mänskliga rättigheterna"
+        ],
+        "reasoning": "The European Day for Artisanally Made Ice Cream is a light, fun, and seasonally relevant theme day that resonates well with a broad Swedish audience, especially as spring approaches and people start enjoying outdoor treats. It is culturally engaging and socially positive, encouraging local craftsmanship and enjoyment. The International Day for the Right to Truth about Gross Human Rights Violations is highly important but more solemn and niche, making it better suited as a backup for a general public calendar.",
+        "scores": [
+          {
+            "themeDay": "Europeiska dagen för hantverksmässigt tillverkad glass",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "Appealing and seasonally relevant; promotes local artisan culture."
+          },
+          {
+            "themeDay": "Int. dagen för rätt till sanning om grova kränkningar av de mänskliga rättigheterna",
+            "audienceAppeal": 5,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 4,
+            "notes": "Highly important socially and culturally but more serious and less broadly engaging."
+          }
+        ]
+      }
+    },
+    {
+      "date": "03-26",
+      "candidateCount": 2,
+      "themeDays": [
+        "Arbetsplatsombudens dag",
+        "Dialersystemens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Arbetsplatsombudens dag",
+        "backupThemeDays": [
+          "Dialersystemens dag"
+        ],
+        "reasoning": "Arbetsplatsombudens dag is more socially relevant and meaningful in Sweden as it highlights the role of workplace representatives who contribute to better working conditions and labor rights, which resonates broadly with the Swedish workforce and society. Dialersystemens dag is more niche and technical, with limited general public appeal.",
+        "scores": [
+          {
+            "themeDay": "Arbetsplatsombudens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Strong social and cultural relevance due to Sweden's focus on labor rights and workplace democracy."
+          },
+          {
+            "themeDay": "Dialersystemens dag",
+            "audienceAppeal": 3,
+            "culturalRelevance": 3,
+            "socialValue": 2,
+            "novelty": 4,
+            "notes": "Niche technical theme with limited appeal beyond specific professional groups."
+          }
+        ]
+      }
+    },
+    {
+      "date": "03-27",
+      "candidateCount": 2,
+      "themeDays": [
+        "Påskafton",
+        "Världsteaterdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Påskafton",
+        "backupThemeDays": [
+          "Världsteaterdagen"
+        ],
+        "reasoning": "Påskafton (Easter Saturday) is a widely recognized and culturally significant day in Sweden, associated with family gatherings, traditional celebrations, and public holidays. It has strong seasonal relevance as it falls in spring and is part of the major Easter holiday period. Världsteaterdagen (World Theatre Day) is important but more niche and less broadly celebrated by the general public.",
+        "scores": [
+          {
+            "themeDay": "Påskafton",
+            "audienceAppeal": 9,
+            "culturalRelevance": 10,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Highly recognized and celebrated in Sweden with strong cultural traditions and public holiday status."
+          },
+          {
+            "themeDay": "Världsteaterdagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 6,
+            "novelty": 7,
+            "notes": "Important for arts and culture communities but less prominent among the general population."
+          }
+        ]
+      }
+    },
+    {
+      "date": "03-31",
+      "candidateCount": 2,
+      "themeDays": [
+        "Kullerbyttans dag",
+        "Världsbackupdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Kullerbyttans dag",
+        "backupThemeDays": [
+          "Världsbackupdagen"
+        ],
+        "reasoning": "Kullerbyttans dag, which translates to 'Somersault Day,' is a playful and physically engaging theme day that can appeal broadly to families, schools, and individuals interested in fun physical activity. It encourages movement and joy, which aligns well with social and health values. Världsbackupdagen (World Backup Day) is important for digital awareness but is more niche and less culturally resonant in Sweden compared to a fun, active day like Kullerbyttans dag.",
+        "scores": [
+          {
+            "themeDay": "Kullerbyttans dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Fun, active, and engaging for a broad audience; promotes physical activity and joy."
+          },
+          {
+            "themeDay": "Världsbackupdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Important for digital safety awareness but less engaging and less culturally embedded."
+          }
+        ]
+      }
+    },
+    {
+      "date": "04-02",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella barnboksdagen",
+        "Studenternas dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella barnboksdagen",
+        "backupThemeDays": [
+          "Studenternas dag"
+        ],
+        "reasoning": "Internationella barnboksdagen (International Children's Book Day) is widely recognized and celebrated in Sweden, promoting literacy and children's literature, which has broad cultural and educational significance. It appeals to families, educators, and the general public, making it socially valuable and seasonally relevant. Studenternas dag, while important, is more niche and less universally engaging.",
+        "scores": [
+          {
+            "themeDay": "Internationella barnboksdagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong cultural and educational significance; widely recognized in Sweden."
+          },
+          {
+            "themeDay": "Studenternas dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "Relevant mainly to students and academic communities; less broad appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "04-07",
+      "candidateCount": 2,
+      "themeDays": [
+        "National Walking Day",
+        "Världshälsodagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Världshälsodagen",
+        "backupThemeDays": [
+          "National Walking Day"
+        ],
+        "reasoning": "Världshälsodagen (World Health Day) is a globally recognized day with strong cultural relevance and social value in Sweden, promoting awareness about health issues which is broadly meaningful and socially useful. National Walking Day, while positive and health-related, is less widely recognized and has lower cultural impact in Sweden compared to Världshälsodagen.",
+        "scores": [
+          {
+            "themeDay": "Världshälsodagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Widely recognized health awareness day with strong social impact."
+          },
+          {
+            "themeDay": "National Walking Day",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Promotes physical activity but less known and less culturally significant in Sweden."
+          }
+        ]
+      }
+    },
+    {
+      "date": "04-15",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella biomedicinska analytikerdagen",
+        "Världens konstdag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Världens konstdag",
+        "backupThemeDays": [
+          "Internationella biomedicinska analytikerdagen"
+        ],
+        "reasoning": "Världens konstdag (World Art Day) has broader cultural appeal and is more likely to engage a general Swedish audience interested in arts and culture. It is seasonally relevant in spring, a time when cultural activities pick up. Internationella biomedicinska analytikerdagen is more niche and specialized, appealing mainly to professionals in biomedical analysis, thus less suitable as a primary theme for a general public calendar.",
+        "scores": [
+          {
+            "themeDay": "Världens konstdag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 8,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Widely relatable theme celebrating art, accessible to broad audiences."
+          },
+          {
+            "themeDay": "Internationella biomedicinska analytikerdagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "Important professional day but niche and less engaging for general public."
+          }
+        ]
+      }
+    },
+    {
+      "date": "04-18",
+      "candidateCount": 2,
+      "themeDays": [
+        "Amatörradions dag",
+        "Internationella dagen för monument och platser"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella dagen för monument och platser",
+        "backupThemeDays": [
+          "Amatörradions dag"
+        ],
+        "reasoning": "Internationella dagen för monument och platser has broader cultural relevance and social value in Sweden, a country with rich historical heritage and many protected sites. It encourages public awareness and preservation of cultural landmarks, which resonates well with a general audience. Amatörradions dag, while interesting, appeals to a more niche group of radio enthusiasts and has less widespread recognition.",
+        "scores": [
+          {
+            "themeDay": "Internationella dagen för monument och platser",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Strong cultural and social relevance; promotes heritage awareness."
+          },
+          {
+            "themeDay": "Amatörradions dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Niche interest group; less broad appeal but unique."
+          }
+        ]
+      }
+    },
+    {
+      "date": "04-20",
+      "candidateCount": 2,
+      "themeDays": [
+        "Polkagrisens dag",
+        "Svenska gin & tonic-dagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Polkagrisens dag",
+        "backupThemeDays": [
+          "Svenska gin & tonic-dagen"
+        ],
+        "reasoning": "Polkagrisens dag is more culturally relevant and widely recognized in Sweden as it celebrates a traditional Swedish candy originating from Gränna, making it seasonally and socially meaningful. Svenska gin & tonic-dagen, while fun, is more niche and less culturally significant.",
+        "scores": [
+          {
+            "themeDay": "Polkagrisens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Strong cultural ties and traditional Swedish confectionery make it appealing and relevant."
+          },
+          {
+            "themeDay": "Svenska gin & tonic-dagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "More niche, appeals to adult beverage enthusiasts but less broadly recognized."
+          }
+        ]
+      }
+    },
+    {
+      "date": "04-23",
+      "candidateCount": 2,
+      "themeDays": [
+        "Sankt Georgsdagen",
+        "Världsbokdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Världsbokdagen",
+        "backupThemeDays": [
+          "Sankt Georgsdagen"
+        ],
+        "reasoning": "Världsbokdagen (World Book Day) is widely recognized internationally and promotes reading and literacy, which has broad social value and cultural relevance in Sweden. It is a meaningful and socially useful observance that appeals to a general audience. Sankt Georgsdagen, while culturally significant in some regions, is less universally recognized and has lower social impact compared to Världsbokdagen.",
+        "scores": [
+          {
+            "themeDay": "Världsbokdagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Strong international recognition and promotes reading, which is socially valuable and culturally relevant in Sweden."
+          },
+          {
+            "themeDay": "Sankt Georgsdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 4,
+            "novelty": 6,
+            "notes": "Culturally significant but less widely celebrated; lower social impact compared to World Book Day."
+          }
+        ]
+      }
+    },
+    {
+      "date": "04-25",
+      "candidateCount": 2,
+      "themeDays": [
+        "Lekens dag",
+        "Mamatummy Day"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Lekens dag",
+        "backupThemeDays": [
+          "Mamatummy Day"
+        ],
+        "reasoning": "Lekens dag (Play Day) is more universally recognized and socially valuable in Sweden, promoting play and well-being across all ages. It has broader cultural relevance and appeal compared to Mamatummy Day, which is more niche and less widely known. Play is seasonally relevant in spring as people spend more time outdoors, making it a meaningful theme day to highlight.",
+        "scores": [
+          {
+            "themeDay": "Lekens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Widely appreciated theme promoting play and well-being, relevant to all ages and culturally significant in Sweden."
+          },
+          {
+            "themeDay": "Mamatummy Day",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Niche focus on post-pregnancy body awareness; less broadly recognized but offers some social value."
+          }
+        ]
+      }
+    },
+    {
+      "date": "04-29",
+      "candidateCount": 2,
+      "themeDays": [
+        "Dansens dag",
+        "Svenska friluftsdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Dansens dag",
+        "backupThemeDays": [
+          "Svenska friluftsdagen"
+        ],
+        "reasoning": "Dansens dag is a widely recognized and celebrated cultural event in Sweden, promoting dance as an art form and physical activity, which appeals broadly across age groups and regions. It has strong cultural relevance and social value, encouraging community participation and enjoyment. Svenska friluftsdagen, while important for promoting outdoor activities and appreciation of nature, is less universally celebrated and may have more niche appeal compared to the vibrant cultural celebration of dance.",
+        "scores": [
+          {
+            "themeDay": "Dansens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Strong cultural tradition, widely celebrated, promotes physical activity and community engagement."
+          },
+          {
+            "themeDay": "Svenska friluftsdagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Encourages outdoor activities and nature appreciation but has a narrower audience and less widespread recognition."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-03",
+      "candidateCount": 2,
+      "themeDays": [
+        "Asociala dagen",
+        "Internationella dagen för pressfrihet"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella dagen för pressfrihet",
+        "backupThemeDays": [
+          "Asociala dagen"
+        ],
+        "reasoning": "Internationella dagen för pressfrihet is a globally recognized observance that highlights the importance of free press, which is crucial for democracy and informed societies. It has strong cultural relevance and social value in Sweden, a country known for valuing freedom of expression and transparent media. Asociala dagen, while potentially interesting, is less recognized and has lower social impact.",
+        "scores": [
+          {
+            "themeDay": "Internationella dagen för pressfrihet",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Highly relevant and meaningful in Sweden; promotes awareness of press freedom."
+          },
+          {
+            "themeDay": "Asociala dagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 6,
+            "notes": "Less known and less impactful socially; more niche and novelty-focused."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-07",
+      "candidateCount": 2,
+      "themeDays": [
+        "Grillens dag",
+        "Internationella tubadagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Grillens dag",
+        "backupThemeDays": [
+          "Internationella tubadagen"
+        ],
+        "reasoning": "Grillens dag (Grill Day) is highly seasonally relevant in Sweden during early July when outdoor grilling is popular. It has broad cultural appeal as grilling is a common social activity in Swedish summer life. Internationella tubadagen (International Tuba Day) is more niche and appeals mainly to musicians and enthusiasts, making it less broadly engaging. Therefore, Grillens dag is the strongest choice for a general audience.",
+        "scores": [
+          {
+            "themeDay": "Grillens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Strong seasonal and cultural relevance; widely relatable and fun."
+          },
+          {
+            "themeDay": "Internationella tubadagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 3,
+            "socialValue": 3,
+            "novelty": 6,
+            "notes": "Niche musical interest; less broad appeal but unique."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-13",
+      "candidateCount": 2,
+      "themeDays": [
+        "Porträttfotots dag",
+        "Receptionistens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Porträttfotots dag",
+        "backupThemeDays": [
+          "Receptionistens dag"
+        ],
+        "reasoning": "Porträttfotots dag (Portrait Photography Day) has broader cultural appeal as photography is a popular hobby and art form in Sweden, engaging a wide audience interested in creativity and visual storytelling. Receptionistens dag, while important, is more niche and workplace-specific, appealing mainly to professionals in that role. Therefore, Porträttfotots dag is more likely to resonate with a general public audience and encourage participation or awareness.",
+        "scores": [
+          {
+            "themeDay": "Porträttfotots dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "Appeals broadly to photography enthusiasts and the general public interested in arts and culture."
+          },
+          {
+            "themeDay": "Receptionistens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 4,
+            "notes": "Recognizes an important but specific professional group; less broad appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-14",
+      "candidateCount": 2,
+      "themeDays": [
+        "Rumpans dag",
+        "Svenska teckenspråkets dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Svenska teckenspråkets dag",
+        "backupThemeDays": [
+          "Rumpans dag"
+        ],
+        "reasoning": "Svenska teckenspråkets dag (Swedish Sign Language Day) is a meaningful and socially valuable observance that raises awareness about the deaf community and promotes inclusivity. It has strong cultural relevance in Sweden and supports social inclusion, making it a priority for a public-facing calendar app. Rumpans dag, while fun and lighthearted, is less culturally significant and socially impactful.",
+        "scores": [
+          {
+            "themeDay": "Svenska teckenspråkets dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Highly relevant to Swedish culture and promotes social inclusion."
+          },
+          {
+            "themeDay": "Rumpans dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Fun and quirky but less socially meaningful."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-18",
+      "candidateCount": 2,
+      "themeDays": [
+        "Fascinerande växters dag",
+        "Internationella museidagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella museidagen",
+        "backupThemeDays": [
+          "Fascinerande växters dag"
+        ],
+        "reasoning": "Internationella museidagen is widely recognized and celebrated internationally, including in Sweden, promoting cultural awareness and education. Museums are important cultural institutions in Sweden, making this day socially valuable and culturally relevant. Fascinerande växters dag, while interesting, has a narrower appeal and less cultural prominence.",
+        "scores": [
+          {
+            "themeDay": "Internationella museidagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Strong cultural and educational relevance; widely recognized internationally and in Sweden."
+          },
+          {
+            "themeDay": "Fascinerande växters dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Appealing to nature enthusiasts; less known and less socially impactful than museum day."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-22",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella dagen för biologiskt mångfald",
+        "Picknickens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella dagen för biologiskt mångfald",
+        "backupThemeDays": [
+          "Picknickens dag"
+        ],
+        "reasoning": "Internationella dagen för biologiskt mångfald is globally recognized and highly relevant in Sweden due to the country's strong environmental values and commitment to biodiversity. It has significant cultural and social value, promoting awareness and action on important ecological issues. Picknickens dag is a pleasant, fun day but less impactful in terms of social and cultural relevance.",
+        "scores": [
+          {
+            "themeDay": "Internationella dagen för biologiskt mångfald",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong environmental awareness in Sweden makes this day highly relevant and meaningful."
+          },
+          {
+            "themeDay": "Picknickens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Fun and seasonally appropriate but less socially impactful than biodiversity day."
+          }
+        ]
+      }
+    },
+    {
+      "date": "05-24",
+      "candidateCount": 2,
+      "themeDays": [
+        "Nationalparkernas dag",
+        "Religionstraumadagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Nationalparkernas dag",
+        "backupThemeDays": [
+          "Religionstraumadagen"
+        ],
+        "reasoning": "Nationalparkernas dag is a well-recognized and positive theme day in Sweden that promotes outdoor activities, nature appreciation, and environmental awareness, which aligns well with Swedish cultural values and seasonal relevance in late May. Religionstraumadagen, while important, is more niche and sensitive, potentially less engaging for a broad public audience.",
+        "scores": [
+          {
+            "themeDay": "Nationalparkernas dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Strong appeal due to Sweden's outdoor culture and environmental focus; widely recognized and family-friendly."
+          },
+          {
+            "themeDay": "Religionstraumadagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "Important for awareness but less mainstream and potentially sensitive topic, limiting broad appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "06-02",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella artrosdagen",
+        "Internationella dagen mot ätstörningar"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella dagen mot ätstörningar",
+        "backupThemeDays": [
+          "Internationella artrosdagen"
+        ],
+        "reasoning": "Internationella dagen mot ätstörningar is prioritized due to its strong social value and relevance in raising awareness about mental health issues, which are highly significant in Sweden. Eating disorders affect a broad demographic and addressing them publicly can foster understanding and support. Internationella artrosdagen, while important, is more niche and less socially urgent in public discourse.",
+        "scores": [
+          {
+            "themeDay": "Internationella dagen mot ätstörningar",
+            "audienceAppeal": 8,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "High social value and relevance to mental health awareness, which is a growing focus in Sweden."
+          },
+          {
+            "themeDay": "Internationella artrosdagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Important for awareness of arthritis but less broad appeal and urgency compared to eating disorders."
+          }
+        ]
+      }
+    },
+    {
+      "date": "06-03",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella cykeldagen",
+        "Internationella klumpfotsdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella cykeldagen",
+        "backupThemeDays": [
+          "Internationella klumpfotsdagen"
+        ],
+        "reasoning": "Internationella cykeldagen has broader appeal and relevance in Sweden, a country known for its strong cycling culture and emphasis on sustainable transportation. It encourages outdoor activity and environmental awareness, which are socially valuable and seasonally relevant in early June. Internationella klumpfotsdagen, while important, is more niche and less widely recognized among the general public.",
+        "scores": [
+          {
+            "themeDay": "Internationella cykeldagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Strong cultural connection to cycling in Sweden, promotes health and environment."
+          },
+          {
+            "themeDay": "Internationella klumpfotsdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Important for awareness but less known and less seasonally engaging."
+          }
+        ]
+      }
+    },
+    {
+      "date": "06-04",
+      "candidateCount": 2,
+      "themeDays": [
+        "Assistansens dag",
+        "Internationella donutdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Assistansens dag",
+        "backupThemeDays": [
+          "Internationella donutdagen"
+        ],
+        "reasoning": "Assistansens dag is more meaningful and socially valuable for a Swedish audience as it highlights the importance of personal assistance and inclusion for people with disabilities, which aligns with Sweden's strong social welfare values. Internationella donutdagen, while fun and internationally recognized, is less culturally significant and socially impactful in Sweden.",
+        "scores": [
+          {
+            "themeDay": "Assistansens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Strong social relevance and cultural importance in Sweden, promoting awareness of personal assistance."
+          },
+          {
+            "themeDay": "Internationella donutdagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 3,
+            "novelty": 7,
+            "notes": "Fun and lighthearted but less culturally significant or socially impactful in Sweden."
+          }
+        ]
+      }
+    },
+    {
+      "date": "06-08",
+      "candidateCount": 2,
+      "themeDays": [
+        "Ride to Work Day",
+        "Världshavens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Världshavens dag",
+        "backupThemeDays": [
+          "Ride to Work Day"
+        ],
+        "reasoning": "Världshavens dag (World Oceans Day) is globally recognized and highly relevant in Sweden due to the country's extensive coastline and strong environmental awareness. It promotes ocean conservation, which aligns well with Swedish values on sustainability and nature protection. Ride to Work Day, while positive and health-oriented, is less prominent and has a narrower appeal compared to the environmental significance of Världshavens dag.",
+        "scores": [
+          {
+            "themeDay": "Världshavens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong environmental theme, widely recognized, aligns with Swedish coastal culture and sustainability values."
+          },
+          {
+            "themeDay": "Ride to Work Day",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Promotes healthy commuting and sustainability but less prominent and less culturally embedded than Världshavens dag."
+          }
+        ]
+      }
+    },
+    {
+      "date": "06-09",
+      "candidateCount": 2,
+      "themeDays": [
+        "Brickbandens dag",
+        "Internationella arkivdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella arkivdagen",
+        "backupThemeDays": [
+          "Brickbandens dag"
+        ],
+        "reasoning": "Internationella arkivdagen (International Archives Day) has broader cultural and social relevance as it highlights the importance of preserving historical records and cultural heritage, which resonates well with a general audience interested in history, culture, and education. Brickbandens dag, while fun and niche, appeals more to a specific hobbyist group and is less universally recognized or socially impactful.",
+        "scores": [
+          {
+            "themeDay": "Internationella arkivdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Widely relevant to culture and education, promotes awareness of archives and heritage."
+          },
+          {
+            "themeDay": "Brickbandens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 7,
+            "notes": "Niche appeal to LEGO enthusiasts, fun but less broadly meaningful."
+          }
+        ]
+      }
+    },
+    {
+      "date": "06-20",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella surfdagen",
+        "Världsdagen för flyktingar"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Världsdagen för flyktingar",
+        "backupThemeDays": [
+          "Internationella surfdagen"
+        ],
+        "reasoning": "Världsdagen för flyktingar has higher cultural relevance and social value in Sweden, a country known for its humanitarian efforts and refugee support. It resonates more deeply with societal issues and promotes awareness and empathy. Internationella surfdagen, while fun and seasonally relevant, has less broad social impact.",
+        "scores": [
+          {
+            "themeDay": "Världsdagen för flyktingar",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Strong cultural and social significance in Sweden; promotes awareness and empathy."
+          },
+          {
+            "themeDay": "Internationella surfdagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Seasonally relevant and fun but less socially impactful."
+          }
+        ]
+      }
+    },
+    {
+      "date": "06-23",
+      "candidateCount": 2,
+      "themeDays": [
+        "FN:s dag för offentliga tjänster",
+        "Internationella dagen för änkor"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "FN:s dag för offentliga tjänster",
+        "backupThemeDays": [
+          "Internationella dagen för änkor"
+        ],
+        "reasoning": "FN:s dag för offentliga tjänster är mer relevant och igenkännbar för en bred svensk publik då det belyser vikten av offentliga tjänster som påverkar många i samhället. Det är också en dag som kan kopplas till aktuella samhällsfrågor och värderingar om välfärd och demokrati. Internationella dagen för änkor är viktig men mer nischad och mindre känd i Sverige, vilket gör den till en bra backup.",
+        "scores": [
+          {
+            "themeDay": "FN:s dag för offentliga tjänster",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Bred samhällsrelevans och koppling till offentliga sektorn som är viktig i Sverige."
+          },
+          {
+            "themeDay": "Internationella dagen för änkor",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Viktig social fråga men mindre känd och mer nischad."
+          }
+        ]
+      }
+    },
+    {
+      "date": "06-26",
+      "candidateCount": 2,
+      "themeDays": [
+        "Chokladpuddingens dag",
+        "Int. dagen mot missbruk av och olaglig handel med narkotika"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Int. dagen mot missbruk av och olaglig handel med narkotika",
+        "backupThemeDays": [
+          "Chokladpuddingens dag"
+        ],
+        "reasoning": "The International Day Against Drug Abuse and Illicit Trafficking has higher social value and cultural relevance due to its serious impact on public health and safety. It encourages awareness and prevention, which is meaningful for a broad audience. Chokladpuddingens dag is fun and recognizable but less socially impactful, making it a good backup option.",
+        "scores": [
+          {
+            "themeDay": "Int. dagen mot missbruk av och olaglig handel med narkotika",
+            "audienceAppeal": 7,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 5,
+            "notes": "Highly relevant socially and culturally, promotes awareness on an important issue."
+          },
+          {
+            "themeDay": "Chokladpuddingens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 6,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Fun and lighthearted, popular food-related theme but less impactful overall."
+          }
+        ]
+      }
+    },
+    {
+      "date": "07-02",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella UFO-dagen",
+        "Rosens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Rosens dag",
+        "backupThemeDays": [
+          "Internationella UFO-dagen"
+        ],
+        "reasoning": "Rosens dag is more culturally relevant and socially valuable in Sweden, as roses are widely appreciated and associated with positive social interactions and celebrations. Internationella UFO-dagen, while interesting, has a more niche appeal and less cultural significance.",
+        "scores": [
+          {
+            "themeDay": "Rosens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Widely recognized and appreciated, associated with beauty and social gifting."
+          },
+          {
+            "themeDay": "Internationella UFO-dagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 3,
+            "socialValue": 3,
+            "novelty": 7,
+            "notes": "Niche interest, more novelty but less broad appeal or cultural significance."
+          }
+        ]
+      }
+    },
+    {
+      "date": "07-10",
+      "candidateCount": 2,
+      "themeDays": [
+        "Hoya - Porslinsblommans dag",
+        "Simborgarmärkets dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Simborgarmärkets dag",
+        "backupThemeDays": [
+          "Hoya - Porslinsblommans dag"
+        ],
+        "reasoning": "Simborgarmärkets dag is more socially valuable and culturally relevant in Sweden as it promotes swimming skills and water safety, which are important public health and safety themes. It has broader appeal across age groups and aligns with national priorities for physical education and safety. Hoya - Porslinsblommans dag, while unique and seasonally relevant, is more niche and less widely recognized.",
+        "scores": [
+          {
+            "themeDay": "Simborgarmärkets dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong cultural and social value due to emphasis on swimming proficiency and safety; widely recognized in Sweden."
+          },
+          {
+            "themeDay": "Hoya - Porslinsblommans dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Niche interest in a specific plant; less social impact but seasonally relevant and visually appealing."
+          }
+        ]
+      }
+    },
+    {
+      "date": "07-11",
+      "candidateCount": 2,
+      "themeDays": [
+        "FN:s befolkningsdag",
+        "Internationella råkostdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "FN:s befolkningsdag",
+        "backupThemeDays": [
+          "Internationella råkostdagen"
+        ],
+        "reasoning": "FN:s befolkningsdag (UN Population Day) is more meaningful and socially relevant for a broad Swedish audience as it highlights global population issues, which align with Sweden's strong engagement in international development and human rights. Internationella råkostdagen (International Raw Food Day) is more niche and less culturally significant in Sweden, making it a suitable backup.",
+        "scores": [
+          {
+            "themeDay": "FN:s befolkningsdag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Strong social and cultural relevance due to Sweden's interest in global issues and sustainable development."
+          },
+          {
+            "themeDay": "Internationella råkostdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 4,
+            "novelty": 6,
+            "notes": "More niche and less widely recognized, but interesting for health-conscious audiences."
+          }
+        ]
+      }
+    },
+    {
+      "date": "07-12",
+      "candidateCount": 2,
+      "themeDays": [
+        "Fulhetens dag",
+        "Malaladagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Malaladagen",
+        "backupThemeDays": [
+          "Fulhetens dag"
+        ],
+        "reasoning": "Malaladagen, commemorating Malala Yousafzai, is widely recognized internationally and resonates strongly with themes of education, women's rights, and social justice, which are meaningful and socially valuable in Sweden. Fulhetens dag (Ugly Day) is less culturally significant and has lower social value, making Malaladagen the stronger choice for a general audience.",
+        "scores": [
+          {
+            "themeDay": "Malaladagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Strong international recognition and social justice relevance."
+          },
+          {
+            "themeDay": "Fulhetens dag",
+            "audienceAppeal": 4,
+            "culturalRelevance": 3,
+            "socialValue": 3,
+            "novelty": 6,
+            "notes": "More niche and less meaningful, though somewhat novel."
+          }
+        ]
+      }
+    },
+    {
+      "date": "07-13",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella rock and roll-dagen",
+        "Paltdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella rock and roll-dagen",
+        "backupThemeDays": [
+          "Paltdagen"
+        ],
+        "reasoning": "Internationella rock and roll-dagen has broader cultural appeal and recognition internationally and in Sweden, celebrating a globally influential music genre that resonates with many age groups. Paltdagen, while culturally significant locally, is more niche and less widely recognized outside specific communities. Rock and roll day is more likely to engage a general Swedish audience with its fun and energetic theme.",
+        "scores": [
+          {
+            "themeDay": "Internationella rock and roll-dagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "Widely recognized music celebration with broad appeal."
+          },
+          {
+            "themeDay": "Paltdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 4,
+            "novelty": 6,
+            "notes": "Regionally important but less known nationally; niche cultural relevance."
+          }
+        ]
+      }
+    },
+    {
+      "date": "07-14",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella dagen för ickebinära",
+        "Kronprinsessans födelsedag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Kronprinsessans födelsedag",
+        "backupThemeDays": [
+          "Internationella dagen för ickebinära"
+        ],
+        "reasoning": "Kronprinsessans födelsedag is a widely recognized and celebrated national event in Sweden, with strong cultural relevance and social value. It is a stable and meaningful theme day that resonates broadly with the Swedish public. The Internationella dagen för ickebinära is important for inclusivity and awareness but has a narrower audience appeal and less cultural embedding in Sweden compared to the royal birthday.",
+        "scores": [
+          {
+            "themeDay": "Kronprinsessans födelsedag",
+            "audienceAppeal": 9,
+            "culturalRelevance": 10,
+            "socialValue": 8,
+            "novelty": 4,
+            "notes": "Highly recognized national celebration with broad appeal and cultural significance."
+          },
+          {
+            "themeDay": "Internationella dagen för ickebinära",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Important for inclusivity and awareness but less widely celebrated and recognized."
+          }
+        ]
+      }
+    },
+    {
+      "date": "07-15",
+      "candidateCount": 2,
+      "themeDays": [
+        "Tornedalingarnas dag",
+        "Världsdagen för ungdomars talanger"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Tornedalingarnas dag",
+        "backupThemeDays": [
+          "Världsdagen för ungdomars talanger"
+        ],
+        "reasoning": "Tornedalingarnas dag is a culturally significant day in Sweden that celebrates the Tornedalian minority, highlighting regional identity and linguistic heritage. It has strong cultural relevance and social value within Sweden, making it more meaningful and recognizable for a Swedish audience compared to the more general and internationally oriented Världsdagen för ungdomars talanger, which, while positive, has less direct cultural resonance.",
+        "scores": [
+          {
+            "themeDay": "Tornedalingarnas dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Strong cultural and regional significance in Sweden, promotes awareness of minority culture."
+          },
+          {
+            "themeDay": "Världsdagen för ungdomars talanger",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 7,
+            "novelty": 7,
+            "notes": "International theme day focused on youth talents, positive but less culturally specific to Sweden."
+          }
+        ]
+      }
+    },
+    {
+      "date": "07-17",
+      "candidateCount": 2,
+      "themeDays": [
+        "Dagen för världsomfattande rättvisa",
+        "Emojins dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Dagen för världsomfattande rättvisa",
+        "backupThemeDays": [
+          "Emojins dag"
+        ],
+        "reasoning": "Dagen för världsomfattande rättvisa has higher social value and cultural relevance in Sweden, aligning with societal interests in fairness and justice. Emojins dag is fun and widely recognized but less impactful socially. Prioritizing meaningful and socially useful themes is preferred for the general audience.",
+        "scores": [
+          {
+            "themeDay": "Dagen för världsomfattande rättvisa",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Strong social and cultural relevance, meaningful theme with broad appeal."
+          },
+          {
+            "themeDay": "Emojins dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Fun and lighthearted, popular but less socially impactful."
+          }
+        ]
+      }
+    },
+    {
+      "date": "07-24",
+      "candidateCount": 2,
+      "themeDays": [
+        "Drive-thru dagen",
+        "Internationella BDSM-dagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Drive-thru dagen",
+        "backupThemeDays": [
+          "Internationella BDSM-dagen"
+        ],
+        "reasoning": "Drive-thru dagen is more broadly relatable and socially neutral, making it a safer and more accessible choice for a general Swedish audience. It can be associated with convenience and everyday life, which is seasonally relevant in summer when people travel and eat on the go. Internationella BDSM-dagen, while recognized internationally, is niche and may not be suitable for all users or public-facing platforms.",
+        "scores": [
+          {
+            "themeDay": "Drive-thru dagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 6,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "Relatable and light-hearted, appeals to a wide audience with minimal controversy."
+          },
+          {
+            "themeDay": "Internationella BDSM-dagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 3,
+            "socialValue": 3,
+            "novelty": 7,
+            "notes": "Niche and potentially sensitive, less suitable for a general public calendar but notable for inclusivity."
+          }
+        ]
+      }
+    },
+    {
+      "date": "07-26",
+      "candidateCount": 2,
+      "themeDays": [
+        "Bellmandagen",
+        "Esperantodagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Bellmandagen",
+        "backupThemeDays": [
+          "Esperantodagen"
+        ],
+        "reasoning": "Bellmandagen celebrates Carl Michael Bellman, a beloved Swedish poet and musician, making it culturally significant and widely recognized in Sweden. Esperantodagen, while internationally notable, has less direct cultural impact in Sweden. Bellmandagen has higher cultural relevance and social value for a Swedish audience.",
+        "scores": [
+          {
+            "themeDay": "Bellmandagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Strong cultural ties to Sweden, well-known figure in Swedish arts."
+          },
+          {
+            "themeDay": "Esperantodagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 5,
+            "novelty": 6,
+            "notes": "International language day, less prominent in Swedish culture."
+          }
+        ]
+      }
+    },
+    {
+      "date": "07-27",
+      "candidateCount": 2,
+      "themeDays": [
+        "Gå på styltor-dagen",
+        "Sjusovardagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Sjusovardagen",
+        "backupThemeDays": [
+          "Gå på styltor-dagen"
+        ],
+        "reasoning": "Sjusovardagen, which translates to 'Sleep in Day,' resonates well with a broad audience as it humorously encourages rest and relaxation, something universally appreciated. It has cultural relevance as a traditional Swedish observance and offers social value by promoting well-being. Gå på styltor-dagen (Stilt Walking Day) is more niche and less widely recognized, making it a suitable backup.",
+        "scores": [
+          {
+            "themeDay": "Sjusovardagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Widely relatable theme promoting rest; culturally recognized in Sweden."
+          },
+          {
+            "themeDay": "Gå på styltor-dagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Fun and quirky but niche activity with limited broad appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "07-28",
+      "candidateCount": 2,
+      "themeDays": [
+        "Jakttornets dag",
+        "Världshepatitdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Världshepatitdagen",
+        "backupThemeDays": [
+          "Jakttornets dag"
+        ],
+        "reasoning": "Världshepatitdagen (World Hepatitis Day) is a globally recognized health awareness day with significant social value, promoting public health education and prevention efforts. It has broader cultural relevance and social impact compared to Jakttornets dag, which is more niche and specific to hunting enthusiasts. Therefore, Världshepatitdagen is more meaningful and useful for a general Swedish audience.",
+        "scores": [
+          {
+            "themeDay": "Världshepatitdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Strong health awareness day with global recognition and important social message."
+          },
+          {
+            "themeDay": "Jakttornets dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 4,
+            "novelty": 6,
+            "notes": "Niche interest day related to hunting, less broad appeal and social impact."
+          }
+        ]
+      }
+    },
+    {
+      "date": "07-29",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella tigerdagen",
+        "Lasagnens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella tigerdagen",
+        "backupThemeDays": [
+          "Lasagnens dag"
+        ],
+        "reasoning": "Internationella tigerdagen has broader global recognition and raises awareness about tiger conservation, which has social and environmental value. It appeals to a wide audience interested in wildlife and nature. Lasagnens dag is more niche and food-specific, appealing mainly to culinary enthusiasts. Therefore, Internationella tigerdagen is prioritized for its meaningfulness and social relevance.",
+        "scores": [
+          {
+            "themeDay": "Internationella tigerdagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong global conservation theme, appeals broadly to nature lovers and general public."
+          },
+          {
+            "themeDay": "Lasagnens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 5,
+            "notes": "Fun food day but less socially impactful and culturally significant."
+          }
+        ]
+      }
+    },
+    {
+      "date": "08-01",
+      "candidateCount": 2,
+      "themeDays": [
+        "Alla flickvänners dag",
+        "Hembygdsgårdarnas dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Alla flickvänners dag",
+        "backupThemeDays": [
+          "Hembygdsgårdarnas dag"
+        ],
+        "reasoning": "Alla flickvänners dag (All Girlfriends' Day) is more relatable and socially engaging for a broad Swedish audience, encouraging personal connections and appreciation among friends. Hembygdsgårdarnas dag, while culturally significant, appeals more to niche interests related to local heritage and may not resonate as widely.",
+        "scores": [
+          {
+            "themeDay": "Alla flickvänners dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 6,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Strong social appeal and encourages positive interpersonal interactions; moderately recognized."
+          },
+          {
+            "themeDay": "Hembygdsgårdarnas dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 7,
+            "socialValue": 6,
+            "novelty": 4,
+            "notes": "Culturally important but niche; less broad social engagement."
+          }
+        ]
+      }
+    },
+    {
+      "date": "08-10",
+      "candidateCount": 2,
+      "themeDays": [
+        "Larsdagen",
+        "Lejonets dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Larsdagen",
+        "backupThemeDays": [
+          "Lejonets dag"
+        ],
+        "reasoning": "Larsdagen is a traditional Swedish name day with cultural and historical significance, making it more recognizable and meaningful to a general Swedish audience. Lejonets dag, while interesting, is less established and less culturally relevant in Sweden. Larsdagen aligns better with Swedish naming traditions and seasonal observances in early October.",
+        "scores": [
+          {
+            "themeDay": "Larsdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 6,
+            "novelty": 4,
+            "notes": "Traditional name day, widely recognized in Sweden, culturally significant."
+          },
+          {
+            "themeDay": "Lejonets dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 6,
+            "notes": "Less known, more novel but with limited cultural or social impact in Sweden."
+          }
+        ]
+      }
+    },
+    {
+      "date": "08-20",
+      "candidateCount": 2,
+      "themeDays": [
+        "Honungens dag",
+        "Internationella myggdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Honungens dag",
+        "backupThemeDays": [
+          "Internationella myggdagen"
+        ],
+        "reasoning": "Honungens dag (Honey Day) is more positively received and culturally relevant in Sweden, as honey production and consumption are appreciated and tied to nature and local agriculture. It promotes awareness of bees and environmental sustainability, which has social value. Internationella myggdagen (International Mosquito Day) is less appealing as mosquitoes are generally seen as pests and the day has less positive cultural resonance.",
+        "scores": [
+          {
+            "themeDay": "Honungens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Positive associations with nature, food, and sustainability; well-known among Swedes interested in local produce."
+          },
+          {
+            "themeDay": "Internationella myggdagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 3,
+            "novelty": 6,
+            "notes": "Mosquitoes are mostly seen negatively; less celebratory and less socially valuable."
+          }
+        ]
+      }
+    },
+    {
+      "date": "08-30",
+      "candidateCount": 2,
+      "themeDays": [
+        "Int. dagen för offren för påtvingade försvinnanden",
+        "Valhajens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Int. dagen för offren för påtvingade försvinnanden",
+        "backupThemeDays": [
+          "Valhajens dag"
+        ],
+        "reasoning": "The International Day of the Victims of Enforced Disappearances is a solemn and globally recognized day that raises awareness about human rights violations, which resonates with a socially conscious Swedish audience. It carries significant cultural and social value, promoting reflection and advocacy. Valhajens dag, while interesting and unique, is more niche and less impactful socially.",
+        "scores": [
+          {
+            "themeDay": "Int. dagen för offren för påtvingade försvinnanden",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Strong social and cultural relevance; important human rights focus."
+          },
+          {
+            "themeDay": "Valhajens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Fun and novel but less socially impactful and culturally central."
+          }
+        ]
+      }
+    },
+    {
+      "date": "09-02",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationell kokosnötsdagen",
+        "Nationella tapetserardagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Nationella tapetserardagen",
+        "backupThemeDays": [
+          "Internationell kokosnötsdagen"
+        ],
+        "reasoning": "Nationella tapetserardagen is more culturally relevant and socially valuable in Sweden, as it highlights a traditional craft and profession that resonates with Swedish heritage and home culture. Internationell kokosnötsdagen, while fun and novel, has less direct cultural connection and social impact in Sweden.",
+        "scores": [
+          {
+            "themeDay": "Nationella tapetserardagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Relevant to Swedish traditions and home improvement culture, moderately appealing and socially valuable."
+          },
+          {
+            "themeDay": "Internationell kokosnötsdagen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 7,
+            "notes": "Fun and novel but less culturally connected or socially impactful in Sweden."
+          }
+        ]
+      }
+    },
+    {
+      "date": "09-07",
+      "candidateCount": 2,
+      "themeDays": [
+        "Salamins dag",
+        "Stora duchennesdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Stora duchennesdagen",
+        "backupThemeDays": [
+          "Salamins dag"
+        ],
+        "reasoning": "Stora duchennesdagen is likely related to raising awareness about Duchenne muscular dystrophy, a serious health condition, which has strong social value and cultural relevance in Sweden due to healthcare and charity activities. Salamins dag, while potentially fun or niche, lacks broad recognition or social impact. Therefore, Stora duchennesdagen is prioritized for its meaningfulness and social usefulness.",
+        "scores": [
+          {
+            "themeDay": "Stora duchennesdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Strong social and health awareness day, recognized by healthcare and charity sectors."
+          },
+          {
+            "themeDay": "Salamins dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 6,
+            "notes": "More niche or novelty day, less socially impactful or widely recognized."
+          }
+        ]
+      }
+    },
+    {
+      "date": "09-08",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella fysioterapins dag",
+        "Internationella läskunnighetsdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella läskunnighetsdagen",
+        "backupThemeDays": [
+          "Internationella fysioterapins dag"
+        ],
+        "reasoning": "Internationella läskunnighetsdagen (International Literacy Day) is globally recognized and has broad social importance, emphasizing education and empowerment, which resonates well with a wide audience in Sweden. It is more universally relatable and socially impactful compared to Internationella fysioterapins dag, which is more specialized and less widely known among the general public.",
+        "scores": [
+          {
+            "themeDay": "Internationella läskunnighetsdagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Widely recognized, socially important, and relevant to education and equality themes."
+          },
+          {
+            "themeDay": "Internationella fysioterapins dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 6,
+            "novelty": 5,
+            "notes": "More niche, focused on health professionals and patients, less broad appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "09-09",
+      "candidateCount": 2,
+      "themeDays": [
+        "Bingons dag",
+        "Yrkesförarens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Yrkesförarens dag",
+        "backupThemeDays": [
+          "Bingons dag"
+        ],
+        "reasoning": "Yrkesförarens dag is more socially valuable and culturally relevant in Sweden as it honors professional drivers who are essential for logistics, public transport, and overall societal function. It has broader recognition and importance compared to Bingons dag, which is more niche and leisure-focused. Yrkesförarens dag also aligns well with public appreciation and awareness campaigns for essential workers.",
+        "scores": [
+          {
+            "themeDay": "Yrkesförarens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Recognizes essential workers, relevant to many Swedes, socially meaningful."
+          },
+          {
+            "themeDay": "Bingons dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 6,
+            "notes": "Fun and leisure-oriented but less socially impactful and less broadly recognized."
+          }
+        ]
+      }
+    },
+    {
+      "date": "09-15",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella dagen för demokrati",
+        "Internationella lymfomdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella dagen för demokrati",
+        "backupThemeDays": [
+          "Internationella lymfomdagen"
+        ],
+        "reasoning": "Internationella dagen för demokrati is more broadly relevant and socially significant in Sweden, a country with strong democratic values and civic engagement. It encourages public reflection on democracy, which is timely and meaningful. Internationella lymfomdagen, while important for health awareness, has a narrower audience and less seasonal or cultural resonance.",
+        "scores": [
+          {
+            "themeDay": "Internationella dagen för demokrati",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Strong civic importance and broad appeal in Sweden."
+          },
+          {
+            "themeDay": "Internationella lymfomdagen",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Important health awareness day but with a more limited audience and impact."
+          }
+        ]
+      }
+    },
+    {
+      "date": "09-17",
+      "candidateCount": 2,
+      "themeDays": [
+        "Höga klackars dag",
+        "Internationella patientsäkerhetsdagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella patientsäkerhetsdagen",
+        "backupThemeDays": [
+          "Höga klackars dag"
+        ],
+        "reasoning": "Internationella patientsäkerhetsdagen has higher social value and cultural relevance in Sweden due to the country's strong healthcare focus and public interest in patient safety. It is a meaningful observance that promotes awareness and improvement in healthcare quality, which benefits a broad audience. Höga klackars dag, while fun and lighthearted, is more niche and less socially impactful.",
+        "scores": [
+          {
+            "themeDay": "Internationella patientsäkerhetsdagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Strong social and cultural relevance due to healthcare importance in Sweden; meaningful awareness day."
+          },
+          {
+            "themeDay": "Höga klackars dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Fun and quirky but less socially impactful; appeals mainly to fashion-interested audiences."
+          }
+        ]
+      }
+    },
+    {
+      "date": "09-26",
+      "candidateCount": 2,
+      "themeDays": [
+        "Europeiska språkdagen",
+        "Internationella dagen för eliminerandet av kärnvapen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Europeiska språkdagen",
+        "backupThemeDays": [
+          "Internationella dagen för eliminerandet av kärnvapen"
+        ],
+        "reasoning": "Europeiska språkdagen (European Day of Languages) is highly relevant in Sweden due to the country's strong emphasis on multilingualism and language learning. It is widely recognized and celebrated in educational and cultural contexts, making it meaningful and socially useful for a broad audience. The International Day for the Total Elimination of Nuclear Weapons is important but more niche and less directly connected to everyday social or cultural activities in Sweden.",
+        "scores": [
+          {
+            "themeDay": "Europeiska språkdagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Strong cultural and educational relevance; widely recognized in Sweden."
+          },
+          {
+            "themeDay": "Internationella dagen för eliminerandet av kärnvapen",
+            "audienceAppeal": 6,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Important global issue but less immediate social engagement in Sweden."
+          }
+        ]
+      }
+    },
+    {
+      "date": "10-17",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella dagen för utrotande av fattigdom",
+        "Parisarens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella dagen för utrotande av fattigdom",
+        "backupThemeDays": [
+          "Parisarens dag"
+        ],
+        "reasoning": "Internationella dagen för utrotande av fattigdom is a globally recognized UN observance with strong social value and cultural relevance in Sweden, aligning with social awareness and humanitarian efforts. Parisarens dag, while interesting, is more niche and less universally impactful. The poverty eradication day encourages reflection and action on a critical global issue, making it more meaningful for a broad audience.",
+        "scores": [
+          {
+            "themeDay": "Internationella dagen för utrotande av fattigdom",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 5,
+            "notes": "Strong social and cultural relevance; widely recognized international day; promotes awareness and action."
+          },
+          {
+            "themeDay": "Parisarens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 6,
+            "notes": "More niche, less widely known; limited social impact; novelty moderate but less meaningful."
+          }
+        ]
+      }
+    },
+    {
+      "date": "10-19",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella gin och tonic-dagen",
+        "Nationella dagen för Strävhårig foxterrier"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella gin och tonic-dagen",
+        "backupThemeDays": [
+          "Nationella dagen för Strävhårig foxterrier"
+        ],
+        "reasoning": "Internationella gin och tonic-dagen has broader appeal as it celebrates a popular beverage enjoyed by many adults, making it more socially relevant and recognizable. It also aligns well with social and leisure activities, which are seasonally relevant in autumn. The Strävhårig foxterrier day is more niche and appeals mainly to dog enthusiasts, limiting its general audience appeal.",
+        "scores": [
+          {
+            "themeDay": "Internationella gin och tonic-dagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Popular drink day with broad adult appeal, socially engaging and seasonally fitting."
+          },
+          {
+            "themeDay": "Nationella dagen för Strävhårig foxterrier",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Niche dog breed day, interesting but limited general appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "10-21",
+      "candidateCount": 2,
+      "themeDays": [
+        "Grynkorvens dag",
+        "Måltidens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Måltidens dag",
+        "backupThemeDays": [
+          "Grynkorvens dag"
+        ],
+        "reasoning": "Måltidens dag is more broadly relevant and socially meaningful as it celebrates the importance of meals and communal eating, which resonates with a wide Swedish audience. It encourages reflection on food culture and social interaction around meals, making it seasonally and culturally significant. Grynkorvens dag, while fun and unique, is more niche and less impactful on a general audience.",
+        "scores": [
+          {
+            "themeDay": "Måltidens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Broad appeal related to food and social gatherings, culturally significant in Sweden."
+          },
+          {
+            "themeDay": "Grynkorvens dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Niche food item celebration, fun but less socially impactful."
+          }
+        ]
+      }
+    },
+    {
+      "date": "10-23",
+      "candidateCount": 2,
+      "themeDays": [
+        "Hackkorvens dag",
+        "Internationella moldagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella moldagen",
+        "backupThemeDays": [
+          "Hackkorvens dag"
+        ],
+        "reasoning": "Internationella moldagen (International Soil Day) has broader environmental and social relevance, aligning with global sustainability themes that resonate well with a wide Swedish audience. It promotes awareness about soil health, which is crucial for agriculture and ecosystems, making it socially valuable and culturally relevant. Hackkorvens dag (Day of the Hackkorv sausage) is more niche and food-specific, appealing less broadly.",
+        "scores": [
+          {
+            "themeDay": "Internationella moldagen",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong environmental theme with global recognition, relevant to Swedish sustainability interests."
+          },
+          {
+            "themeDay": "Hackkorvens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 5,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "Fun and lighthearted food day, but less socially impactful and culturally broad."
+          }
+        ]
+      }
+    },
+    {
+      "date": "11-01",
+      "candidateCount": 2,
+      "themeDays": [
+        "Frysrättens dag",
+        "Internationella vegandagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella vegandagen",
+        "backupThemeDays": [
+          "Frysrättens dag"
+        ],
+        "reasoning": "Internationella vegandagen has broader cultural relevance and social value in Sweden, reflecting growing interest in veganism, sustainability, and animal welfare. It is more recognizable and meaningful to a general audience compared to Frysrättens dag, which is more niche and less widely celebrated. Vegan Day also aligns well with contemporary social trends and public discourse.",
+        "scores": [
+          {
+            "themeDay": "Internationella vegandagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong appeal due to rising veganism and sustainability awareness in Sweden."
+          },
+          {
+            "themeDay": "Frysrättens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 4,
+            "novelty": 5,
+            "notes": "More niche, focused on frozen food dishes, less socially impactful."
+          }
+        ]
+      }
+    },
+    {
+      "date": "11-08",
+      "candidateCount": 2,
+      "themeDays": [
+        "Infraservicedagen",
+        "Läromedlets dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Läromedlets dag",
+        "backupThemeDays": [
+          "Infraservicedagen"
+        ],
+        "reasoning": "Läromedlets dag (Learning Materials Day) is more broadly relevant and socially valuable in Sweden, emphasizing education and learning resources which resonate with a wide audience including students, teachers, and parents. It aligns well with societal values around education and knowledge sharing. Infraservicedagen is more niche, focusing on infrastructure services, which has less general public appeal.",
+        "scores": [
+          {
+            "themeDay": "Läromedlets dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Strong relevance to education and learning, widely relatable."
+          },
+          {
+            "themeDay": "Infraservicedagen",
+            "audienceAppeal": 4,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 4,
+            "notes": "More technical and niche, less general public interest."
+          }
+        ]
+      }
+    },
+    {
+      "date": "11-10",
+      "candidateCount": 2,
+      "themeDays": [
+        "Mårtensafton",
+        "Världsdagen för vetenskap för fred och utveckling"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Mårtensafton",
+        "backupThemeDays": [
+          "Världsdagen för vetenskap för fred och utveckling"
+        ],
+        "reasoning": "Mårtensafton is a traditional Swedish celebration with strong cultural roots and seasonal relevance in November, making it more recognizable and engaging for a general Swedish audience. The World Day of Science for Peace and Development, while important, is less known and less tied to Swedish cultural practices, thus less likely to resonate broadly.",
+        "scores": [
+          {
+            "themeDay": "Mårtensafton",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Strong cultural tradition, seasonal relevance, widely recognized in Sweden."
+          },
+          {
+            "themeDay": "Världsdagen för vetenskap för fred och utveckling",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Important global theme but less known and less culturally embedded in Sweden."
+          }
+        ]
+      }
+    },
+    {
+      "date": "11-12",
+      "candidateCount": 2,
+      "themeDays": [
+        "Alla krossade hjärtans dag",
+        "Miniatyrrävens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Alla krossade hjärtans dag",
+        "backupThemeDays": [
+          "Miniatyrrävens dag"
+        ],
+        "reasoning": "Alla krossade hjärtans dag resonates more broadly as it taps into universal human emotions related to heartbreak, making it more socially relevant and engaging for a general audience. Miniatyrrävens dag, while unique and fun, is more niche and less likely to have widespread appeal or cultural significance.",
+        "scores": [
+          {
+            "themeDay": "Alla krossade hjärtans dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 7,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Strong emotional connection and broad recognition, moderate novelty."
+          },
+          {
+            "themeDay": "Miniatyrrävens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 3,
+            "novelty": 8,
+            "notes": "Unique and quirky but niche interest and limited social impact."
+          }
+        ]
+      }
+    },
+    {
+      "date": "11-14",
+      "candidateCount": 2,
+      "themeDays": [
+        "Fars dag",
+        "Ostkakans dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Fars dag",
+        "backupThemeDays": [
+          "Ostkakans dag"
+        ],
+        "reasoning": "Fars dag (Father's Day) is a widely recognized and celebrated day in Sweden, with strong cultural relevance and social value as it honors fathers and father figures. It has broad appeal across demographics and is seasonally relevant in November. Ostkakans dag (Cheesecake Day) is more niche and less socially impactful, making it a good backup but not the primary choice.",
+        "scores": [
+          {
+            "themeDay": "Fars dag",
+            "audienceAppeal": 9,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 5,
+            "notes": "Widely celebrated, culturally significant, and socially meaningful day honoring fathers."
+          },
+          {
+            "themeDay": "Ostkakans dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 4,
+            "novelty": 7,
+            "notes": "A fun, food-related day but with limited social impact and narrower appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "11-15",
+      "candidateCount": 2,
+      "themeDays": [
+        "Filantropins dag",
+        "Musikterapins dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Filantropins dag",
+        "backupThemeDays": [
+          "Musikterapins dag"
+        ],
+        "reasoning": "Filantropins dag (Philanthropy Day) is more broadly relevant and socially impactful, encouraging charitable actions and community support, which resonates well with a general Swedish audience. Musikterapins dag (Music Therapy Day) is meaningful but more niche and less widely recognized.",
+        "scores": [
+          {
+            "themeDay": "Filantropins dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Broad appeal due to its focus on charity and social good, aligns with Swedish values of community and support."
+          },
+          {
+            "themeDay": "Musikterapins dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 7,
+            "novelty": 7,
+            "notes": "Interesting niche theme with therapeutic and cultural value but less mainstream recognition."
+          }
+        ]
+      }
+    },
+    {
+      "date": "11-19",
+      "candidateCount": 2,
+      "themeDays": [
+        "Amaryllisens dag",
+        "Womens Entrepreneurship Day"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Amaryllisens dag",
+        "backupThemeDays": [
+          "Womens Entrepreneurship Day"
+        ],
+        "reasoning": "Amaryllisens dag is a well-known and seasonally relevant theme day in Sweden, celebrated in mid-November as the amaryllis flower is a popular winter and Christmas decoration. It resonates culturally and socially as part of Swedish holiday traditions. Women's Entrepreneurship Day, while important, is less widely recognized in Sweden and less seasonally tied, making Amaryllisens dag a stronger choice for broad public appeal.",
+        "scores": [
+          {
+            "themeDay": "Amaryllisens dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Strong seasonal and cultural relevance in Sweden; widely recognized and celebrated."
+          },
+          {
+            "themeDay": "Womens Entrepreneurship Day",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 8,
+            "novelty": 7,
+            "notes": "Important social theme but less recognized and less seasonally relevant in Sweden."
+          }
+        ]
+      }
+    },
+    {
+      "date": "11-23",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella hattdagen",
+        "Sankt Clemens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella hattdagen",
+        "backupThemeDays": [
+          "Sankt Clemens dag"
+        ],
+        "reasoning": "Internationella hattdagen (International Hat Day) is a fun and lighthearted theme day that can engage a broad audience with fashion and personal expression, which is generally appealing and socially accessible. Sankt Clemens dag, while culturally significant, is more niche and less widely recognized among the general public. Therefore, Internationella hattdagen is a better lead for a general Swedish audience.",
+        "scores": [
+          {
+            "themeDay": "Internationella hattdagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Fun and accessible, encourages participation and creativity."
+          },
+          {
+            "themeDay": "Sankt Clemens dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 7,
+            "socialValue": 5,
+            "novelty": 4,
+            "notes": "More niche, historical/religious significance but less broad appeal."
+          }
+        ]
+      }
+    },
+    {
+      "date": "11-26",
+      "candidateCount": 2,
+      "themeDays": [
+        "E-handelns dag",
+        "Internationella undersköterskedagen"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella undersköterskedagen",
+        "backupThemeDays": [
+          "E-handelns dag"
+        ],
+        "reasoning": "Internationella undersköterskedagen is more socially valuable and culturally relevant in Sweden as it honors healthcare workers who play a crucial role in society, especially recognized during and after the pandemic. It has broader public appeal and recognition compared to E-handelns dag, which is more niche and commercial.",
+        "scores": [
+          {
+            "themeDay": "Internationella undersköterskedagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 6,
+            "notes": "Highly respected profession, strong societal impact, widely recognized in Sweden."
+          },
+          {
+            "themeDay": "E-handelns dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Relevant to commerce and consumers but less emotionally engaging or socially critical."
+          }
+        ]
+      }
+    },
+    {
+      "date": "12-01",
+      "candidateCount": 2,
+      "themeDays": [
+        "Brandvarnardagen",
+        "Glöggens dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Brandvarnardagen",
+        "backupThemeDays": [
+          "Glöggens dag"
+        ],
+        "reasoning": "Brandvarnardagen (Fire Safety Day) is highly relevant in Sweden during the colder months when fire hazards increase due to heating and candle use. It has strong social value and public safety importance, making it meaningful and useful for a broad audience. Glöggens dag (Mulled Wine Day) is culturally significant and seasonally relevant but more niche and leisure-focused, so it serves well as a backup.",
+        "scores": [
+          {
+            "themeDay": "Brandvarnardagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 10,
+            "novelty": 5,
+            "notes": "Widely recognized safety day with practical importance during winter."
+          },
+          {
+            "themeDay": "Glöggens dag",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 6,
+            "novelty": 6,
+            "notes": "Popular seasonal tradition but less critical socially than fire safety."
+          }
+        ]
+      }
+    },
+    {
+      "date": "12-05",
+      "candidateCount": 2,
+      "themeDays": [
+        "Int. dagen för frivilligas arbete för ekonomisk och social utveckling",
+        "Världsdagen för jordmån"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Int. dagen för frivilligas arbete för ekonomisk och social utveckling",
+        "backupThemeDays": [
+          "Världsdagen för jordmån"
+        ],
+        "reasoning": "The International Volunteer Day for Economic and Social Development is more socially impactful and widely relatable for a general Swedish audience, highlighting volunteerism which is a strong cultural value in Sweden. It encourages community engagement and social responsibility, which are meaningful and recognizable themes. The World Soil Day, while important environmentally, is more niche and less likely to engage a broad audience.",
+        "scores": [
+          {
+            "themeDay": "Int. dagen för frivilligas arbete för ekonomisk och social utveckling",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong social relevance and cultural alignment with Swedish values of volunteerism and community support."
+          },
+          {
+            "themeDay": "Världsdagen för jordmån",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 7,
+            "novelty": 7,
+            "notes": "Important environmental theme but more niche and less broadly engaging for general public."
+          }
+        ]
+      }
+    },
+    {
+      "date": "12-06",
+      "candidateCount": 2,
+      "themeDays": [
+        "Nikolausdagen",
+        "Städarnas dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Nikolausdagen",
+        "backupThemeDays": [
+          "Städarnas dag"
+        ],
+        "reasoning": "Nikolausdagen (St. Nicholas Day) is a well-known traditional celebration in Sweden and many other European countries, associated with gift-giving and festive customs, making it culturally relevant and socially engaging. Städarnas dag (Cleaners' Day) is less widely recognized and has lower cultural resonance, though it promotes social value by appreciating cleaning workers. Nikolausdagen scores higher in audience appeal and cultural relevance, making it the preferred choice for a general Swedish audience.",
+        "scores": [
+          {
+            "themeDay": "Nikolausdagen",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 7,
+            "novelty": 5,
+            "notes": "Strong traditional and cultural significance, widely recognized in Sweden."
+          },
+          {
+            "themeDay": "Städarnas dag",
+            "audienceAppeal": 5,
+            "culturalRelevance": 4,
+            "socialValue": 8,
+            "novelty": 6,
+            "notes": "Important social recognition day but less known and celebrated."
+          }
+        ]
+      }
+    },
+    {
+      "date": "12-11",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella dagen för världens berg",
+        "Tangons dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Internationella dagen för världens berg",
+        "backupThemeDays": [
+          "Tangons dag"
+        ],
+        "reasoning": "Internationella dagen för världens berg has broader cultural and environmental relevance, aligning with global awareness and sustainability themes that resonate well in Sweden. It also has a strong social value by promoting nature appreciation and conservation. Tangons dag, while culturally interesting, appeals to a more niche audience and has less widespread recognition.",
+        "scores": [
+          {
+            "themeDay": "Internationella dagen för världens berg",
+            "audienceAppeal": 7,
+            "culturalRelevance": 8,
+            "socialValue": 9,
+            "novelty": 6,
+            "notes": "Strong environmental and cultural relevance; promotes awareness of natural heritage."
+          },
+          {
+            "themeDay": "Tangons dag",
+            "audienceAppeal": 6,
+            "culturalRelevance": 5,
+            "socialValue": 5,
+            "novelty": 7,
+            "notes": "Niche cultural appeal; less broad social impact but fun and engaging for dance enthusiasts."
+          }
+        ]
+      }
+    },
+    {
+      "date": "12-12",
+      "candidateCount": 2,
+      "themeDays": [
+        "Internationella dagen för neutralitet",
+        "Julstjärnans dag"
+      ],
+      "suggestion": {
+        "primaryThemeDay": "Julstjärnans dag",
+        "backupThemeDays": [
+          "Internationella dagen för neutralitet"
+        ],
+        "reasoning": "Julstjärnans dag is seasonally relevant and culturally resonant in Sweden during December, aligning with the Christmas season and its associated traditions. It is more likely to engage a broad audience with festive and familiar themes. Internationella dagen för neutralitet, while meaningful, is less widely recognized and less seasonally tied, making it a better backup option.",
+        "scores": [
+          {
+            "themeDay": "Julstjärnans dag",
+            "audienceAppeal": 8,
+            "culturalRelevance": 9,
+            "socialValue": 7,
+            "novelty": 6,
+            "notes": "Strong seasonal and cultural connection to Christmas traditions in Sweden."
+          },
+          {
+            "themeDay": "Internationella dagen för neutralitet",
+            "audienceAppeal": 5,
+            "culturalRelevance": 6,
+            "socialValue": 8,
+            "novelty": 5,
+            "notes": "Important theme but less recognized and less tied to the season; good as a backup."
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/fredagskoll-frontend/package-lock.json
+++ b/fredagskoll-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vadkanmanfira-frontend",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vadkanmanfira-frontend",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "dependencies": {
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",

--- a/fredagskoll-frontend/package.json
+++ b/fredagskoll-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vadkanmanfira-frontend",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/fredagskoll-frontend/src/App.test.tsx
+++ b/fredagskoll-frontend/src/App.test.tsx
@@ -6,6 +6,7 @@ import { buildInfo } from './buildInfo.generated';
 import { ContentPack } from './contentPack';
 import { MOOD_STORAGE_KEY } from './mood';
 import { getReleaseNote } from './releaseNotes';
+import { getThemeDaysForDate } from './temadagar';
 
 jest.mock('./aiBlurbs', () => ({
   fetchAiBlurbBundle: jest.fn().mockResolvedValue(null),
@@ -271,13 +272,14 @@ test('renders Nyårsafton ahead of the generic Thursday fallback with an actual 
 
 test('renders filtered temadagar for an otherwise ordinary date', async () => {
   const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
+  const leadThemeDay = getThemeDaysForDate(new Date(2027, 2, 23))[0];
 
   await renderAppAt(new Date(2027, 2, 23));
 
   expect(
     screen.getByRole('heading', {
       level: 2,
-      name: /Matlådans dag\.\s*Det får väl bära dagen då\./i,
+      name: new RegExp(`${leadThemeDay}\\.\\s*Det får väl bära dagen då\\.`, 'i'),
     })
   ).toBeInTheDocument();
   expect(screen.getAllByRole('list').length).toBeGreaterThan(0);
@@ -285,9 +287,25 @@ test('renders filtered temadagar for an otherwise ordinary date', async () => {
   expect(screen.getAllByText(/Världsmeteorologidagen/i).length).toBeGreaterThan(0);
   expect(screen.queryByText(/Internationella barnreumatikerdagen/i)).not.toBeInTheDocument();
   expect(screen.getByText(/Dagens temadagar/i)).toBeInTheDocument();
+  expect(screen.getAllByText(new RegExp(leadThemeDay, 'i')).length).toBeGreaterThan(0);
+
+  randomSpy.mockRestore();
+});
+
+test('picks the more meaningful March 21 theme day instead of blindly using source order', async () => {
+  const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
+  const leadThemeDay = getThemeDaysForDate(new Date(2026, 2, 21))[0];
+
+  await renderAppAt(new Date(2026, 2, 21));
+
   expect(
-    screen.getByText(/Matlådans dag är i praktiken ett erkännande av kall disciplin i plastform\./i)
+    screen.getByRole('heading', {
+      level: 2,
+      name: new RegExp(`${leadThemeDay}\\.\\s*Det får väl bära dagen då\\.`, 'i'),
+    })
   ).toBeInTheDocument();
+  expect(leadThemeDay).toBe('Rocka sockorna-dagen');
+  expect(screen.getAllByText(/Internationella dagen för Nowruz/i).length).toBeGreaterThan(0);
 
   randomSpy.mockRestore();
 });

--- a/fredagskoll-frontend/src/buildInfo.generated.ts
+++ b/fredagskoll-frontend/src/buildInfo.generated.ts
@@ -1,6 +1,6 @@
 export const buildInfo = {
-  "version": "0.1.17",
-  "gitSha": "52dcc18",
-  "buildRef": "52dcc18",
-  "builtAt": "2026-03-15T11:07:34.266Z"
+  "version": "0.1.18",
+  "gitSha": "8de67df",
+  "buildRef": "8de67df",
+  "builtAt": "2026-03-15T11:35:59.801Z"
 } as const;

--- a/fredagskoll-frontend/src/data/themeDayPriorityByDate.json
+++ b/fredagskoll-frontend/src/data/themeDayPriorityByDate.json
@@ -1,0 +1,1101 @@
+{
+  "06-21": [
+    "Sommarsolståndet",
+    "Musikens dag",
+    "Internationella yogadagen",
+    "Giraffens dag",
+    "Internationella ALS-dagen",
+    "Internationella selfiedagen",
+    "Långsamhetens dag",
+    "Världshumanistdagen",
+    "Världsmusikdagen"
+  ],
+  "03-21": [
+    "Rocka sockorna-dagen",
+    "Internationella Downs syndrom-dagen",
+    "Världspoesidagen",
+    "Internationella dagen för Nowruz",
+    "Internationella skogsdagen",
+    "Internationella dockteaterdagen",
+    "Internationella färgdagen",
+    "Internationella Tiramisudagen"
+  ],
+  "09-18": [
+    "Strandens dag",
+    "Surkålens dag",
+    "4H-dagen",
+    "E-bokens dag",
+    "Internationella Batman-dagen",
+    "Internationella röd panda-dagen",
+    "Software freedom day",
+    "Worldwide spin in public day"
+  ],
+  "09-23": [
+    "Höstdagjämningen",
+    "BeActiveDay - Rörelsens dag",
+    "Internationella dagen för teckenspråken i världen",
+    "Bisexualitetens dag",
+    "D-vitaminens dag",
+    "Hjälpmedelsdagen",
+    "Trappans dag",
+    "Upphandlarens dag"
+  ],
+  "09-29": [
+    "Internationella hjärtdagen",
+    "Kaffets dag",
+    "Internationella matsvinnsdagen",
+    "Alla soffpotatisars dag",
+    "Återvinningens dag",
+    "Internationella pussdagen",
+    "Resandefolkets dag",
+    "Skolmjölkens dag"
+  ],
+  "10-15": [
+    "Internationella dagen för att tvätta händerna",
+    "Internationella landsbygdskvinnors dag",
+    "Vita käppens dag",
+    "Metoo-dagen",
+    "Brösthälsodagen",
+    "Alla chefers dag",
+    "Fetaostens dag",
+    "Internationella beröringsdagen"
+  ],
+  "06-06": [
+    "Sveriges nationaldag",
+    "Sillens dag",
+    "Färskpotatisens dag",
+    "Dagen-D",
+    "Den stora lupinbekämpardagen",
+    "Fruktens dag",
+    "Motorhistoriska dagen"
+  ],
+  "10-04": [
+    "Kanelbullens dag",
+    "Djurens dag",
+    "Alla djurhelgons dag",
+    "Internationella Tacodagen",
+    "Internationella vodkadagen",
+    "Internationella dagen för boende- och bebyggelsefrågor",
+    "Skolfotografiets dag"
+  ],
+  "10-16": [
+    "Världshungerdagen",
+    "Världslivsmedelsdagen",
+    "Alla kan rädda liv-dagen",
+    "Alla broars dag",
+    "Lexikonens dag",
+    "Polyneuropatidagen",
+    "Steve Jobs Day"
+  ],
+  "03-12": [
+    "Kronprinsessans namnsdag",
+    "Världsdagen mot cybercensur",
+    "Nationella syntolkningsdagen",
+    "Alla korvars dag",
+    "Republiken Jamtland",
+    "Världsglaukomdagen"
+  ],
+  "05-08": [
+    "Röda Korsets dag",
+    "Internationella dagen för rättvis handel",
+    "Internationella vikingadagen",
+    "Hantverksölets dag",
+    "Tunnbrödets dag",
+    "Tunnbrödsrullens dag"
+  ],
+  "05-12": [
+    "Dagbokens dag",
+    "Gamla vänners dag",
+    "Massagens dag",
+    "Internationella fibromyalgidagen",
+    "ME/CFS-dagen",
+    "Automower®-dagen"
+  ],
+  "05-20": [
+    "Förskolans dag",
+    "Internationella bi-dagen",
+    "Kulturskolans dag",
+    "Internationella tillgänglighetsdagen",
+    "Vyshyvanka-dagen",
+    "Williams syndromdagen"
+  ],
+  "06-05": [
+    "Världsmiljödagen",
+    "Alla vänners dag",
+    "Internationella brädspelsdagen",
+    "Ångans dag",
+    "Barfotadagen",
+    "Int. dagen för kampen mot illegalt, orapporterat och oreglerat fiske"
+  ],
+  "08-21": [
+    "Alla pensionärers dag",
+    "Hemlösa djurs dag",
+    "Världsentreprenörsdagen",
+    "Internationella geocachingdagen",
+    "Groggens dag",
+    "Durspelets dag"
+  ],
+  "10-01": [
+    "Internationella dagen för äldre",
+    "Vegetariska världsdagen",
+    "Reflexens dag",
+    "Internationella kaffedagen",
+    "Intelligensens dag",
+    "Svenska flaskans dag"
+  ],
+  "10-27": [
+    "Internationella religionsfrihetsdagen",
+    "Internationella skolbiblioteksdagen",
+    "Världsdagen för audiovisuellt kulturarv",
+    "Alla svärmödrars dag",
+    "Arbetsterapins dag",
+    "Internationella nalledagen"
+  ],
+  "11-11": [
+    "Alla singlars dag",
+    "Chokladens dag",
+    "Nordiska klimatdagen",
+    "Användbarhetsdagen",
+    "Hållbarhetsdagen för barn & unga",
+    "World Quality Day"
+  ],
+  "02-02": [
+    "Internationella våtmarksdagen",
+    "Kyndelsmässodagen",
+    "Internationella tvillingdagen",
+    "Murmeldjursdagen",
+    "Smoothiens dag"
+  ],
+  "03-20": [
+    "Vårdagjämningen",
+    "Internationella glädjedagen",
+    "Världsberättardagen",
+    "Internationella munhälsodagen",
+    "World Salad Day"
+  ],
+  "04-24": [
+    "Alla barns dag",
+    "Internationella veterinärdagen",
+    "Int. dagen för multilateralism och diplomati för fred",
+    "Den lokala handelns dag",
+    "Försöksdjurens dag"
+  ],
+  "05-02": [
+    "Världsskrattdagen",
+    "Harry potter-dagen",
+    "Internationella barfotalöpningsdagen",
+    "Nässlans dag",
+    "Världsdagen för tonfisk"
+  ],
+  "05-05": [
+    "Kristi himmelsfärdsafton",
+    "Internationella barnmorskedagen",
+    "Internationella handhygiendagen",
+    "Internationella kebabdagen",
+    "Internationella Ragdolldagen"
+  ],
+  "05-06": [
+    "Regnbågsfamiljers dag",
+    "Folknykterhetens dag",
+    "Hembakatdagen",
+    "Dragspelets dag",
+    "Första metardagen"
+  ],
+  "05-11": [
+    "Internationella strokedagen",
+    "Chokladbollens dag",
+    "Fritidshemmens dag",
+    "Nämndemännens dag",
+    "Skolidrottsföreningens dag"
+  ],
+  "08-08": [
+    "Kräftpremiären",
+    "Internationella kattdagen",
+    "Drottningens namnsdag",
+    "Internationella orgasmdagen",
+    "Lyckans dag"
+  ],
+  "09-04": [
+    "Dagen för ungas psykiska hälsa",
+    "Hemslöjdens dag",
+    "Skäggets dag",
+    "Ostronets dag",
+    "Scooterns dag"
+  ],
+  "10-10": [
+    "Världsdagen för mental hälsa",
+    "Internationella hemlöshetsdagen",
+    "Grötens dag",
+    "Nordiska afasidagen",
+    "Tacksägelsedagen"
+  ],
+  "10-31": [
+    "Halloween",
+    "Grannens dag",
+    "Världsdagen för städer",
+    "Magins dag",
+    "Världsspardagen"
+  ],
+  "11-30": [
+    "Andersdagen",
+    "Giving Tuesday",
+    "Mustaschens dag",
+    "Guldsmedens dag",
+    "Kåldolmens dag"
+  ],
+  "02-06": [
+    "Samernas nationaldag",
+    "Int. dagen för nolltolerans mot kvinnlig könsstympning",
+    "Löpningens dag",
+    "Semikolonets dag"
+  ],
+  "02-28": [
+    "Kälkåkningens dag",
+    "Internationella musarmsdagen",
+    "Myggholkens dag",
+    "Kalevaladagen"
+  ],
+  "05-15": [
+    "Internationella familjedagen",
+    "Pingstafton",
+    "Kardemummabullens dag",
+    "Internationella whiskydagen"
+  ],
+  "05-28": [
+    "Den stressfria dagen",
+    "Internationella burgardagen",
+    "Internationella krama en musiker-dagen",
+    "Internationella onanidagen"
+  ],
+  "06-18": [
+    "Internationella dagen för hållbar gastronomi",
+    "Internationella picknickdagen",
+    "Pionens dag",
+    "Internationella sushidagen"
+  ],
+  "06-19": [
+    "Frisörens dag",
+    "Naturismens dag",
+    "Internationella flanerardagen",
+    "Husbilens dag"
+  ],
+  "07-18": [
+    "Internationella glassdagen",
+    "Internationella Nelson Mandela-dagen",
+    "Skånska flaggans dag",
+    "Baddräktsfria dagen"
+  ],
+  "07-30": [
+    "Internationella dagen mot trafficking av personer",
+    "Pocketbokens dag",
+    "Världsbroderidagen",
+    "Systemadministratörens dag"
+  ],
+  "08-07": [
+    "Ängens dag",
+    "Örtens dag",
+    "Senapens dag",
+    "Hattens dag"
+  ],
+  "08-19": [
+    "Internationella dagen för humanitärt arbete",
+    "Världsfotografidagen",
+    "Internationella orangutangdagen",
+    "Luftfartsdagen"
+  ],
+  "08-24": [
+    "Bartolomeusdagen",
+    "Alla vägräckens dag",
+    "Tandvårdsrädslans dag",
+    "Årsdagen av Plutos degradering"
+  ],
+  "08-26": [
+    "Jämställdhetsdagen",
+    "Alla hundars dag",
+    "Polisens dag",
+    "Östersjödagen"
+  ],
+  "09-01": [
+    "Sveriges lärares dag",
+    "Tjejnyår",
+    "Däckcheckdagen",
+    "Fluortantens dag"
+  ],
+  "09-05": [
+    "Internationella dagen för välgörenhet",
+    "Svampens dag",
+    "Dansbandens dag",
+    "Hittekattens dag"
+  ],
+  "09-19": [
+    "Brunchens dag",
+    "Internationella piratdagen",
+    "Världsdagen för aortadissektion",
+    "Messmörets dag"
+  ],
+  "09-21": [
+    "Internationella fredsdagen",
+    "Världstacksamhetsdagen",
+    "Scouternas fredsdag",
+    "Minigolfdagen"
+  ],
+  "09-28": [
+    "Internationella dagen för säkra aborter",
+    "Int. dagen för universell tillgång till information",
+    "Internationella rabiesdagen",
+    "Neurodagen"
+  ],
+  "10-13": [
+    "Internationella klarspråksdagen",
+    "Världstrombosdagen",
+    "International Suit Up Day",
+    "No Bra day"
+  ],
+  "10-14": [
+    "Räkmackans dag",
+    "Världsdagen för synskadade",
+    "World Standards Day",
+    "Världssyndagen"
+  ],
+  "10-24": [
+    "FN-dagen",
+    "Raggsockans dag",
+    "Världsdagen för information om utvecklingsfrågor",
+    "Montessorilärardagen"
+  ],
+  "11-13": [
+    "Internationella vänlighetsdagen",
+    "Arkivens dag",
+    "Smörgåstårtans dag",
+    "Bäskens Dag"
+  ],
+  "11-17": [
+    "De prestigelösas dag",
+    "Internationella elevdagen",
+    "Napoleonbakelsens dag",
+    "Internationella GIS-dagen"
+  ],
+  "12-10": [
+    "Mänskliga rättigheternas dag",
+    "Nobeldagen",
+    "Internationella djurrättsdagen",
+    "Terra Madre day"
+  ],
+  "01-18": [
+    "Martin Luther King-dagen",
+    "Internationella Nalle Puh-dagen",
+    "Blue Monday"
+  ],
+  "01-19": [
+    "Internationella popcorndagen",
+    "Henriksdagen",
+    "Sten Stures ben"
+  ],
+  "01-28": [
+    "Konungens namnsdag",
+    "Dataskyddsdagen",
+    "Internationella LEGO-dagen"
+  ],
+  "02-07": [
+    "Fastlagssöndagen",
+    "Tankens dag",
+    "Trafiklärarens dag"
+  ],
+  "02-20": [
+    "Världsdagen för social rättvisa",
+    "Internationella piprökardagen",
+    "Slarvighetens dag"
+  ],
+  "03-03": [
+    "Världsdagen för natur- och djurliv",
+    "Dagen för musikalisk frihet",
+    "Mandelkubbens dag"
+  ],
+  "03-14": [
+    "Pi-dagen",
+    "Matematikens dag",
+    "Steak and BJ day"
+  ],
+  "03-17": [
+    "Saint Patrick's day",
+    "Hallongrottans dag",
+    "Kollektivavtalets dag"
+  ],
+  "03-23": [
+    "Nordens dag",
+    "Världsmeteorologidagen",
+    "Matlådans dag"
+  ],
+  "03-25": [
+    "Våffeldagen",
+    "Trandagen",
+    "Tolkien reading day"
+  ],
+  "04-06": [
+    "Internationella sportdagen för utveckling och fred",
+    "Pingisens dag",
+    "Internationella Carbonara-dagen"
+  ],
+  "04-10": [
+    "Internationella syskondagen",
+    "Surdegsdagen",
+    "Bulle med bullens-dag"
+  ],
+  "04-12": [
+    "Lakritsdagen",
+    "Linssoppans dag",
+    "Internationella dagen för bemannade rymdfärder"
+  ],
+  "04-14": [
+    "Cultural Unity Day",
+    "Volvons dag",
+    "Mahl Language Day"
+  ],
+  "04-21": [
+    "Världsdagen för kreativitet och innovation",
+    "Internationella sekreterardagen",
+    "Terrakottakrukans dag",
+    "Världsdagen för kreativitet och innovation"
+  ],
+  "04-26": [
+    "Promenadens dag",
+    "Alien-dagen",
+    "Världsdagen för intellektuell äganderätt"
+  ],
+  "04-28": [
+    "Arbetsmiljödagen",
+    "Ledarhundens dag",
+    "Möteskulturdagen"
+  ],
+  "04-30": [
+    "Valborgsmässoafton",
+    "Konungens födelsedag",
+    "Internationella jazzdagen"
+  ],
+  "05-01": [
+    "Arbetarrörelsens dag",
+    "Gratis serietidningsdagen",
+    "Budapestbakelsens dag"
+  ],
+  "05-04": [
+    "Star wars-dagen",
+    "Internationella brandmännens dag",
+    "Fothälsodagen"
+  ],
+  "05-09": [
+    "Europadagen",
+    "Nedkopplingens dag",
+    "Linderödsgrisens dag"
+  ],
+  "05-16": [
+    "Internationella dagen för fredlig samlevnad",
+    "Internationella celiakidagen",
+    "Internationella ljusdagen"
+  ],
+  "05-17": [
+    "Internationella dagen mot homo- och transfobi",
+    "Annandag pingst",
+    "Internationella telekommunikationsdagen"
+  ],
+  "05-19": [
+    "Nationella mag-och tarmdagen",
+    "Halloumiostens dag",
+    "IT-chefens dag"
+  ],
+  "05-21": [
+    "Världsdagen för kulturell mångfald för dialog och utveckling",
+    "Internationella flytvästdagen",
+    "Internationella tedagen"
+  ],
+  "05-23": [
+    "Måltidens gemenskapsdag",
+    "Internationella sköldpaddsdagen",
+    "Internationella dagen för utrotning av obstetrisk fistula"
+  ],
+  "05-25": [
+    "Internationella sköldkörteldagen",
+    "Internationella nörddagen",
+    "Handduksdagen"
+  ],
+  "05-27": [
+    "Ostens dag",
+    "Muffinsdagen",
+    "Parfymfria dagen"
+  ],
+  "05-29": [
+    "Veterandagen",
+    "Internationella dagen för FN:s fredsbevarande personal",
+    "Ofrivilligt barnlösas dag"
+  ],
+  "05-30": [
+    "Mors dag",
+    "Internationella MS-dagen",
+    "Fönsterrenoveringens dag"
+  ],
+  "06-01": [
+    "Globala dagen för föräldrar",
+    "Mobilfria dagen",
+    "Mjölkens dag"
+  ],
+  "06-12": [
+    "Internationella dagen mot barnarbete",
+    "Nationalbastudagen",
+    "Världsstickningsdagen"
+  ],
+  "06-16": [
+    "Bloomsday",
+    "Internationella dagen för familjeremitteringar",
+    "Redovisningskonsultens dag"
+  ],
+  "06-30": [
+    "Internationella dagen för parlamentarism",
+    "Internationella dagen för asteroider",
+    "Pilsnerkorvens dag"
+  ],
+  "07-31": [
+    "Världsvänskapsdagen",
+    "Koloniträdgårdens dag",
+    "Dagen för ovanliga instrument"
+  ],
+  "08-06": [
+    "Hiroshimadagen",
+    "Internationella öldagen",
+    "Internationella dagen för frisk andedräkt"
+  ],
+  "08-09": [
+    "Internationella dagen för världens ursprungsfolk",
+    "Mumindagen",
+    "Rulltårtans dag"
+  ],
+  "08-28": [
+    "Snapsens dag",
+    "Squaredansens dag",
+    "Världsdagen för Turners syndrom"
+  ],
+  "08-29": [
+    "Arkeologidagen",
+    "Internationella dagen mot kärnvapenprov",
+    "Porslinets dag"
+  ],
+  "09-11": [
+    "Vandringens dag",
+    "Geologins dag",
+    "Kebabens dag"
+  ],
+  "09-12": [
+    "Kulturarvsdagen",
+    "TV-spelsdagen",
+    "Internationella dagen för syd-syd-samarbete"
+  ],
+  "09-20": [
+    "Allemansrättens dag",
+    "World Cleanup Day",
+    "Bålens dag"
+  ],
+  "09-22": [
+    "Internationella bilfria dagen",
+    "Hobbitdagen",
+    "Noshörningens dag"
+  ],
+  "09-24": [
+    "Janssons-dagen",
+    "Dagvattnets dag",
+    "Skiljetecknets dag"
+  ],
+  "09-25": [
+    "Äpplets dag",
+    "Lösgodisets dag",
+    "Internationella farmaceutdagen"
+  ],
+  "09-27": [
+    "Hummerpremiären",
+    "Världsturismdagen",
+    "Tjänstepensionens dag"
+  ],
+  "09-30": [
+    "Internationella dagen för översättning",
+    "International Blasphemy Rights Day",
+    "Naprapatins dag"
+  ],
+  "10-03": [
+    "Gräddtårtans dag",
+    "Alla pojkvänners dag",
+    "Den helige Mikaels dag"
+  ],
+  "10-06": [
+    "Nationella anhörigdagen",
+    "Internationella CP-dagen",
+    "HSP-dagen"
+  ],
+  "10-08": [
+    "Världsdyslexidagen",
+    "Äggets dag",
+    "Vägledningens dag"
+  ],
+  "10-09": [
+    "Finlandssvenska matkulturdagen",
+    "Världspostunionens dag",
+    "PANDAS/PANS Awareness Day"
+  ],
+  "10-11": [
+    "Internationella flickdagen",
+    "Internationella komma-ut-dagen",
+    "Äpplemustens Dag"
+  ],
+  "10-12": [
+    "Civilkuragets dag",
+    "Ada Lovelace-dagen",
+    "Sockerfria dagen"
+  ],
+  "10-18": [
+    "Chokladmuffins dag",
+    "Internationella klimakteriedagen",
+    "Internationella slipsdagen"
+  ],
+  "10-20": [
+    "Internationella osteoporosdagen",
+    "Internationella flygledardagen",
+    "Världsdagen för statistik"
+  ],
+  "10-22": [
+    "Internationella stamningsdagen",
+    "Internationella champagnedagen",
+    "INTERNATIONELLA CAPS LOCK-DAGEN"
+  ],
+  "10-28": [
+    "Bilens dag",
+    "Internationella animationens dag",
+    "Veckopengens dag"
+  ],
+  "11-16": [
+    "Internationella dagen för tolerans",
+    "Mångkulturella matdagen",
+    "Raggmunkens dag"
+  ],
+  "11-18": [
+    "Adoptionernas dag",
+    "Världsfilosofidagen",
+    "Benbuljongens dag"
+  ],
+  "11-21": [
+    "Världsdagen för TV",
+    "Världshejardagen",
+    "Musikfri dag"
+  ],
+  "11-28": [
+    "Första advent",
+    "Kattens dag",
+    "Flaskmatardagen"
+  ],
+  "12-09": [
+    "Annadagen",
+    "Pepparkakans dag",
+    "Läkarsekreterarens dag"
+  ],
+  "12-21": [
+    "Tomasdagen",
+    "Kortfilmens dag",
+    "Skumtomtens dag"
+  ],
+  "01-04": [
+    "Punktskriftens dag",
+    "Världshypnosdagen"
+  ],
+  "01-15": [
+    "Tulpanens dag",
+    "Internationella fetischdagen"
+  ],
+  "01-16": [
+    "Släktforskningens dag",
+    "Internationella LCHF-dagen"
+  ],
+  "01-22": [
+    "Vinets dag",
+    "Pilsnerfilmens dag"
+  ],
+  "01-24": [
+    "Världssnödagen",
+    "Frufridagen"
+  ],
+  "01-25": [
+    "Paulusdagen",
+    "Halvsnödagen"
+  ],
+  "01-29": [
+    "Internationella pusseldagen",
+    "Veganpizza-dagen"
+  ],
+  "01-31": [
+    "Upp och hoppa-dagen",
+    "Lönekonsultens dag"
+  ],
+  "02-03": [
+    "Andningens dag",
+    "Morotskakans dag"
+  ],
+  "02-05": [
+    "Runebergsdagen",
+    "Nutelladagen"
+  ],
+  "02-08": [
+    "Äggahalvans dag",
+    "Clean Out Your Computer Day"
+  ],
+  "02-09": [
+    "Fettisdagen",
+    "Internationella pannkaksdagen"
+  ],
+  "02-10": [
+    "Askonsdagen",
+    "Baljväxtens dag"
+  ],
+  "02-11": [
+    "Int. dagen för kvinnor och flickor inom vetenskap",
+    "Internationella 112-dagen"
+  ],
+  "02-12": [
+    "Darwins födelsedag",
+    "Vintercyklingens dag"
+  ],
+  "02-13": [
+    "Världsradiodagen",
+    "Tandborstbytardagen"
+  ],
+  "02-14": [
+    "Alla hjärtans dag",
+    "Alla hjärtebarns dag"
+  ],
+  "02-21": [
+    "Internationella dagen för modersmål",
+    "Fondvalsdagen"
+  ],
+  "02-24": [
+    "Sverigefinnarnas dag",
+    "Internationella EBM-dagen"
+  ],
+  "02-26": [
+    "Husmanskostens dag",
+    "World Hobby Day"
+  ],
+  "02-27": [
+    "Meänkielidagen",
+    "Internationella isbjörnsdagen"
+  ],
+  "03-01": [
+    "Internationella dagen mot diskriminering",
+    "Krama en bibliotekarie-dagen"
+  ],
+  "03-04": [
+    "Fössta Tossdan i Mass",
+    "Bananens dag"
+  ],
+  "03-05": [
+    "Världsböndagen för fred",
+    "Ostbågens dag"
+  ],
+  "03-06": [
+    "Europeiska logopeddagen",
+    "Nolltaxedagen"
+  ],
+  "03-07": [
+    "Punschrullens dag",
+    "Podcastens dag"
+  ],
+  "03-10": [
+    "Super Mario-dagen",
+    "V8-motorns dag"
+  ],
+  "03-11": [
+    "Världsnjurdagen",
+    "Rörmokeriets världsdag"
+  ],
+  "03-13": [
+    "Källkritikens dag",
+    "Mazarindagen"
+  ],
+  "03-15": [
+    "Internationella konsumentdagen",
+    "NPF-dagen"
+  ],
+  "03-22": [
+    "Internationella vattendagen",
+    "Kennethdagen"
+  ],
+  "03-24": [
+    "Europeiska dagen för hantverksmässigt tillverkad glass",
+    "Int. dagen för rätt till sanning om grova kränkningar av de mänskliga rättigheterna",
+    "Int. dagen för rätt till sanning om grova kränkningar av de mänskliga rättigheterna..."
+  ],
+  "03-26": [
+    "Arbetsplatsombudens dag",
+    "Dialersystemens dag"
+  ],
+  "03-27": [
+    "Påskafton",
+    "Världsteaterdagen"
+  ],
+  "03-31": [
+    "Kullerbyttans dag",
+    "Världsbackupdagen"
+  ],
+  "04-02": [
+    "Internationella barnboksdagen",
+    "Studenternas dag"
+  ],
+  "04-07": [
+    "Världshälsodagen",
+    "National Walking Day"
+  ],
+  "04-15": [
+    "Världens konstdag",
+    "Internationella biomedicinska analytikerdagen"
+  ],
+  "04-18": [
+    "Internationella dagen för monument och platser",
+    "Amatörradions dag"
+  ],
+  "04-20": [
+    "Polkagrisens dag",
+    "Svenska gin & tonic-dagen"
+  ],
+  "04-23": [
+    "Världsbokdagen",
+    "Sankt Georgsdagen"
+  ],
+  "04-25": [
+    "Lekens dag",
+    "Mamatummy Day"
+  ],
+  "04-29": [
+    "Dansens dag",
+    "Svenska friluftsdagen"
+  ],
+  "05-03": [
+    "Internationella dagen för pressfrihet",
+    "Asociala dagen"
+  ],
+  "05-07": [
+    "Grillens dag",
+    "Internationella tubadagen"
+  ],
+  "05-13": [
+    "Porträttfotots dag",
+    "Receptionistens dag"
+  ],
+  "05-14": [
+    "Svenska teckenspråkets dag",
+    "Rumpans dag"
+  ],
+  "05-18": [
+    "Internationella museidagen",
+    "Fascinerande växters dag"
+  ],
+  "05-22": [
+    "Internationella dagen för biologiskt mångfald",
+    "Picknickens dag"
+  ],
+  "05-24": [
+    "Nationalparkernas dag",
+    "Religionstraumadagen"
+  ],
+  "06-02": [
+    "Internationella dagen mot ätstörningar",
+    "Internationella artrosdagen"
+  ],
+  "06-03": [
+    "Internationella cykeldagen",
+    "Internationella klumpfotsdagen"
+  ],
+  "06-04": [
+    "Assistansens dag",
+    "Internationella donutdagen"
+  ],
+  "06-08": [
+    "Världshavens dag",
+    "Ride to Work Day"
+  ],
+  "06-09": [
+    "Internationella arkivdagen",
+    "Brickbandens dag"
+  ],
+  "06-20": [
+    "Världsdagen för flyktingar",
+    "Internationella surfdagen"
+  ],
+  "06-23": [
+    "FN:s dag för offentliga tjänster",
+    "Internationella dagen för änkor"
+  ],
+  "06-26": [
+    "Int. dagen mot missbruk av och olaglig handel med narkotika",
+    "Chokladpuddingens dag"
+  ],
+  "07-02": [
+    "Rosens dag",
+    "Internationella UFO-dagen"
+  ],
+  "07-10": [
+    "Simborgarmärkets dag",
+    "Hoya - Porslinsblommans dag"
+  ],
+  "07-11": [
+    "FN:s befolkningsdag",
+    "Internationella råkostdagen"
+  ],
+  "07-12": [
+    "Malaladagen",
+    "Fulhetens dag"
+  ],
+  "07-13": [
+    "Internationella rock and roll-dagen",
+    "Paltdagen"
+  ],
+  "07-14": [
+    "Kronprinsessans födelsedag",
+    "Internationella dagen för ickebinära"
+  ],
+  "07-15": [
+    "Tornedalingarnas dag",
+    "Världsdagen för ungdomars talanger"
+  ],
+  "07-17": [
+    "Dagen för världsomfattande rättvisa",
+    "Emojins dag"
+  ],
+  "07-24": [
+    "Drive-thru dagen",
+    "Internationella BDSM-dagen"
+  ],
+  "07-26": [
+    "Bellmandagen",
+    "Esperantodagen"
+  ],
+  "07-27": [
+    "Sjusovardagen",
+    "Gå på styltor-dagen"
+  ],
+  "07-28": [
+    "Världshepatitdagen",
+    "Jakttornets dag"
+  ],
+  "07-29": [
+    "Internationella tigerdagen",
+    "Lasagnens dag"
+  ],
+  "08-01": [
+    "Alla flickvänners dag",
+    "Hembygdsgårdarnas dag"
+  ],
+  "08-10": [
+    "Larsdagen",
+    "Lejonets dag"
+  ],
+  "08-20": [
+    "Honungens dag",
+    "Internationella myggdagen"
+  ],
+  "08-30": [
+    "Int. dagen för offren för påtvingade försvinnanden",
+    "Valhajens dag"
+  ],
+  "09-02": [
+    "Nationella tapetserardagen",
+    "Internationell kokosnötsdagen"
+  ],
+  "09-07": [
+    "Stora duchennesdagen",
+    "Salamins dag"
+  ],
+  "09-08": [
+    "Internationella läskunnighetsdagen",
+    "Internationella fysioterapins dag"
+  ],
+  "09-09": [
+    "Yrkesförarens dag",
+    "Bingons dag"
+  ],
+  "09-15": [
+    "Internationella dagen för demokrati",
+    "Internationella lymfomdagen"
+  ],
+  "09-17": [
+    "Internationella patientsäkerhetsdagen",
+    "Höga klackars dag"
+  ],
+  "09-26": [
+    "Europeiska språkdagen",
+    "Internationella dagen för eliminerandet av kärnvapen"
+  ],
+  "10-17": [
+    "Internationella dagen för utrotande av fattigdom",
+    "Parisarens dag"
+  ],
+  "10-19": [
+    "Internationella gin och tonic-dagen",
+    "Nationella dagen för Strävhårig foxterrier"
+  ],
+  "10-21": [
+    "Måltidens dag",
+    "Grynkorvens dag"
+  ],
+  "10-23": [
+    "Internationella moldagen",
+    "Hackkorvens dag"
+  ],
+  "11-01": [
+    "Internationella vegandagen",
+    "Frysrättens dag"
+  ],
+  "11-08": [
+    "Läromedlets dag",
+    "Infraservicedagen"
+  ],
+  "11-10": [
+    "Mårtensafton",
+    "Världsdagen för vetenskap för fred och utveckling"
+  ],
+  "11-12": [
+    "Alla krossade hjärtans dag",
+    "Miniatyrrävens dag"
+  ],
+  "11-14": [
+    "Fars dag",
+    "Ostkakans dag"
+  ],
+  "11-15": [
+    "Filantropins dag",
+    "Musikterapins dag"
+  ],
+  "11-19": [
+    "Amaryllisens dag",
+    "Womens Entrepreneurship Day"
+  ],
+  "11-23": [
+    "Internationella hattdagen",
+    "Sankt Clemens dag"
+  ],
+  "11-26": [
+    "Internationella undersköterskedagen",
+    "E-handelns dag"
+  ],
+  "12-01": [
+    "Brandvarnardagen",
+    "Glöggens dag"
+  ],
+  "12-05": [
+    "Int. dagen för frivilligas arbete för ekonomisk och social utveckling",
+    "Världsdagen för jordmån"
+  ],
+  "12-06": [
+    "Nikolausdagen",
+    "Städarnas dag"
+  ],
+  "12-11": [
+    "Internationella dagen för världens berg",
+    "Tangons dag"
+  ],
+  "12-12": [
+    "Julstjärnans dag",
+    "Internationella dagen för neutralitet"
+  ]
+}

--- a/fredagskoll-frontend/src/releaseNotes.ts
+++ b/fredagskoll-frontend/src/releaseNotes.ts
@@ -8,6 +8,19 @@ export type ReleaseNote = {
 
 export const releaseNotes: ReleaseNote[] = [
   {
+    version: '0.1.18',
+    shortSummary: {
+      sv: 'Temadagar väljs nu mer vettigt när flera krockar samma dag.',
+      en: 'Theme days are now chosen more sensibly when several land on the same date.',
+      'pt-BR': 'As datas temáticas agora são escolhidas de forma mais sensata quando várias caem no mesmo dia.',
+    },
+    summary: {
+      sv: 'Appen använder inte längre rå ordning från källdatan när flera temadagar delar datum. I stället görs en enklare redaktionell bedömning, så dagar som Rocka sockorna-dagen, vårdagjämningen och Star wars-dagen oftare får leda när de faktiskt känns mest relevanta eller roliga.',
+      en: 'The app no longer follows raw source order when several theme days share the same date. Instead it makes a lighter editorial choice, so days like Rock Your Socks Day, the spring equinox, and Star Wars Day are more likely to lead when they are clearly the most relevant or fun option.',
+      'pt-BR': 'O app não segue mais a ordem bruta da fonte quando várias datas temáticas compartilham o mesmo dia. Em vez disso, ele faz uma escolha editorial simples, para que datas como Rock Your Socks Day, o equinócio da primavera e Star Wars Day apareçam primeiro quando fizerem mais sentido ou forem mais divertidas.',
+    },
+  },
+  {
     version: '0.1.17',
     shortSummary: {
       sv: 'Renare styling och lugnare rubriker i appen.',

--- a/fredagskoll-frontend/src/temadagar.test.ts
+++ b/fredagskoll-frontend/src/temadagar.test.ts
@@ -1,0 +1,23 @@
+import { getThemeDaysForDate } from './temadagar';
+
+test('prioritizes Rocka sockorna before the other March 21 theme days', () => {
+  const themeDays = getThemeDaysForDate(new Date(2026, 2, 21));
+
+  expect(themeDays[0]).toBe('Rocka sockorna-dagen');
+  expect(themeDays).toContain('Internationella dagen för Nowruz');
+  expect(themeDays).toContain('Internationella Downs syndrom-dagen');
+});
+
+test('prioritizes seasonal anchors before novelty fillers when many theme days share a date', () => {
+  const themeDays = getThemeDaysForDate(new Date(2026, 2, 20));
+
+  expect(themeDays[0]).toBe('Vårdagjämningen');
+  expect(themeDays.indexOf('Vårdagjämningen')).toBeLessThan(themeDays.indexOf('World Salad Day'));
+});
+
+test('prioritizes culturally recognizable days over niche ones when the date is crowded', () => {
+  const themeDays = getThemeDaysForDate(new Date(2026, 4, 4));
+
+  expect(themeDays[0]).toBe('Star wars-dagen');
+  expect(themeDays.indexOf('Star wars-dagen')).toBeLessThan(themeDays.indexOf('Fothälsodagen'));
+});

--- a/fredagskoll-frontend/src/temadagar.ts
+++ b/fredagskoll-frontend/src/temadagar.ts
@@ -1,13 +1,15 @@
 import temadagarByDate from './data/temadagarByDate.json';
+import { prioritizeThemeDays } from './themeDayPriority';
 
 const themeDaysByDate = temadagarByDate as Record<string, string[]>;
 
-function formatMonthDay(date: Date): string {
+export function formatMonthDay(date: Date): string {
   const month = `${date.getMonth() + 1}`.padStart(2, '0');
   const day = `${date.getDate()}`.padStart(2, '0');
   return `${month}-${day}`;
 }
 
 export function getThemeDaysForDate(date: Date): string[] {
-  return themeDaysByDate[formatMonthDay(date)] ?? [];
+  const dateKey = formatMonthDay(date);
+  return prioritizeThemeDays(themeDaysByDate[dateKey] ?? [], dateKey);
 }

--- a/fredagskoll-frontend/src/themeDayPriority.ts
+++ b/fredagskoll-frontend/src/themeDayPriority.ts
@@ -1,0 +1,197 @@
+import curatedThemeDayPriorityByDate from './data/themeDayPriorityByDate.json';
+import { normalizeLabel } from './themeDayTextUtils';
+
+const curatedDateOverrides = curatedThemeDayPriorityByDate as Record<string, string[]>;
+
+const exactDateOverrides: Record<string, string[]> = {
+  '03-20': ['Vårdagjämningen', 'Internationella glädjedagen', 'Världsberättardagen'],
+  '03-21': ['Rocka sockorna-dagen', 'Internationella Downs syndrom-dagen', 'Världspoesidagen'],
+  '04-12': ['Internationella dagen för bemannade rymdfärder', 'Lakritsdagen'],
+  '05-04': ['Star wars-dagen', 'Internationella brandmännens dag'],
+  '06-21': ['Sommarsolståndet', 'Internationella yogadagen', 'Musikens dag'],
+  '09-21': ['Internationella fredsdagen', 'Världstacksamhetsdagen', 'Scouternas fredsdag'],
+  '10-04': ['Kanelbullens dag', 'Djurens dag', 'Internationella Tacodagen'],
+  '11-14': ['Fars dag'],
+  '12-10': ['Nobeldagen', 'Mänskliga rättigheternas dag'],
+};
+
+const strongPositiveKeywords = [
+  'mänskliga rättigheter',
+  'fred',
+  'downs syndrom',
+  'tillgänglighet',
+  'demokrati',
+  'mental hälsa',
+  'psykiska hälsa',
+  'teckenspråk',
+  'modersmål',
+  'pressfrihet',
+  'världsmiljö',
+  'miljö',
+  'biologiskt mångfald',
+  'hållbar',
+  'barnarbete',
+  'hemlös',
+  'äldres',
+  'äldre',
+  'vetenskap',
+  'kreativitet',
+  'innovation',
+  'jämställdhet',
+  'familj',
+  'ursprungsfolk',
+  'samernas nationaldag',
+  'nowruz',
+];
+
+const seasonalAnchorKeywords = [
+  'vårdagjämningen',
+  'höstdagjämningen',
+  'sommarsolståndet',
+  'valborgsmässoafton',
+  'halloween',
+  'nobeldagen',
+  'fars dag',
+  'mors dag',
+  'alla hjärtans dag',
+  'star wars-dagen',
+  'kanelbullens dag',
+  'rocka sockorna',
+];
+
+const mediumPositiveKeywords = [
+  'världs',
+  'internationella dagen för',
+  'internationella ',
+  'nationella ',
+  'nationaldag',
+  'poesi',
+  'skog',
+  'vatten',
+  'hav',
+  'havens',
+  'yoga',
+  'musik',
+  'djur',
+  'bibliotekarie',
+  'bok',
+  'språk',
+  'museum',
+  'cykel',
+  'klarspråk',
+];
+
+const noveltyKeywords = [
+  'taco',
+  'bull',
+  'lakrits',
+  'glass',
+  'pizza',
+  'choklad',
+  'våffel',
+  'kaffe',
+  'kebab',
+  'salad',
+  'salad day',
+  'selfie',
+  'batman',
+  'lego',
+];
+
+const weakOrNicheKeywords = [
+  'brandvarnar',
+  'automower',
+  'lönekonsult',
+  'receptionist',
+  'it-chef',
+  'upphandlar',
+  'syntolk',
+  'moldagen',
+  'dialersystem',
+  'skolmjölk',
+  'flaska',
+  'korv',
+  'parisar',
+  'fothälsa',
+  'vodka',
+  'ostkaka',
+  'linssoppa',
+  'salad day',
+  'world quality day',
+  'software freedom day',
+];
+
+function normalizeKeywords(keywords: string[]): string[] {
+  return keywords.map((keyword) => normalizeLabel(keyword));
+}
+
+const normalizedStrongPositiveKeywords = normalizeKeywords(strongPositiveKeywords);
+const normalizedSeasonalAnchorKeywords = normalizeKeywords(seasonalAnchorKeywords);
+const normalizedMediumPositiveKeywords = normalizeKeywords(mediumPositiveKeywords);
+const normalizedNoveltyKeywords = normalizeKeywords(noveltyKeywords);
+const normalizedWeakOrNicheKeywords = normalizeKeywords(weakOrNicheKeywords);
+
+function scoreByKeywords(normalizedLabel: string, keywords: string[], weight: number): number {
+  return keywords.some((keyword) => normalizedLabel.includes(keyword)) ? weight : 0;
+}
+
+function scoreThemeDay(dateKey: string, themeDay: string, index: number): number {
+  const normalized = normalizeLabel(themeDay);
+  let score = 100 - index;
+
+  const overrides = exactDateOverrides[dateKey];
+  if (overrides) {
+    const exactIndex = overrides.findIndex((value) => normalizeLabel(value) === normalized);
+    if (exactIndex >= 0) {
+      score += 400 - exactIndex * 30;
+    }
+  }
+
+  score += scoreByKeywords(normalized, normalizedStrongPositiveKeywords, 45);
+  score += scoreByKeywords(normalized, normalizedSeasonalAnchorKeywords, 35);
+  score += scoreByKeywords(normalized, normalizedMediumPositiveKeywords, 16);
+  score += scoreByKeywords(normalized, normalizedNoveltyKeywords, 6);
+  score -= scoreByKeywords(normalized, normalizedWeakOrNicheKeywords, 18);
+
+  if (normalized.startsWith('internationella dagen for')) {
+    score += 10;
+  }
+
+  if (normalized.includes('varlds') || normalized.includes('world')) {
+    score += 8;
+  }
+
+  if (normalized.includes('dag') && normalized.includes('namnsdag')) {
+    score -= 8;
+  }
+
+  return score;
+}
+
+export function prioritizeThemeDays(themeDays: string[], dateKey: string): string[] {
+  const overrides = curatedDateOverrides[dateKey] ?? exactDateOverrides[dateKey] ?? [];
+  const remaining = [...themeDays];
+  const prioritized: string[] = [];
+
+  for (const override of overrides) {
+    const matchIndex = remaining.findIndex(
+      (themeDay) => normalizeLabel(themeDay) === normalizeLabel(override)
+    );
+
+    if (matchIndex >= 0) {
+      prioritized.push(remaining[matchIndex]);
+      remaining.splice(matchIndex, 1);
+    }
+  }
+
+  const scoredRemainder = remaining
+    .map((themeDay, index) => ({
+      themeDay,
+      score: scoreThemeDay(dateKey, themeDay, index),
+      index,
+    }))
+    .sort((left, right) => right.score - left.score || left.index - right.index)
+    .map((entry) => entry.themeDay);
+
+  return [...prioritized, ...scoredRemainder];
+}

--- a/scripts/curate-theme-days-openai.js
+++ b/scripts/curate-theme-days-openai.js
@@ -1,0 +1,213 @@
+const fs = require('fs');
+const path = require('path');
+
+const API_URL = 'https://api.openai.com/v1/chat/completions';
+const DEFAULT_MODEL = process.env.OPENAI_MODEL || 'gpt-4.1-mini';
+const ROOT = path.resolve(__dirname, '..');
+const DATA_PATH = path.resolve(ROOT, 'fredagskoll-frontend', 'src', 'data', 'temadagarByDate.json');
+const OUTPUT_PATH = path.resolve(ROOT, 'docs', 'theme-day-priority-suggestions.json');
+
+function parseArgs(argv) {
+  const args = {
+    limit: null,
+    minCount: 2,
+    dates: null,
+    model: DEFAULT_MODEL,
+    output: OUTPUT_PATH,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === '--limit' && next) {
+      args.limit = Number(next);
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--min-count' && next) {
+      args.minCount = Number(next);
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--dates' && next) {
+      args.dates = next.split(',').map((value) => value.trim()).filter(Boolean);
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--model' && next) {
+      args.model = next.trim();
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--output' && next) {
+      args.output = path.resolve(ROOT, next);
+      index += 1;
+    }
+  }
+
+  return args;
+}
+
+function loadThemeDays() {
+  return JSON.parse(fs.readFileSync(DATA_PATH, 'utf8'));
+}
+
+function getCrowdedDates(data, options) {
+  const entries = Object.entries(data)
+    .filter(([, days]) => Array.isArray(days) && days.length >= options.minCount)
+    .sort((left, right) => right[1].length - left[1].length || left[0].localeCompare(right[0]));
+
+  const filtered = options.dates
+    ? entries.filter(([date]) => options.dates.includes(date))
+    : entries;
+
+  return options.limit ? filtered.slice(0, options.limit) : filtered;
+}
+
+function buildMessages(dateKey, themeDays) {
+  return [
+    {
+      role: 'system',
+      content:
+        'You are helping curate Swedish theme-day priorities for a public-facing calendar app. Return JSON only. Prefer the theme day that feels most meaningful, recognizable, socially useful, seasonally relevant, or genuinely fun to lead with for a general Swedish audience. Avoid choosing a niche corporate, hyper-technical, or low-signal observance unless it is clearly the strongest option available.',
+    },
+    {
+      role: 'user',
+      content: [
+        `Date: ${dateKey}`,
+        'Candidate theme days:',
+        ...themeDays.map((themeDay, index) => `${index + 1}. ${themeDay}`),
+        '',
+        'Pick the best primary theme day for the app to lead with.',
+        'Then give 1-2 backups and short scoring notes.',
+        'Prefer stable editorial judgment over random novelty.',
+      ].join('\n'),
+    },
+  ];
+}
+
+function buildResponseFormat() {
+  return {
+    type: 'json_schema',
+    json_schema: {
+      name: 'theme_day_priority_suggestion',
+      strict: true,
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          primaryThemeDay: { type: 'string' },
+          backupThemeDays: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+          reasoning: { type: 'string' },
+          scores: {
+            type: 'array',
+            items: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                themeDay: { type: 'string' },
+                audienceAppeal: { type: 'integer' },
+                culturalRelevance: { type: 'integer' },
+                socialValue: { type: 'integer' },
+                novelty: { type: 'integer' },
+                notes: { type: 'string' },
+              },
+              required: [
+                'themeDay',
+                'audienceAppeal',
+                'culturalRelevance',
+                'socialValue',
+                'novelty',
+                'notes',
+              ],
+            },
+          },
+        },
+        required: ['primaryThemeDay', 'backupThemeDays', 'reasoning', 'scores'],
+      },
+    },
+  };
+}
+
+async function fetchSuggestion(apiKey, model, dateKey, themeDays) {
+  const response = await fetch(API_URL, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      temperature: 0.2,
+      messages: buildMessages(dateKey, themeDays),
+      response_format: buildResponseFormat(),
+    }),
+  });
+
+  const body = await response.text();
+
+  if (!response.ok) {
+    throw new Error(`OpenAI request failed for ${dateKey}: ${response.status} ${body}`);
+  }
+
+  const parsed = JSON.parse(body);
+  const content = parsed.choices?.[0]?.message?.content;
+
+  if (!content) {
+    throw new Error(`OpenAI returned no content for ${dateKey}.`);
+  }
+
+  return JSON.parse(content);
+}
+
+function ensureDirectoryFor(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+async function main() {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error('OPENAI_API_KEY is required.');
+  }
+
+  const options = parseArgs(process.argv.slice(2));
+  const data = loadThemeDays();
+  const crowdedDates = getCrowdedDates(data, options);
+
+  const suggestions = [];
+
+  for (const [dateKey, themeDays] of crowdedDates) {
+    console.log(`Reviewing ${dateKey} (${themeDays.length})`);
+    const suggestion = await fetchSuggestion(apiKey, options.model, dateKey, themeDays);
+    suggestions.push({
+      date: dateKey,
+      candidateCount: themeDays.length,
+      themeDays,
+      suggestion,
+    });
+  }
+
+  const output = {
+    generatedAt: new Date().toISOString(),
+    model: options.model,
+    itemCount: suggestions.length,
+    suggestions,
+  };
+
+  ensureDirectoryFor(options.output);
+  fs.writeFileSync(options.output, `${JSON.stringify(output, null, 2)}\n`, 'utf8');
+  console.log(`Wrote suggestions to ${options.output}`);
+}
+
+main().catch((error) => {
+  console.error(error.message || error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## What this changes

This changes how the app chooses a lead theme day when several theme days land on the same date.

Until now, the app mostly followed source order from the raw theme-day data. That meant some dates led with whichever item happened to be listed first, even when another day on the same date was clearly more relevant, recognizable, or fun for a general Swedish audience.

Examples of the problem:
- March 21 could lead with `Internationella dagen f�r Nowruz` instead of `Rocka sockorna-dagen`
- dates with seasonal anchors, awareness days, or very recognizable Swedish observances could get buried behind weaker or more random entries

## What changed

The app now uses curated per-date theme-day priorities for all dates that have multiple theme days.

The flow is now:
- run an offline OpenAI-assisted curation pass over crowded dates
- save the suggested ordering into frontend data
- use that curated order first in runtime
- keep local scoring heuristics as fallback underneath

This PR includes:
- a full generated suggestion file for review and audit
- a curated runtime data file used by the app
- the runtime prioritization layer
- tests for the new ordering behavior
- a small offline script so the curation can be rerun later instead of becoming a one-time mystery

## Why this is better

It makes the app feel more intentional.

When multiple theme days share a date, the lead day should usually be the one that is:
- more culturally recognizable
- more socially meaningful
- more seasonally relevant
- or simply more obviously fun to foreground

That is a much better product behavior than treating source-array order as editorial judgment.

## Validation

I ran:
- `npm run build`
- `CI=true npm test -- --watch=false temadagar.test.ts App.test.tsx aiBlurbs.test.ts`

Both passed.
