### PR TITLE
[codex] Defer mobile date scroll until confirm

### DIFF
--- a/fredagskoll-frontend/package-lock.json
+++ b/fredagskoll-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vadkanmanfira-frontend",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vadkanmanfira-frontend",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "dependencies": {
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",

--- a/fredagskoll-frontend/package.json
+++ b/fredagskoll-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vadkanmanfira-frontend",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/fredagskoll-frontend/src/App.test.tsx
+++ b/fredagskoll-frontend/src/App.test.tsx
@@ -664,6 +664,10 @@ test('scrolls back to the main card after confirming a mobile date change', asyn
     target: { value: '2026-03-15' },
   });
 
+  expect(scrollIntoViewMock).not.toHaveBeenCalled();
+
+  fireEvent.blur(document.getElementById('date-picker') as HTMLInputElement);
+
   jest.advanceTimersByTime(150);
 
   expect(scrollIntoViewMock).toHaveBeenCalled();

--- a/fredagskoll-frontend/src/App.tsx
+++ b/fredagskoll-frontend/src/App.tsx
@@ -73,6 +73,7 @@ function App({
   });
   const [selectedDate, setSelectedDate] = useState(formatForInput(initialDate));
   const mainCardRef = useRef<HTMLElement | null>(null);
+  const shouldScrollAfterDateCommitRef = useRef(false);
 
   const text = appText[locale];
   const buildStamp = useMemo(() => formatBuildStamp(locale), [locale]);
@@ -265,11 +266,19 @@ function App({
 
   function handleDateChange(nextDate: string): void {
     setSelectedDate(nextDate);
+    shouldScrollAfterDateCommitRef.current = isMobileLayout;
+  }
 
-    if (!isMobileLayout || typeof window === 'undefined') {
+  function handleDateCommit(): void {
+    if (
+      !isMobileLayout ||
+      typeof window === 'undefined' ||
+      !shouldScrollAfterDateCommitRef.current
+    ) {
       return;
     }
 
+    shouldScrollAfterDateCommitRef.current = false;
     window.setTimeout(() => {
       mainCardRef.current?.scrollIntoView({
         behavior: 'smooth',
@@ -314,6 +323,7 @@ function App({
           onSelectLocale={setLocale}
           onSelectMood={setMood}
           onDateChange={handleDateChange}
+          onDateCommit={handleDateCommit}
           onToggleMobileSection={toggleMobileSection}
         />
 

--- a/fredagskoll-frontend/src/buildInfo.generated.ts
+++ b/fredagskoll-frontend/src/buildInfo.generated.ts
@@ -1,6 +1,6 @@
 export const buildInfo = {
-  "version": "0.1.21",
-  "gitSha": "c7e8d11",
-  "buildRef": "c7e8d11",
-  "builtAt": "2026-03-15T12:04:43.555Z"
+  "version": "0.1.22",
+  "gitSha": "76888ec",
+  "buildRef": "76888ec",
+  "builtAt": "2026-03-15T12:12:21.100Z"
 } as const;

--- a/fredagskoll-frontend/src/components/IntroPanel.tsx
+++ b/fredagskoll-frontend/src/components/IntroPanel.tsx
@@ -40,6 +40,7 @@ type IntroPanelProps = {
   onSelectLocale: (locale: Locale) => void;
   onSelectMood: (mood: Mood) => void;
   onDateChange: (date: string) => void;
+  onDateCommit: () => void;
   onToggleMobileSection: (section: MobileSectionKey) => void;
 };
 
@@ -65,6 +66,7 @@ export function IntroPanel({
   onSelectLocale,
   onSelectMood,
   onDateChange,
+  onDateCommit,
   onToggleMobileSection,
 }: IntroPanelProps) {
   const text = appText[locale];
@@ -140,6 +142,7 @@ export function IntroPanel({
           type="date"
           value={selectedDate}
           onChange={(event) => onDateChange(event.target.value)}
+          onBlur={onDateCommit}
           className="date-picker"
         />
         <div className="picker-meta">

--- a/fredagskoll-frontend/src/releaseNotes.ts
+++ b/fredagskoll-frontend/src/releaseNotes.ts
@@ -8,6 +8,19 @@ export type ReleaseNote = {
 
 export const releaseNotes: ReleaseNote[] = [
   {
+    version: '0.1.22',
+    shortSummary: {
+      sv: 'Mobilvyn väntar nu med scroll tills datumväljaren faktiskt stängs.',
+      en: 'Mobile now waits to scroll until the date picker actually closes.',
+      'pt-BR': 'No celular, o app só rola depois que o seletor de data realmente fecha.',
+    },
+    summary: {
+      sv: 'När du byter datum på mobil hoppar appen inte längre direkt medan datumväljaren fortfarande är öppen. Scrollen sker först när datumfältet faktiskt bekräftas och stängs, vilket känns lugnare och mindre ryckigt.',
+      en: 'When you change the date on mobile, the app no longer jumps away while the date picker is still open. It now scrolls only after the field is actually confirmed and closed, which feels calmer and less jarring.',
+      'pt-BR': 'Ao trocar a data no celular, o app não pula mais enquanto o seletor ainda está aberto. A rolagem agora só acontece depois que o campo é realmente confirmado e fechado, deixando tudo mais calmo e menos brusco.',
+    },
+  },
+  {
     version: '0.1.21',
     shortSummary: {
       sv: 'På gång har flyttat till högersidan och footern ligger lägre.',


### PR DESCRIPTION
## Summary
This change fixes the mobile date-picker behavior so the app does not try to scroll away while the native picker is still open. The mobile flow now waits for the date field to be confirmed and blurred before it scrolls the result card back into view.

## Why
The previous implementation scrolled directly from the date change handler. On some mobile browsers that made the page jump as soon as the selected day changed, even though the native picker UI was still active. That felt awkward and made the picker interaction seem less stable.

## What Changed
The date input still updates the selected date immediately, but the mobile scroll is now triggered from a separate commit step when the field loses focus. In practice, that means the app reacts after the picker is actually closed rather than during the in-picker selection moment.

This does not remove the native mobile confirmation UI itself. That part belongs to the browser/platform for `input[type="date"]`. What we can control is when the app responds, and this PR makes that response happen at the calmer point in the interaction.

The frontend version is bumped to `0.1.22`, build info is regenerated, and the release notes explain the updated mobile behavior.

## Validation
I ran:
- `npm run build`
- `CI=true npm test -- --watch=false App.test.tsx`

The suite passes. It still emits the same pre-existing React `act(...)` warnings from async hook updates, but there are no test failures.
