### PR TITLE
[codex] Strengthen standout theme day copy

### DIFF
--- a/fredagskoll-frontend/package-lock.json
+++ b/fredagskoll-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vadkanmanfira-frontend",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vadkanmanfira-frontend",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",

--- a/fredagskoll-frontend/package.json
+++ b/fredagskoll-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vadkanmanfira-frontend",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/fredagskoll-frontend/src/buildInfo.generated.ts
+++ b/fredagskoll-frontend/src/buildInfo.generated.ts
@@ -1,6 +1,6 @@
 export const buildInfo = {
-  "version": "0.1.18",
-  "gitSha": "8de67df",
-  "buildRef": "8de67df",
-  "builtAt": "2026-03-15T11:35:59.801Z"
+  "version": "0.1.19",
+  "gitSha": "cd5b6f2",
+  "buildRef": "cd5b6f2",
+  "builtAt": "2026-03-15T11:43:40.817Z"
 } as const;

--- a/fredagskoll-frontend/src/releaseNotes.ts
+++ b/fredagskoll-frontend/src/releaseNotes.ts
@@ -8,6 +8,19 @@ export type ReleaseNote = {
 
 export const releaseNotes: ReleaseNote[] = [
   {
+    version: '0.1.19',
+    shortSummary: {
+      sv: 'Fler temadagar har fått mer egen röst och mindre generisk text.',
+      en: 'More theme days now have their own voice instead of generic copy.',
+      'pt-BR': 'Mais datas temáticas agora têm voz própria em vez de texto genérico.',
+    },
+    summary: {
+      sv: 'Flera tydliga temadagar, som Saint Patrick’s day, Rocka sockorna-dagen, Kanelbullens dag och Nobeldagen, har fått mer egen och mer minnesvärd text. Resultatet är att “Ny ursäkt” oftare känns som att den faktiskt hör till just den dagen i stället för att låta som en allmän temadagsmall.',
+      en: 'Several standout theme days, such as Saint Patrick’s Day, Rock Your Socks Day, Cinnamon Bun Day, and Nobel Day, now have more distinct and memorable writing. The result is that “New excuse” more often feels tied to that specific day instead of sounding like a generic theme-day template.',
+      'pt-BR': 'Várias datas temáticas mais marcantes, como Saint Patrick’s Day, Rock Your Socks Day, Cinnamon Bun Day e Nobel Day, agora têm textos mais próprios e memoráveis. O resultado é que “Nova desculpa” parece com mais frequência algo realmente ligado àquele dia, em vez de soar como um modelo genérico.',
+    },
+  },
+  {
     version: '0.1.18',
     shortSummary: {
       sv: 'Temadagar väljs nu mer vettigt när flera krockar samma dag.',

--- a/fredagskoll-frontend/src/themeDayBlurbs.test.ts
+++ b/fredagskoll-frontend/src/themeDayBlurbs.test.ts
@@ -27,3 +27,19 @@ test('does not generate plural self-reference blurbs for a single themeday', () 
     )
   ).toBe(false);
 });
+
+test('uses dedicated copy for Saint Patricks day instead of generic filler', () => {
+  const blurbs = buildThemeDayBlurbs(["Saint Patrick's day"]);
+
+  expect(
+    blurbs.some((blurb) => blurb.includes('grönt plötsligt uppträder som fullgod personlighet'))
+  ).toBe(true);
+});
+
+test('uses dedicated copy for Rocka sockorna-dagen', () => {
+  const blurbs = buildThemeDayBlurbs(['Rocka sockorna-dagen']);
+
+  expect(
+    blurbs.some((blurb) => blurb.includes('färg och moralisk ryggrad'))
+  ).toBe(true);
+});

--- a/fredagskoll-frontend/src/themeDaySpecificBlurbs.ts
+++ b/fredagskoll-frontend/src/themeDaySpecificBlurbs.ts
@@ -132,6 +132,78 @@ export function getThemeDaySpecificBlurbs(
   const normalized = normalizeLabel(themeDay);
   const overrides: Array<[string, string[]]> = [
     [
+      "saint patrick's day",
+      [
+        "Saint Patrick's day är dagen då grönt plötsligt uppträder som fullgod personlighet och ingen riktigt orkar invända.",
+        "Det är Saint Patrick's day idag, alltså datumet då irländsk myt, pubenergi och kollektiv färgkoordinering går ihop i ett märkligt fungerande paket.",
+        "Saint Patrick's day ger kalendern exakt den sortens självsäker folklore som vanliga vardagar bara kan drömma om.",
+      ],
+    ],
+    [
+      'rocka sockorna-dagen',
+      [
+        'Rocka sockorna-dagen lyckas vara både varm, synlig och faktiskt värd att bry sig om, vilket inte direkt gäller varje temadag.',
+        'Det är Rocka sockorna-dagen idag, alltså en av få dagar där ett litet symboliskt grepp faktiskt säger något vettigt om hur vi ser på varandra.',
+        'Rocka sockorna-dagen ger datumet både färg och moralisk ryggrad. Det är mer än kalendern brukar erbjuda gratis.',
+      ],
+    ],
+    [
+      'vårdagjämningen',
+      [
+        'Vårdagjämningen känns som en av få kalenderpunkter som inte behöver marknadsföring för att bära sig själv.',
+        'Det är Vårdagjämningen idag, alltså den officiella starten på årstiden där svenskar långsamt återgår till att tro på livet.',
+        'Vårdagjämningen ger dagen en sorts stillsam tyngd som gör resten av temadagssällskapet märkbart mindre viktigt.',
+      ],
+    ],
+    [
+      'sommarsolståndet',
+      [
+        'Sommarsolståndet kommer in med så mycket egen auktoritet att resten av dagens temadagar mest får stå vid sidan och nicka.',
+        'Det är Sommarsolståndet idag, alltså datumet då ljuset tar över helt och folk börjar resonera som om sömn vore en valfri tjänst.',
+        'Sommarsolståndet gör dagen större än vanligt. Det är inte pynt, det är själva årstiden som kliver in och tar ordet.',
+      ],
+    ],
+    [
+      'kanelbullens dag',
+      [
+        'Kanelbullens dag är så djupt etablerad att den knappt ens känns som temadag längre. Den känns som civil ordning.',
+        'Det är Kanelbullens dag idag, alltså ett tillfälle då Sverige kollektivt accepterar att kardemumma får driva samhällsutvecklingen några timmar.',
+        'Kanelbullens dag ger datumet exakt rätt blandning av trygghet, socker och nationell självbild.',
+      ],
+    ],
+    [
+      'star wars-dagen',
+      [
+        'Star wars-dagen är den sortens nördhögtid som gått så långt att ingen längre låtsas att den bara är ett skämt.',
+        'Det är Star wars-dagen idag, vilket betyder att ett mycket stort antal vuxna människor tänker "May the Fourth" och känner sig nöjda med sig själva.',
+        'Star wars-dagen ger datumet en fullt fungerande blandning av popkultur, ritual och obefogat självförtroende.',
+      ],
+    ],
+    [
+      'internationella fredsdagen',
+      [
+        'Internationella fredsdagen är en ovanligt seriös påminnelse om att världen blir bättre av mer eftertanke och betydligt mindre idioti.',
+        'Det är Internationella fredsdagen idag, alltså en dag som faktiskt har större ambitioner än att bara sälja bakverk eller prylar.',
+        'Internationella fredsdagen ger datumet en tyngd som gör det svårt att behandla det som ännu ett dekorativt kalenderpåhitt.',
+      ],
+    ],
+    [
+      'halloween',
+      [
+        'Halloween har sedan länge passerat gränsen för importerat påhitt och gått över till att vara fullgod mörkerteater med folkligt stöd.',
+        'Det är Halloween idag, alltså datumet då pumpor, socker och lätt organiserad dödsestetik får verka helt rimliga tillsammans.',
+        'Halloween ger kalendern ett ovanligt starkt visuellt självförtroende. Det får man nästan respektera.',
+      ],
+    ],
+    [
+      'nobeldagen',
+      [
+        'Nobeldagen bär sig med den sortens stel elegans som får resten av temadagskatalogen att se ut som ett studentprojekt.',
+        'Det är Nobeldagen idag, alltså en dag då vetenskap, litteratur och väldigt kontrollerad festlighet får tala med full auktoritet.',
+        'Nobeldagen ger datumet ett ovanligt högtidligt självförtroende och faktiskt tillräcklig substans för att motivera det.',
+      ],
+    ],
+    [
       'matladans dag',
       [
         'Matlådans dag är i praktiken ett erkännande av kall disciplin i plastform.',


### PR DESCRIPTION
## What this changes

This follow-up strengthens the actual writing for standout theme days.

The theme-day prioritization work fixed which day gets picked when several theme days share a date, but some of the picked days still sounded too generic once they reached the visible blurb layer. Saint Patrick's Day was a good example: the app could choose the right day and still describe it with copy that felt like a generic theme-day template.

## Fix

I added dedicated blurb writing for a set of more recognizable and personality-heavy theme days, including:
- Saint Patrick's Day
- Rocka sockorna-dagen
- V�rdagj�mningen
- Sommarsolst�ndet
- Kanelbullens dag
- Star wars-dagen
- Internationella fredsdagen
- Halloween
- Nobeldagen

That means the visible "Ny urs�kt" text now lands with more day-specific voice instead of falling through to generic category copy as often.

## Validation

I ran:
- `npm run build`
- `CI=true npm test -- --watch=false themeDayBlurbs.test.ts temadagar.test.ts App.test.tsx aiBlurbs.test.ts`

Both passed.
