### PR TITLE
[codex] Move upcoming dates into the main panel

### DIFF
--- a/fredagskoll-frontend/package-lock.json
+++ b/fredagskoll-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vadkanmanfira-frontend",
-  "version": "0.1.19",
+  "version": "0.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vadkanmanfira-frontend",
-      "version": "0.1.19",
+      "version": "0.1.21",
       "dependencies": {
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",

--- a/fredagskoll-frontend/package.json
+++ b/fredagskoll-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vadkanmanfira-frontend",
-  "version": "0.1.19",
+  "version": "0.1.21",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/fredagskoll-frontend/src/App.test.tsx
+++ b/fredagskoll-frontend/src/App.test.tsx
@@ -360,7 +360,7 @@ test('renders an upcoming official holiday note when one lands later that week',
 test('renders upcoming notable dates with major celebrations ahead of random filler', async () => {
   await renderAppAt(new Date(2026, 3, 27));
 
-  expect(screen.getByText(/På gång/i)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /På gång/i })).toBeInTheDocument();
   expect(screen.getByText(/^Valborg$/i)).toBeInTheDocument();
   expect(screen.getAllByText(/^Första maj$/i).length).toBeGreaterThan(0);
   expect(screen.getAllByText(/Om 3 dagar/i).length).toBeGreaterThan(0);
@@ -637,4 +637,36 @@ test('only asks for another ai variant when reroll is clicked', async () => {
   await waitFor(() =>
     expect(screen.getByText(/Ny ai-text efter reroll\./i)).toBeInTheDocument()
   );
+});
+
+test('scrolls back to the main card after confirming a mobile date change', async () => {
+  jest.useFakeTimers();
+
+  const matchMediaMock = jest.fn().mockReturnValue({
+    matches: true,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  });
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: matchMediaMock,
+  });
+
+  const scrollIntoViewMock = jest.fn();
+  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    writable: true,
+    value: scrollIntoViewMock,
+  });
+
+  await renderAppAt(new Date(2026, 2, 14));
+
+  fireEvent.change(screen.getByLabelText(/Välj datum/i), {
+    target: { value: '2026-03-15' },
+  });
+
+  jest.advanceTimersByTime(150);
+
+  expect(scrollIntoViewMock).toHaveBeenCalled();
+
+  jest.useRealTimers();
 });

--- a/fredagskoll-frontend/src/App.tsx
+++ b/fredagskoll-frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import './App.css';
 import { AiBlurbRequest } from './aiBlurbs';
 import { appText } from './appText';
@@ -21,6 +21,7 @@ import {
   formatCenterDate,
   formatForHumans,
   formatForInput,
+  formatShortSwedishDate,
   getDaysUntil,
 } from './dateUtils';
 import { getDayStatus, getUpcomingOfficialHolidayInWeek } from './dayLogic';
