### PR TITLE
[codex] fix readme managed api wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Vad kan man fira?
 
-`Vad kan man fira?` is a React app with managed Azure Static Web Apps APIs that
+`Vad kan man fira?` is a React app with a managed Azure Static Web Apps API at
+`/api` that
 decides whether a Swedish date deserves celebration, resignation, baked goods,
 or a dry remark about calendar reality.
 
@@ -34,18 +35,24 @@ If the variable is unset, the app defaults to `public`.
   Content-pack selection, public/team boundaries, and recurring weekday rules.
 - `fredagskoll-frontend/src/dayLogic.ts`
   Date classification and official Swedish holiday calculations.
-- `fredagskoll-frontend/src/celebrations.ts`
+- `fredagskoll-frontend/src/features/celebrations/celebrations.ts`
   Built-in celebration content and pack-filtered exports.
-- `fredagskoll-frontend/src/themeDaySpecificBlurbs.ts`
+- `fredagskoll-frontend/src/features/theme-days/themeDaySpecificBlurbs.ts`
   Handwritten temadag overrides.
-- `fredagskoll-frontend/src/themeDayCategoryBlurbs.ts`
+- `fredagskoll-frontend/src/features/theme-days/themeDayCategoryBlurbs.ts`
   Category fallback blurbs for temadagar.
+- `fredagskoll-frontend/src/features/ai`
+  Frontend request types, fetch logic, and AI content hook.
+- `fredagskoll-frontend/src/features/upcoming`
+  Upcoming notables and seasonal context blocks.
+- `fredagskoll-frontend/src/features/national-days`
+  World/national day panel logic and localization.
 - `fredagskoll-frontend/src/data/temadagarByDate.json`
   Curated unofficial temadag dataset.
 - `fredagskoll-frontend/public/images`
   Celebration images and source metadata.
 - `api/blurbs`
-  Azure Function endpoint for optional AI-generated blurb bundles.
+  Managed Static Web Apps API route for optional AI-generated blurb bundles.
 - `api/shared`
   Request validation, prompt building, Azure OpenAI calling, and Table Storage cache logic.
 
@@ -145,7 +152,8 @@ npm run build
 
 ## Optional AI blurbs
 
-The app can now ask a managed Azure Functions API for generated blurb bundles.
+The app can ask the managed Static Web Apps API route at `/api/blurbs` for
+generated blurb bundles.
 This is optional: if the API is unavailable or Azure OpenAI is not configured,
 the frontend keeps using the existing handwritten/static blurbs.
 
@@ -153,7 +161,7 @@ The frontend calls:
 
 - `/api/blurbs`
 
-What it does:
+What the managed API does:
 
 - receives a structured date context from the frontend
 - computes a deterministic request hash


### PR DESCRIPTION
## What changed
This PR fixes README wording that had drifted behind the actual production setup. The file still described the optional AI path in a way that sounded like a separate Azure Functions app was the live entrypoint, even though the deployed frontend now calls the managed Static Web Apps API on the same origin at `/api/blurbs`.

It also updates the project structure section to match the current frontend layout after the feature-folder refactor. Several paths in the README still pointed at old flat source locations, which made the repo look more outdated than it is.

## User impact
This is docs-only, but it matters because the README is supposed to explain how the app actually works now. Anyone reading it to understand the architecture, the AI path, or where code lives would otherwise get the wrong picture.

## Root cause
The app architecture changed over several PRs: the dedicated public Function App was removed from the normal browser path, the frontend was moved back to same-origin `/api/blurbs`, and the frontend source tree was reorganized into feature folders. The README was only partially updated during those changes.

## Validation
I reviewed the README against the current code and deployment wiring:
- `fredagskoll-frontend/src/features/ai/aiBlurbs.ts`
- `.github/workflows/deploy-static-apps.yml`
- `api/blurbs/index.js`

No runtime code changed.
