### PR TITLE
[codex] Fix release-note encoding and dark mode contrast

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,3 +38,9 @@
 
 - Favor small, explicit changes. This project is simple enough that extra
   abstraction usually adds more maintenance cost than value.
+- Review your own diff critically before committing or pushing. Check for
+  broken text encoding, obvious UI regressions, naming drift, and copy that
+  does not actually read the way it is intended to in the app.
+- Do not ship unreviewed string or UI changes just because the code compiles.
+  For user-visible changes, at minimum inspect the rendered result and the
+  final changed files before committing.

--- a/fredagskoll-frontend/package-lock.json
+++ b/fredagskoll-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vadkanmanfira-frontend",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vadkanmanfira-frontend",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "dependencies": {
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",

--- a/fredagskoll-frontend/package.json
+++ b/fredagskoll-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vadkanmanfira-frontend",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/fredagskoll-frontend/src/buildInfo.generated.ts
+++ b/fredagskoll-frontend/src/buildInfo.generated.ts
@@ -1,6 +1,6 @@
 export const buildInfo = {
-  "version": "0.1.24",
-  "gitSha": "19f3dc7",
-  "buildRef": "19f3dc7",
-  "builtAt": "2026-03-15T12:47:23.756Z"
+  "version": "0.1.25",
+  "gitSha": "487e6b1",
+  "buildRef": "487e6b1",
+  "builtAt": "2026-03-15T13:02:12.696Z"
 } as const;

--- a/fredagskoll-frontend/src/releaseNotes.ts
+++ b/fredagskoll-frontend/src/releaseNotes.ts
@@ -8,16 +8,29 @@ export type ReleaseNote = {
 
 export const releaseNotes: ReleaseNote[] = [
   {
-    version: '0.1.24',
+    version: '0.1.25',
     shortSummary: {
-      sv: 'Koden Ã¤r bÃ¤ttre uppdelad och mÃ¶rkt lÃ¤ge Ã¤r lÃ¤ttare att lÃ¤sa.',
-      en: 'The code is better organized and dark mode is easier to read.',
-      'pt-BR': 'O cÃ³digo estÃ¡ melhor organizado e o modo escuro ficou mais fÃ¡cil de ler.',
+      sv: 'Trasiga specialtecken är fixade och mörka knappar går lättare att läsa.',
+      en: 'Broken characters are fixed and dark buttons are easier to read.',
+      'pt-BR': 'Os caracteres quebrados foram corrigidos e os botões escuros ficaram mais legíveis.',
     },
     summary: {
-      sv: 'Frontendkoden Ã¤r nu sorterad tydligare efter omrÃ¥de, sÃ¥ AI, temadagar, nationaldagar, namnsdagar och kommande datum ligger samlade i egna delar i stÃ¤llet fÃ¶r att ligga utspridda i en platt mapp. Samtidigt har mÃ¶rkt lÃ¤ge fÃ¥tt tydligare kontrast i knappar, badges och smÃ¥ etiketter som Firardag, sÃ¥ det viktiga innehÃ¥llet blir lÃ¤ttare att lÃ¤sa utan att appens ton fÃ¶rsvinner.',
-      en: 'The frontend code is now grouped more clearly by area, so AI, theme days, national days, name days, and upcoming dates live in their own sections instead of a flat pile. At the same time, dark mode has better contrast in buttons, badges, and smaller labels like Celebration, so the important UI is easier to read without losing the appâ€™s tone.',
-      'pt-BR': 'O cÃ³digo do frontend agora estÃ¡ agrupado de forma mais clara por Ã¡rea, para que IA, datas temÃ¡ticas, datas nacionais, nomes do dia e prÃ³ximas datas fiquem em suas prÃ³prias seÃ§Ãµes em vez de um monte plano. Ao mesmo tempo, o modo escuro ganhou melhor contraste em botÃµes, badges e pequenas etiquetas como ComemoraÃ§Ã£o, deixando a interface mais legÃ­vel sem perder o clima do app.',
+      sv: 'Den senaste versionsnotisen visade trasiga tecken i stället för å, ä och ö, och mörkt läge hade fortfarande vissa knappar och badges som blev för svåra att läsa i de mörkare stämningarna. Det är nu rättat, så både versionsnytt och de mörka knappytorna går att läsa som normalt igen.',
+      en: 'The latest release note showed broken characters instead of proper accented text, and dark mode still had some buttons and badges that became too hard to read in the darker moods. That is now fixed, so both the changelog and those darker button surfaces read normally again.',
+      'pt-BR': 'A última nota de versão mostrava caracteres quebrados no lugar dos acentos corretos, e o modo escuro ainda tinha alguns botões e badges difíceis de ler nos tons mais escuros. Isso foi corrigido, então tanto o changelog quanto essas superfícies escuras voltaram a ficar legíveis.',
+    },
+  },
+  {
+    version: '0.1.24',
+    shortSummary: {
+      sv: 'Koden är bättre uppdelad och mörkt läge är lättare att läsa.',
+      en: 'The code is better organized and dark mode is easier to read.',
+      'pt-BR': 'O código está melhor organizado e o modo escuro ficou mais fácil de ler.',
+    },
+    summary: {
+      sv: 'Frontendkoden är nu sorterad tydligare efter område, så AI, temadagar, nationaldagar, namnsdagar och kommande datum ligger samlade i egna delar i stället för att ligga utspridda i en platt mapp. Samtidigt har mörkt läge fått tydligare kontrast i knappar, badges och små etiketter som Firardag, så det viktiga innehållet blir lättare att läsa utan att appens ton försvinner.',
+      en: 'The frontend code is now grouped more clearly by area, so AI, theme days, national days, name days, and upcoming dates live in their own sections instead of a flat pile. At the same time, dark mode has better contrast in buttons, badges, and smaller labels like Celebration, so the important UI is easier to read without losing the app’s tone.',
+      'pt-BR': 'O código do frontend agora está agrupado de forma mais clara por área, para que IA, datas temáticas, datas nacionais, nomes do dia e próximas datas fiquem em suas próprias seções em vez de um monte plano. Ao mesmo tempo, o modo escuro ganhou melhor contraste em botões, badges e pequenas etiquetas como Comemoração, deixando a interface mais legível sem perder o clima do app.',
     },
   },
   {

--- a/fredagskoll-frontend/src/styles/layout.css
+++ b/fredagskoll-frontend/src/styles/layout.css
@@ -171,6 +171,11 @@
   background: var(--accent-soft);
 }
 
+.App.dark .language-option:hover,
+.App.dark .language-option--active {
+  background: color-mix(in srgb, var(--accent) 18%, rgba(255, 255, 255, 0.08));
+}
+
 .language-option-text {
   font-size: 0.92rem;
   font-weight: 700;
@@ -356,6 +361,11 @@
   box-shadow:
     inset 0 0 0 1px color-mix(in srgb, white 10%, var(--tone-accent) 24%),
     var(--mood-badge-shadow);
+}
+
+.App.dark .card-nav-button:hover,
+.App.dark .reroll-button:hover {
+  filter: brightness(1.06) saturate(1.02);
 }
 
 .picker-label {
@@ -903,6 +913,10 @@
 
 .App.dark .mobile-section-toggle {
   background: rgba(255, 255, 255, 0.05);
+}
+
+.App.dark .mobile-section-toggle:hover {
+  background: rgba(255, 255, 255, 0.09);
 }
 
 .mobile-section-chevron {

--- a/fredagskoll-frontend/src/styles/theme.css
+++ b/fredagskoll-frontend/src/styles/theme.css
@@ -346,6 +346,23 @@
   --bg: linear-gradient(135deg, #1d1a28 0%, #262238 52%, #393353 100%);
 }
 
+.App.dark[data-mood] {
+  --accent-ui-text: color-mix(in srgb, var(--accent) 16%, white);
+  --accent-ui-bg: color-mix(in srgb, var(--accent) 22%, rgba(255, 255, 255, 0.14));
+  --tone-accent-text: color-mix(in srgb, var(--tone-accent) 16%, white);
+  --tone-ink-text: color-mix(in srgb, var(--tone-ink) 10%, white);
+  --mood-button-bg:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--tone-accent) 18%, rgba(255, 255, 255, 0.14)),
+      rgba(255, 255, 255, 0.1)
+    );
+  --mood-button-text: var(--tone-ink-text);
+  --mood-badge-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 10px 24px rgba(0, 0, 0, 0.28);
+}
+
 .app-backdrop {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
## Summary
This follow-up fixes two user-visible regressions from the last release.

First, the `0.1.24` release note text had broken character encoding, so Swedish and Portuguese copy showed mojibake instead of proper accented characters. Second, dark mode still had several low-contrast interactive surfaces in the darker moods, especially buttons, chips, and smaller context labels.

## Root Cause
The release note content was committed with damaged text encoding, and the dark-mode styling still let some mood-specific variables override the safer dark tokens later in the CSS cascade. That meant the branch compiled fine, but the rendered result was not acceptable.

## Fix
The release note copy has been repaired and the frontend version is bumped to `0.1.25` so the live app clearly reflects the correction. The new version note explicitly mentions the repaired characters and the dark-mode readability improvement.

For dark mode, the darker mood variants now inherit stronger dark-safe text and button tokens. Smaller labels and button-like surfaces also get safer contrast treatment and slightly more solid hover/background behavior, so controls do not collapse into muddy low-contrast states.

I also added a small repo instruction in `AGENTS.md` requiring a critical self-review before commit/push, specifically calling out encoding issues, UI regressions, and rendered copy checks.

## Validation
I ran:

- `npm run build`
- `npm test -- --watch=false App.test.tsx aiBlurbs.test.ts temadagar.test.ts themeDayBlurbs.test.ts upcomingNotables.test.ts nationalDays.test.ts nationalDaysPanel.test.tsx seasonalNotes.test.ts localeSwitch.test.tsx`

Those checks passed. The existing async React `act(...)` warnings are still present in the test output, but there were no test failures.
