### PR TITLE
[codex] Fix dark mode contrast

### DIFF
--- a/fredagskoll-frontend/package-lock.json
+++ b/fredagskoll-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vadkanmanfira-frontend",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vadkanmanfira-frontend",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "dependencies": {
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",

--- a/fredagskoll-frontend/package.json
+++ b/fredagskoll-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vadkanmanfira-frontend",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/fredagskoll-frontend/src/buildInfo.generated.ts
+++ b/fredagskoll-frontend/src/buildInfo.generated.ts
@@ -1,6 +1,6 @@
 export const buildInfo = {
-  "version": "0.1.22",
-  "gitSha": "76888ec",
-  "buildRef": "76888ec",
-  "builtAt": "2026-03-15T12:12:21.100Z"
+  "version": "0.1.23",
+  "gitSha": "aef2c67",
+  "buildRef": "aef2c67",
+  "builtAt": "2026-03-15T12:29:41.571Z"
 } as const;

--- a/fredagskoll-frontend/src/releaseNotes.ts
+++ b/fredagskoll-frontend/src/releaseNotes.ts
@@ -8,6 +8,19 @@ export type ReleaseNote = {
 
 export const releaseNotes: ReleaseNote[] = [
   {
+    version: '0.1.23',
+    shortSummary: {
+      sv: 'Mörkt läge har fått tydligare kontrast i knappar och etiketter.',
+      en: 'Dark mode now has clearer contrast in buttons and labels.',
+      'pt-BR': 'O modo escuro agora tem contraste mais claro em botões e etiquetas.',
+    },
+    summary: {
+      sv: 'Mörkt läge använder nu ljusare accentfärger där text faktiskt måste gå att läsa, som i knappar, badges och små etiketter. Resultatet är att appen fortfarande känns som samma stämning, men utan att viktiga delar blir grumliga eller svåra att urskilja.',
+      en: 'Dark mode now uses brighter accent text where people actually need to read it, such as buttons, badges, and small labels. The app still keeps the same mood, but important UI details are no longer muddy or hard to pick out.',
+      'pt-BR': 'O modo escuro agora usa textos de destaque mais claros onde as pessoas realmente precisam ler, como em botões, badges e pequenas etiquetas. O app continua com o mesmo clima, mas sem deixar partes importantes confusas ou difíceis de enxergar.',
+    },
+  },
+  {
     version: '0.1.22',
     shortSummary: {
       sv: 'Mobilvyn väntar nu med scroll tills datumväljaren faktiskt stängs.',

--- a/fredagskoll-frontend/src/styles/content.css
+++ b/fredagskoll-frontend/src/styles/content.css
@@ -322,7 +322,7 @@
   border-radius: var(--mood-chip-radius);
   background:
     linear-gradient(135deg, color-mix(in srgb, var(--tone-soft) 92%, rgba(255, 255, 255, 0.36)), rgba(255, 255, 255, 0.18));
-  color: var(--tone-ink);
+  color: var(--tone-ink-text);
   font-size: 0.76rem;
   font-weight: 900;
   letter-spacing: var(--mood-chip-letter);

--- a/fredagskoll-frontend/src/styles/layout.css
+++ b/fredagskoll-frontend/src/styles/layout.css
@@ -84,7 +84,7 @@
   align-items: center;
   gap: 0.45rem;
   background: transparent;
-  color: var(--tone-ink);
+  color: var(--tone-ink-text);
   border: 1px solid color-mix(in srgb, var(--tone-accent) 28%, var(--panel-border));
   box-shadow: none;
   padding-inline: 0.75rem;
@@ -252,8 +252,12 @@
   letter-spacing: 0.18em;
   font-size: 0.78rem;
   font-weight: 800;
-  color: var(--tone-accent);
+  color: var(--tone-accent-text);
   text-shadow: 0 1px 0 rgba(255, 255, 255, 0.18);
+}
+
+.App.dark .eyebrow {
+  text-shadow: none;
 }
 
 .brand-title,
@@ -383,7 +387,7 @@
 
 .mood-note {
   margin: 0;
-  color: color-mix(in srgb, var(--tone-ink) 82%, var(--muted));
+  color: color-mix(in srgb, var(--tone-ink-text) 72%, var(--muted));
   font-size: 0.88rem;
   line-height: 1.38;
   max-width: 28ch;
@@ -518,7 +522,7 @@
   letter-spacing: 0.18em;
   font-size: 0.78rem;
   font-weight: 800;
-  color: var(--tone-accent);
+  color: var(--tone-accent-text);
 }
 
 .disclosure-chevron {
@@ -831,7 +835,7 @@
   font-weight: 900;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--tone-accent);
+  color: var(--tone-accent-text);
 }
 
 .source-link {

--- a/fredagskoll-frontend/src/styles/theme.css
+++ b/fredagskoll-frontend/src/styles/theme.css
@@ -10,6 +10,8 @@
   --tone-accent: #6a5e89;
   --tone-soft: rgba(106, 94, 137, 0.16);
   --tone-ink: #433d58;
+  --tone-accent-text: var(--tone-accent);
+  --tone-ink-text: var(--tone-ink);
   --mood-ui-font: "Trebuchet MS", "Segoe UI", sans-serif;
   --mood-display-font: Georgia, "Times New Roman", serif;
   --mood-wash:
@@ -89,11 +91,14 @@
   --panel-border: rgba(255, 233, 205, 0.12);
   --text: #f7eedf;
   --muted: rgba(247, 238, 223, 0.76);
+  --tone-accent-text: color-mix(in srgb, var(--tone-accent) 38%, white);
+  --tone-ink-text: color-mix(in srgb, var(--tone-ink) 34%, white);
   --shadow: 0 24px 80px rgba(0, 0, 0, 0.38);
   --mood-panel-tint: rgba(255, 255, 255, 0.04);
   --mood-panel-border: rgba(255, 255, 255, 0.06);
   --mood-card-shadow: 0 26px 72px rgba(0, 0, 0, 0.28);
   --mood-outline: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  --mood-button-text: var(--tone-ink-text);
 }
 
 .App[data-mood="dry"] {


### PR DESCRIPTION
## Summary
This PR fixes dark-mode contrast problems in the accent layer of the app and ships that as frontend version `0.1.23`.

## Problem
Dark mode had a solid base palette (`--text`, `--muted`, dark panel background), but several interactive and label-like surfaces were still using mood accent colors that were tuned for light mode. In practice that meant some buttons, pills, badges, and small headings ended up using dark-ish accent text on dark translucent panels.

That kept the page looking "on brand" for each mood, but the contrast on those text-bearing accent surfaces was too weak.

## Root Cause
The token system reused `--tone-ink` and `--tone-accent` directly for text in both light and dark mode. Those tokens are fine as decorative accent colors, but in dark mode they are too muddy when used as actual readable text.

## Fix
The change introduces dark-safe accent text tokens at the theme layer:
- `--tone-accent-text`
- `--tone-ink-text`

In dark mode those are lifted toward white while still preserving the mood hue. Components that actually render readable accent text now use those text-specific tokens instead of the raw accent colors.

That includes surfaces such as:
- language toggle text
- eyebrow labels
- mood note text
- mood pill text
- disclosure titles
- release-note version labels
- button/badge text via the shared `--mood-button-text` token

I also removed the light-theme text shadow from eyebrow labels in dark mode, because it made small text look fuzzier rather than clearer.

## Validation
I ran:
- `npm run build`
- `CI=true npm test -- --watch=false App.test.tsx`

The tests pass. The suite still emits the same pre-existing React `act(...)` warnings from async hook updates, but there are no failures.