@@ -36,6 +37,7 @@ import {
 import { getNationalDayPanel } from './nationalDays';
 import { getSeasonalNotes } from './seasonalNotes';
 import { getInitialMood, getMoodLabel, MOOD_STORAGE_KEY, Mood } from './mood';
+import { getReleaseNote } from './releaseNotes';
 import { buildThemeDayBlurbs, filterThemeDays, joinWithAnd } from './themeDayBlurbs';
 import { getThemeDaysForDate } from './temadagar';
 import { getUpcomingNotables } from './upcomingNotables';
@@ -70,9 +72,11 @@ function App({
     worldNationalDays: true,
   });
   const [selectedDate, setSelectedDate] = useState(formatForInput(initialDate));
+  const mainCardRef = useRef<HTMLElement | null>(null);
 
   const text = appText[locale];
   const buildStamp = useMemo(() => formatBuildStamp(locale), [locale]);
+  const currentReleaseNote = useMemo(() => getReleaseNote(buildInfo.version), []);
   const celebrations = useMemo(
     () => getCelebrations(locale, contentPack, mood),
     [contentPack, locale, mood]
@@ -259,6 +263,21 @@ function App({
     setSelectedDate(formatForInput(addDays(selectedDateObject, days)));
   }
 
+  function handleDateChange(nextDate: string): void {
+    setSelectedDate(nextDate);
+
+    if (!isMobileLayout || typeof window === 'undefined') {
+      return;
+    }
+
+    window.setTimeout(() => {
+      mainCardRef.current?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'start',
+      });
+    }, 120);
+  }
+
   function toggleMobileSection(section: MobileSectionKey): void {
     setExpandedSections((current) => ({
       ...current,
@@ -277,7 +296,6 @@ function App({
           locale={locale}
           darkMode={darkMode}
           contentPack={contentPack}
-          buildStamp={buildStamp}
           mood={mood}
           selectedDate={selectedDate}
           humanDate={humanDate}
@@ -288,209 +306,280 @@ function App({
           upcomingHolidayDate={upcomingHoliday?.date}
           daysUntilHoliday={daysUntilHoliday}
           seasonalNotes={seasonalNotes}
-          upcomingNotables={upcomingNotables}
           isMobileLayout={isMobileLayout}
           showLanguageMenu={showLanguageMenu}
           expandedSections={expandedSections}
-          currentReleaseVersion={buildInfo.version}
           onToggleLanguageMenu={() => setShowLanguageMenu((current) => !current)}
           onToggleDarkMode={() => setDarkMode((current) => !current)}
           onSelectLocale={setLocale}
           onSelectMood={setMood}
-          onDateChange={setSelectedDate}
+          onDateChange={handleDateChange}
           onToggleMobileSection={toggleMobileSection}
-          onOpenImageCredits={() => setShowImageCredits(true)}
-          onOpenReleaseNotes={() => setShowReleaseNotes(true)}
         />
 
-        <main className="app-panel celebration-card">
-          <div className="card-nav" aria-label={text.dateNavigationAria}>
-            <button
-              type="button"
-              className="card-nav-button"
-              onClick={() => stepSelectedDate(-1)}
-            >
-              {text.previousDay}
-            </button>
-            <p className="card-date">{centerDate}</p>
-            <button
-              type="button"
-              className="card-nav-button"
-              onClick={() => stepSelectedDate(1)}
-            >
-              {text.nextDay}
-            </button>
-          </div>
-
-          <div className="card-kicker-row">
-            <p className="eyebrow">{kicker}</p>
-            <span className="mood-pill">{getMoodLabel(mood, locale)}</span>
-          </div>
-
-          {themeDayDisplayTitle && !celebration ? (
-            <h2
-              className={`celebration-title celebration-title--stacked${
-                hasLongWordTitle ? ' celebration-title--longword' : ''
-              }`}
-            >
-              {themeDayDisplayTitle}.
-              <span className="celebration-title-subline">
-                {isAiBundleLoading ? text.blurbLoading : themeDayTitleEnding}
-              </span>
-            </h2>
-          ) : celebrationSubtitle ? (
-            <h2
-              className={`celebration-title celebration-title--stacked${
-                hasLongWordTitle ? ' celebration-title--longword' : ''
-              }`}
-            >
-              {formatTitle(mainTitle)}
-              <span className="celebration-title-subline">{celebrationSubtitle}</span>
-            </h2>
-          ) : (
-            <h2
-              className={`celebration-title${
-                hasLongWordTitle ? ' celebration-title--longword' : ''
-              }`}
-            >
-              {formatTitle(mainTitle)}
-            </h2>
-          )}
-
-          <div className="blurb-row">
-            {isAiBundleLoading ? (
-              <p className="celebration-blurb celebration-blurb--loading" aria-live="polite">
-                {text.blurbLoading}
-              </p>
-            ) : (
-              <p className="celebration-blurb">{blurb}</p>
-            )}
-            {currentBlurbs && !isAiBundleLoading ? (
+        <div className="app-main-column">
+          <main ref={mainCardRef} className="app-panel celebration-card">
+            <div className="card-nav" aria-label={text.dateNavigationAria}>
               <button
                 type="button"
-                className="reroll-button"
-                onClick={() => {
-                  void handleReroll();
-                }}
-                disabled={isAiRerolling}
+                className="card-nav-button"
+                onClick={() => stepSelectedDate(-1)}
               >
-                {text.reroll}
+                {text.previousDay}
               </button>
-            ) : null}
-          </div>
+              <p className="card-date">{centerDate}</p>
+              <button
+                type="button"
+                className="card-nav-button"
+                onClick={() => stepSelectedDate(1)}
+              >
+                {text.nextDay}
+              </button>
+            </div>
 
-          {celebration ? (
-            <>
-              <div className="media-grid">
-                {celebration.primaryImage ? (
-                  <figure
-                    className={`media-card media-card--primary${
-                      compactPrimaryMedia ? ' media-card--compact' : ''
-                    }`}
-                  >
-                    <img src={celebration.primaryImage} alt={celebration.alt ?? celebration.title} />
-                  </figure>
-                ) : null}
-                {celebration.secondaryImage ? (
-                  <figure className="media-card">
-                    <img
-                      src={celebration.secondaryImage}
-                      alt={`${celebration.alt ?? celebration.title} extra`}
-                    />
-                  </figure>
-                ) : null}
-                {!celebration.primaryImage && !celebration.secondaryImage ? (
-                  <div className="placeholder-card placeholder-card--visual">
-                    <span>{celebration.visualBadge ?? text.noImageBadge}</span>
-                    <strong>{celebration.visualTitle ?? text.noImageTitle}</strong>
-                    <p>{celebration.visualBody ?? text.noImageBody}</p>
-                  </div>
-                ) : null}
-              </div>
+            <div className="card-kicker-row">
+              <p className="eyebrow">{kicker}</p>
+              <span className="mood-pill">{getMoodLabel(mood, locale)}</span>
+            </div>
 
-              {extraDisplayThemeDays.length > 0 ? (
-                <DisclosurePanel
-                  className="theme-day-panel"
-                  isOpen={expandedSections.extraThemeDays}
-                  onToggle={() => toggleMobileSection('extraThemeDays')}
-                  badge={text.extraThemeDays}
-                  title={text.extraThemeDays}
+            {themeDayDisplayTitle && !celebration ? (
+              <h2
+                className={`celebration-title celebration-title--stacked${
+                  hasLongWordTitle ? ' celebration-title--longword' : ''
+                }`}
+              >
+                {themeDayDisplayTitle}.
+                <span className="celebration-title-subline">
+                  {isAiBundleLoading ? text.blurbLoading : themeDayTitleEnding}
+                </span>
+              </h2>
+            ) : celebrationSubtitle ? (
+              <h2
+                className={`celebration-title celebration-title--stacked${
+                  hasLongWordTitle ? ' celebration-title--longword' : ''
+                }`}
+              >
+                {formatTitle(mainTitle)}
+                <span className="celebration-title-subline">{celebrationSubtitle}</span>
+              </h2>
+            ) : (
+              <h2
+                className={`celebration-title${
+                  hasLongWordTitle ? ' celebration-title--longword' : ''
+                }`}
+              >
+                {formatTitle(mainTitle)}
+              </h2>
+            )}
+
+            <div className="blurb-row">
+              {isAiBundleLoading ? (
+                <p className="celebration-blurb celebration-blurb--loading" aria-live="polite">
+                  {text.blurbLoading}
+                </p>
+              ) : (
+                <p className="celebration-blurb">{blurb}</p>
+              )}
+              {currentBlurbs && !isAiBundleLoading ? (
+                <button
+                  type="button"
+                  className="reroll-button"
+                  onClick={() => {
+                    void handleReroll();
+                  }}
+                  disabled={isAiRerolling}
                 >
-                  <p>
-                    {getAsIfThatWasNotEnough(
-                      locale,
-                      mood,
-                      extraThemeDayLead ?? '',
-                      joinWithAnd(extraDisplayThemeDays, locale)
-                    )}
-                  </p>
+                  {text.reroll}
+                </button>
+              ) : null}
+            </div>
+
+            {celebration ? (
+              <>
+                <div className="media-grid">
+                  {celebration.primaryImage ? (
+                    <figure
+                      className={`media-card media-card--primary${
+                        compactPrimaryMedia ? ' media-card--compact' : ''
+                      }`}
+                    >
+                      <img src={celebration.primaryImage} alt={celebration.alt ?? celebration.title} />
+                    </figure>
+                  ) : null}
+                  {celebration.secondaryImage ? (
+                    <figure className="media-card">
+                      <img
+                        src={celebration.secondaryImage}
+                        alt={`${celebration.alt ?? celebration.title} extra`}
+                      />
+                    </figure>
+                  ) : null}
+                  {!celebration.primaryImage && !celebration.secondaryImage ? (
+                    <div className="placeholder-card placeholder-card--visual">
+                      <span>{celebration.visualBadge ?? text.noImageBadge}</span>
+                      <strong>{celebration.visualTitle ?? text.noImageTitle}</strong>
+                      <p>{celebration.visualBody ?? text.noImageBody}</p>
+                    </div>
+                  ) : null}
+                </div>
+
+                {extraDisplayThemeDays.length > 0 ? (
+                  <DisclosurePanel
+                    className="theme-day-panel"
+                    isOpen={expandedSections.extraThemeDays}
+                    onToggle={() => toggleMobileSection('extraThemeDays')}
+                    badge={text.extraThemeDays}
+                    title={text.extraThemeDays}
+                  >
+                    <p>
+                      {getAsIfThatWasNotEnough(
+                        locale,
+                        mood,
+                        extraThemeDayLead ?? '',
+                        joinWithAnd(extraDisplayThemeDays, locale)
+                      )}
+                    </p>
+                    <ul className="theme-day-list">
+                      {extraDisplayThemeDays.map((themeDay) => (
+                        <li key={themeDay}>{themeDay}</li>
+                      ))}
+                    </ul>
+                  </DisclosurePanel>
+                ) : null}
+              </>
+            ) : (
+              <DisclosurePanel
+                className="ordinary-card"
+                isOpen={!hasThemeDays || expandedSections.themeDays}
+                onToggle={() => {
+                  if (hasThemeDays) {
+                    toggleMobileSection('themeDays');
+                  }
+                }}
+                badge={hasThemeDays ? text.todayThemeDays : text.noHit}
+                title={hasThemeDays ? text.todayThemeDays : text.noHit}
+              >
+                <p>
+                  {hasThemeDays && isAiBundleLoading
+                    ? text.blurbLoading
+                    : hasThemeDays
+                      ? getOrdinaryThemeDayLead(
+                          locale,
+                          mood,
+                          joinWithAnd(displayThemeDays, locale),
+                          themeDayCardNote
+                        )
+                      : getOrdinaryNoHitBody(locale, mood)}
+                </p>
+                {hasThemeDays ? (
                   <ul className="theme-day-list">
-                    {extraDisplayThemeDays.map((themeDay) => (
+                    {displayThemeDays.map((themeDay) => (
                       <li key={themeDay}>{themeDay}</li>
                     ))}
                   </ul>
-                </DisclosurePanel>
-              ) : null}
-            </>
-          ) : (
-            <DisclosurePanel
-              className="ordinary-card"
-              isOpen={!hasThemeDays || expandedSections.themeDays}
-              onToggle={() => {
-                if (hasThemeDays) {
-                  toggleMobileSection('themeDays');
-                }
-              }}
-              badge={hasThemeDays ? text.todayThemeDays : text.noHit}
-              title={hasThemeDays ? text.todayThemeDays : text.noHit}
-            >
-              <p>
-                {hasThemeDays && isAiBundleLoading
-                  ? text.blurbLoading
-                  : hasThemeDays
-                    ? getOrdinaryThemeDayLead(
-                        locale,
-                        mood,
-                        joinWithAnd(displayThemeDays, locale),
-                        themeDayCardNote
-                      )
-                    : getOrdinaryNoHitBody(locale, mood)}
-              </p>
-              {hasThemeDays ? (
-                <ul className="theme-day-list">
-                  {displayThemeDays.map((themeDay) => (
-                    <li key={themeDay}>{themeDay}</li>
+                ) : null}
+              </DisclosurePanel>
+            )}
+
+            {nationalDayPanel ? (
+              <DisclosurePanel
+                className="world-day-panel"
+                isOpen={expandedSections.worldNationalDays}
+                onToggle={() => toggleMobileSection('worldNationalDays')}
+                badge={text.worldNationalDaysBadge}
+                title={text.worldNationalDays}
+              >
+                <p className="world-day-summary">{nationalDayPanel.summary}</p>
+                <ul className="theme-day-list world-day-list">
+                  {nationalDayPanel.items.map((item) => (
+                    <li key={`${item.nation}-${item.significance}`}>
+                      <strong>{item.nation}</strong>
+                      <span>{item.significance}</span>
+                    </li>
                   ))}
                 </ul>
-              ) : null}
-            </DisclosurePanel>
-          )}
+                {nationalDayPanel.hiddenCount > 0 ? (
+                  <p className="world-day-more">
+                    {text.worldNationalDaysMore(nationalDayPanel.hiddenCount)}
+                  </p>
+                ) : null}
+              </DisclosurePanel>
+            ) : null}
 
-          {nationalDayPanel ? (
-            <DisclosurePanel
-              className="world-day-panel"
-              isOpen={expandedSections.worldNationalDays}
-              onToggle={() => toggleMobileSection('worldNationalDays')}
-              badge={text.worldNationalDaysBadge}
-              title={text.worldNationalDays}
-            >
-              <p className="world-day-summary">{nationalDayPanel.summary}</p>
-              <ul className="theme-day-list world-day-list">
-                {nationalDayPanel.items.map((item) => (
-                  <li key={`${item.nation}-${item.significance}`}>
-                    <strong>{item.nation}</strong>
-                    <span>{item.significance}</span>
-                  </li>
-                ))}
-              </ul>
-              {nationalDayPanel.hiddenCount > 0 ? (
-                <p className="world-day-more">
-                  {text.worldNationalDaysMore(nationalDayPanel.hiddenCount)}
-                </p>
-              ) : null}
-            </DisclosurePanel>
-          ) : null}
-        </main>
+            {upcomingNotables.length > 0 ? (
+              <DisclosurePanel
+                className="upcoming-card"
+                isOpen={expandedSections.upcoming}
+                onToggle={() => toggleMobileSection('upcoming')}
+                title={text.upcoming}
+              >
+                <div className="upcoming-list">
+                  {upcomingNotables.map((item) => (
+                    <article key={item.dateLabel} className="upcoming-item">
+                      <div className="upcoming-item-top">
+                        <span className="upcoming-label">{item.label}</span>
+                        <span className="upcoming-days">
+                          {item.daysUntil === 1
+                            ? text.upcomingTomorrow
+                            : text.upcomingInDays(item.daysUntil)}
+                        </span>
+                      </div>
+                      <p className="upcoming-title">{item.title}</p>
+                      <p className="upcoming-date">
+                        {formatShortSwedishDate(item.date, locale)}
+                      </p>
+                      <p className="upcoming-note">{item.note}</p>
+                    </article>
+                  ))}
+                </div>
+              </DisclosurePanel>
+            ) : null}
+          </main>
+
+          <footer className="app-panel main-footer-meta">
+            <div className="main-footer-links">
+              <button
+                type="button"
+                className="source-link source-link--button"
+                onClick={() => setShowImageCredits(true)}
+              >
+                {text.imageCredits}
+              </button>
+              <a
+                className="source-link"
+                href="https://temadagar.se/kalender/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                {text.themeDaySource}
+              </a>
+              <a
+                className="source-link"
+                href="https://sholiday.faboul.se/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                {text.namedaySource}
+              </a>
+            </div>
+            <div className="release-note-card release-note-card--subtle main-release-note-card">
+              <p className="eyebrow">{text.releaseNotesLabel}</p>
+              <p className="release-note-current">
+                {currentReleaseNote?.shortSummary[locale] ?? buildStamp}
+              </p>
+              <button
+                type="button"
+                className="source-link source-link--button release-note-button"
+                onClick={() => setShowReleaseNotes(true)}
+              >
+                {text.releaseNotesOpen}
+              </button>
+            </div>
+            <span className="build-stamp">
+              {text.buildInfoLabel} {buildStamp}
+            </span>
+          </footer>
+        </div>
       </div>
 
       <AppDialogs

--- a/fredagskoll-frontend/src/appText.ts
+++ b/fredagskoll-frontend/src/appText.ts
@@ -100,6 +100,7 @@ export const appText: Record<
     releaseNotesOpen: string;
     imageCredits: string;
     themeDaySource: string;
+    namedaySource: string;
     previousDay: string;
     nextDay: string;
     reroll: string;
@@ -168,6 +169,7 @@ export const appText: Record<
     releaseNotesOpen: 'Visa alla ändringar',
     imageCredits: 'Bildkällor',
     themeDaySource: 'Temadagar inspirerade av temadagar.se',
+    namedaySource: 'Namnsdagar via sholiday.faboul.se',
     previousDay: 'Föregående dag',
     nextDay: 'Nästa dag',
     reroll: 'Ny ursäkt',
@@ -240,6 +242,7 @@ export const appText: Record<
     releaseNotesOpen: 'Show all changes',
     imageCredits: 'Image credits',
     themeDaySource: 'Theme days inspired by temadagar.se',
+    namedaySource: 'Name days via sholiday.faboul.se',
     previousDay: 'Previous day',
     nextDay: 'Next day',
     reroll: 'New excuse',
@@ -312,6 +315,7 @@ export const appText: Record<
     releaseNotesOpen: 'Mostrar todas as mudanças',
     imageCredits: 'Créditos das imagens',
     themeDaySource: 'Datas temáticas inspiradas em temadagar.se',
+    namedaySource: 'Nomes do dia via sholiday.faboul.se',
     previousDay: 'Dia anterior',
     nextDay: 'Próximo dia',
     reroll: 'Nova desculpa',

--- a/fredagskoll-frontend/src/buildInfo.generated.ts
+++ b/fredagskoll-frontend/src/buildInfo.generated.ts
@@ -1,6 +1,6 @@
 export const buildInfo = {
-  "version": "0.1.19",
-  "gitSha": "cd5b6f2",
-  "buildRef": "cd5b6f2",
-  "builtAt": "2026-03-15T11:43:40.817Z"
+  "version": "0.1.21",
+  "gitSha": "c7e8d11",
+  "buildRef": "c7e8d11",
+  "builtAt": "2026-03-15T12:04:43.555Z"
 } as const;

--- a/fredagskoll-frontend/src/components/IntroPanel.tsx
+++ b/fredagskoll-frontend/src/components/IntroPanel.tsx
@@ -7,9 +7,7 @@ import { formatShortSwedishDate } from '../dateUtils';
 import { formatDaysUntilLabel, getUpcomingHolidayBlurb } from '../holidayPresentation';
 import { joinWithConjunction, Locale, localeOptions } from '../locale';
 import { getMoodLabel, getMoodNote, Mood, moodOptions } from '../mood';
-import { getReleaseNote } from '../releaseNotes';
 import { MobileSectionKey } from '../appTypes';
-import { DisclosurePanel } from './DisclosurePanel';
 import { MobileSection } from './MobileSection';
 
 type SeasonalNote = {
@@ -20,20 +18,10 @@ type SeasonalNote = {
   note: string;
 };
 
-type UpcomingNote = {
-  dateLabel: string;
-  label: string;
-  daysUntil: number;
-  title: string;
-  date: Date;
-  note: string;
-};
-
 type IntroPanelProps = {
   locale: Locale;
   darkMode: boolean;
   contentPack: ContentPack;
-  buildStamp: string;
   mood: Mood;
   selectedDate: string;
   humanDate: string;
@@ -44,26 +32,21 @@ type IntroPanelProps = {
   upcomingHolidayDate?: Date;
   daysUntilHoliday: number | null;
   seasonalNotes: SeasonalNote[];
-  upcomingNotables: UpcomingNote[];
   isMobileLayout: boolean;
   showLanguageMenu: boolean;
   expandedSections: Record<MobileSectionKey, boolean>;
-  currentReleaseVersion: string;
   onToggleLanguageMenu: () => void;
   onToggleDarkMode: () => void;
   onSelectLocale: (locale: Locale) => void;
   onSelectMood: (mood: Mood) => void;
   onDateChange: (date: string) => void;
   onToggleMobileSection: (section: MobileSectionKey) => void;
-  onOpenImageCredits: () => void;
-  onOpenReleaseNotes: () => void;
 };
 
 export function IntroPanel({
   locale,
   darkMode,
   contentPack,
-  buildStamp,
   mood,
   selectedDate,
   humanDate,
@@ -74,22 +57,17 @@ export function IntroPanel({
   upcomingHolidayDate,
   daysUntilHoliday,
   seasonalNotes,
-  upcomingNotables,
   isMobileLayout,
   showLanguageMenu,
   expandedSections,
-  currentReleaseVersion,
   onToggleLanguageMenu,
   onToggleDarkMode,
   onSelectLocale,
   onSelectMood,
   onDateChange,
   onToggleMobileSection,
-  onOpenImageCredits,
-  onOpenReleaseNotes,
 }: IntroPanelProps) {
   const text = appText[locale];
-  const currentReleaseNote = getReleaseNote(currentReleaseVersion);
 
   return (
     <header className="app-panel app-panel--intro">
@@ -247,68 +225,6 @@ export function IntroPanel({
         </MobileSection>
       ) : null}
 
-      {upcomingNotables.length > 0 ? (
-        <DisclosurePanel
-          className="upcoming-card"
-          isOpen={expandedSections.upcoming}
-          onToggle={() => onToggleMobileSection('upcoming')}
-          title={text.upcoming}
-        >
-          <div className="upcoming-list">
-            {upcomingNotables.map((item) => (
-              <article key={item.dateLabel} className="upcoming-item">
-                <div className="upcoming-item-top">
-                  <span className="upcoming-label">{item.label}</span>
-                  <span className="upcoming-days">
-                    {item.daysUntil === 1
-                      ? text.upcomingTomorrow
-                      : text.upcomingInDays(item.daysUntil)}
-                  </span>
-                </div>
-                <p className="upcoming-title">{item.title}</p>
-                <p className="upcoming-date">{formatShortSwedishDate(item.date, locale)}</p>
-                <p className="upcoming-note">{item.note}</p>
-              </article>
-            ))}
-          </div>
-        </DisclosurePanel>
-      ) : null}
-
-      <footer className="intro-footer">
-        <div className="intro-footer-links">
-          <button
-            type="button"
-            className="source-link source-link--button"
-            onClick={onOpenImageCredits}
-          >
-            {text.imageCredits}
-          </button>
-          <a
-            className="source-link"
-            href="https://temadagar.se/kalender/"
-            target="_blank"
-            rel="noreferrer"
-          >
-            {text.themeDaySource}
-          </a>
-          <span className="build-stamp">
-            {text.buildInfoLabel} {buildStamp}
-          </span>
-        </div>
-        <div className="release-note-card release-note-card--subtle">
-          <p className="eyebrow">{text.releaseNotesLabel}</p>
-          <p className="release-note-current">
-            {currentReleaseNote?.shortSummary[locale] ?? buildStamp}
-          </p>
-          <button
-            type="button"
-            className="source-link source-link--button release-note-button"
-            onClick={onOpenReleaseNotes}
-          >
-            {text.releaseNotesOpen}
-          </button>
-        </div>
-      </footer>
     </header>
   );
 }

--- a/fredagskoll-frontend/src/releaseNotes.ts
+++ b/fredagskoll-frontend/src/releaseNotes.ts
@@ -8,6 +8,32 @@ export type ReleaseNote = {
 
 export const releaseNotes: ReleaseNote[] = [
   {
+    version: '0.1.21',
+    shortSummary: {
+      sv: 'På gång har flyttat till högersidan och footern ligger lägre.',
+      en: 'Upcoming dates moved to the right side and the footer now sits lower.',
+      'pt-BR': 'O bloco de próximas datas foi para a direita e o rodapé agora fica mais baixo.',
+    },
+    summary: {
+      sv: 'På gång ligger nu i en egen panel på högersidan under Också idag, så vänsterspalten kan fokusera på val och snabb överblick. Samtidigt ligger källor, versionsnytt och bygge längre ner och följer helheten bättre i layouten.',
+      en: 'Upcoming dates now live in their own panel on the right side below Also today, so the left column can focus on controls and quick context. At the same time, sources, release notes, and build info sit lower and follow the overall layout more naturally.',
+      'pt-BR': 'As próximas datas agora ficam em seu próprio painel à direita, abaixo de Também hoje, para a coluna da esquerda focar nos controles e no contexto rápido. Ao mesmo tempo, fontes, novidades da versão e build ficaram mais embaixo e acompanham melhor o layout.',
+    },
+  },
+  {
+    version: '0.1.20',
+    shortSummary: {
+      sv: 'Versionsinfo flyttad till huvudkortet och mobil datumväljare hoppar rätt.',
+      en: 'Version info moved to the main card and the mobile date picker now jumps back correctly.',
+      'pt-BR': 'As informações de versão foram para o cartão principal e o seletor de data no celular agora volta para o lugar certo.',
+    },
+    summary: {
+      sv: 'Bygge, Bildkällor och versionsnytt ligger nu längst ner i huvudkortet i stället för att ta plats i vänsterspalten. På mobil scrollar appen också tillbaka till huvudkortet när du bekräftar ett nytt datum, så resultatet hamnar direkt där blicken borde vara.',
+      en: 'Build info, Image credits, and version notes now live at the bottom of the main card instead of taking space in the left column. On mobile, the app also scrolls back to the main card after you confirm a new date so the result appears where your attention should be.',
+      'pt-BR': 'As informações de build, os créditos das imagens e as notas da versão agora ficam no rodapé do cartão principal em vez de ocupar espaço na coluna da esquerda. No celular, o app também volta para o cartão principal depois que você confirma uma nova data, para que o resultado apareça exatamente onde deveria.',
+    },
+  },
+  {
     version: '0.1.19',
     shortSummary: {
       sv: 'Fler temadagar har fått mer egen röst och mindre generisk text.',

--- a/fredagskoll-frontend/src/styles/layout.css
+++ b/fredagskoll-frontend/src/styles/layout.css
@@ -26,6 +26,14 @@
     transform 360ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
+.app-main-column {
+  min-height: 100%;
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-self: stretch;
+}
+
 .app-panel--intro {
   padding: 1.75rem 3rem 1.75rem 1.75rem;
   display: flex;
@@ -753,14 +761,14 @@
   font-size: 0.9rem;
 }
 
-.intro-footer {
-  margin-top: auto;
-  padding-top: 0.35rem;
+.main-footer-meta {
+  align-self: end;
+  padding: 1rem 1.2rem 1.1rem;
   display: grid;
-  gap: 0.8rem;
+  gap: 0.7rem;
 }
 
-.intro-footer-links {
+.main-footer-links {
   display: flex;
   flex-wrap: wrap;
   gap: 0.8rem 1rem;
@@ -786,6 +794,10 @@
   padding: 0.2rem 0 0;
   background: transparent;
   border: 0;
+}
+
+.main-release-note-card {
+  gap: 0.28rem;
 }
 
 .release-note-current,

--- a/fredagskoll-frontend/src/styles/responsive.css
+++ b/fredagskoll-frontend/src/styles/responsive.css
@@ -3,6 +3,11 @@
     grid-template-columns: 1fr;
   }
 
+  .app-main-column {
+    min-height: auto;
+    grid-template-rows: auto auto;
+  }
+
   .brand-title,
   .celebration-title {
     max-width: none;


### PR DESCRIPTION
## Summary
This change finishes the footer/layout pass by moving the date-context panel `P� g�ng` out of the left control column and into the main result side. The app had ended up with the left column doing both input controls and secondary result context, which made the layout feel muddled after the footer metadata moved right. This PR gives the page a cleaner split: the left column now focuses on controls and quick context, while the right side owns the main result plus related day information.

## What Changed
The `P� g�ng` block is no longer rendered inside `IntroPanel`. Instead, the same disclosure pattern is rendered in `App.tsx` below the world/national-day context as its own panel. That keeps it visually separate from `Ocks� idag` while still grouping it with the other result-side day panels. The right column footer remains a separate bottom panel, and its vertical placement now follows the full right-side stack more naturally.

The version was bumped to `0.1.21`, the generated build info was refreshed, and the release notes were updated so the footer summary accurately describes this layout change.

## User Impact
Users now get a clearer page structure:
- the left side is for choosing date, tone, language, and seeing quick sidebar context
- the right side is for the selected day, related day panels, upcoming notable dates, and footer metadata

This makes the page easier to scan and makes `P� g�ng` feel like part of the result instead of part of the controls.

## Validation
I ran:
- `npm run build`
- `CI=true npm test -- --watch=false App.test.tsx`

The test suite passes. It still logs the pre-existing React `act(...)` warnings from async hook updates, but there are no failing tests.
