### PR TITLE
Add phase 2 engagement features

### DIFF
--- a/docs/phases/phase-2.md
+++ b/docs/phases/phase-2.md
@@ -1,0 +1,39 @@
+# Phase 2 - Engagement Features
+
+Status: completed
+
+GitHub issues:
+- `#71` Add a surprise celebration button
+- `#72` Add a celebration scoring system
+- `#75` Add celebration categories
+- `#77` Add a "Dagens ursäkt att fika" feature
+
+## What was added
+
+- A `Surprise me` action in the left-side intro panel that jumps to a celebration-worthy
+  date instead of a random dead zone in the calendar.
+- A lightweight engagement scoring layer that gives each day a `1-100` celebration
+  score based on built-in celebration priority, category, official holiday status, and
+  interesting theme-day matches.
+- Visible celebration categories in the UI, reused from the shared celebration rule
+  definitions.
+- A `Dagens ursäkt att fika` panel with a fika item, a fika score, and a short excuse
+  note that fits the selected day.
+
+## Main files
+
+- `fredagskoll-frontend/src/features/engagement/engagement.ts`
+- `fredagskoll-frontend/src/components/EngagementPanel.tsx`
+- `fredagskoll-frontend/src/components/IntroPanel.tsx`
+- `fredagskoll-frontend/src/components/MainCelebrationCard.tsx`
+- `fredagskoll-frontend/src/components/AppMainColumn.tsx`
+- `fredagskoll-frontend/src/hooks/useAppShellState.ts`
+- `fredagskoll-frontend/src/features/engagement/engagement.test.ts`
+
+## Notes
+
+- The surprise button is weighted toward stronger dates, not just random picks.
+- The scoring layer is intentionally simple. It is meant to support better product
+  behavior and future ranking, not to become a giant rules engine.
+- Categories now have a real UI surface, which gives later browsing/filtering work a
+  clearer base to build on.

--- a/fredagskoll-frontend/package-lock.json
+++ b/fredagskoll-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vadkanmanfira-frontend",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vadkanmanfira-frontend",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "dependencies": {
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",

--- a/fredagskoll-frontend/package.json
+++ b/fredagskoll-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vadkanmanfira-frontend",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "private": true,
   "dependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/fredagskoll-frontend/src/App.test.tsx
+++ b/fredagskoll-frontend/src/App.test.tsx
@@ -114,6 +114,10 @@ test('renders Fettisdag content on the actual Fettisdag date', async () => {
   expect(
     screen.getByRole('heading', { level: 2, name: /Nationen hålls ihop av grädde/i })
   ).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /Överraska mig/i })).toBeInTheDocument();
+  expect(screen.getByText(/Dagens ursäkt att fika/i)).toBeInTheDocument();
+  expect(screen.getByText(/^semla$/i, { selector: '.fika-item' })).toBeInTheDocument();
+  expect(screen.getAllByText(/Fika\/fest/i)).toHaveLength(2);
 });
 
 test('renders Kanelbullens dag ahead of the generic Saturday fallback', async () => {

--- a/fredagskoll-frontend/src/App.tsx
+++ b/fredagskoll-frontend/src/App.tsx
@@ -35,6 +35,13 @@ import { getUpcomingNotables } from './features/upcoming/upcomingNotables';
 import { useAiContent } from './features/ai/useAiContent';
 import { useNameDays } from './features/name-days/useNameDays';
 import {
+  getCategoryLabel,
+  getDailyFikaSuggestion,
+  getEngagementScoreLabel,
+  pickSurpriseDate,
+  scoreEngagementSnapshot,
+} from './features/engagement/engagement';
+import {
   buildAiRequest,
   buildMainCardViewModel,
   getCurrentCelebration,
@@ -70,6 +77,7 @@ function App({
     showLanguageMenu,
     showReleaseNotes,
     toggleMobileSection,
+    jumpToDate,
   } = useAppShellState({ initialDate });
 
   const text = appText[locale];
@@ -100,6 +108,18 @@ function App({
   const extraDisplayThemeDays = displayThemeDays;
   const hasThemeDays = displayThemeDays.length > 0;
   const humanDate = formatForHumans(selectedDateObject, locale);
+  const engagementSnapshot = useMemo(
+    () => scoreEngagementSnapshot(selectedDateObject, contentPack),
+    [contentPack, selectedDateObject]
+  );
+  const categoryLabel = useMemo(
+    () => getCategoryLabel(engagementSnapshot.category, locale),
+    [engagementSnapshot.category, locale]
+  );
+  const scoreLabel = useMemo(
+    () => getEngagementScoreLabel(engagementSnapshot.score, locale),
+    [engagementSnapshot.score, locale]
+  );
   const centerDate = formatCenterDate(selectedDateObject, locale);
   const upcomingHoliday = getUpcomingOfficialHolidayInWeek(selectedDateObject);
   const upcomingHolidayName = upcomingHoliday
@@ -203,6 +223,26 @@ function App({
     hasThemeDays,
     themeDayDisplayTitle,
   });
+  const fikaSuggestion = useMemo(
+    () =>
+      getDailyFikaSuggestion({
+        celebration:
+          dayStatus.dayType === 'ordinary' ? null : dayStatus.dayType,
+        category: engagementSnapshot.category,
+        themeDays: displayThemeDays,
+        locale,
+        mood,
+        score: engagementSnapshot.score,
+      }),
+    [
+      dayStatus.dayType,
+      displayThemeDays,
+      engagementSnapshot.category,
+      engagementSnapshot.score,
+      locale,
+      mood,
+    ]
+  );
 
   const mainTitle = celebration
     ? celebration.title
@@ -212,6 +252,11 @@ function App({
 
   function stepSelectedDate(days: number): void {
     handleDateChange(formatForInput(addDays(selectedDateObject, days)));
+  }
+
+  function handleSurpriseDate(): void {
+    const surprise = pickSurpriseDate(selectedDateObject, contentPack);
+    jumpToDate(formatForInput(surprise.date), mainCardRef);
   }
 
   return (
@@ -244,11 +289,13 @@ function App({
           onSelectMood={setMood}
           onDateChange={handleDateChange}
           onDateCommit={() => handleDateCommit(mainCardRef)}
+          onSurpriseDate={handleSurpriseDate}
           onToggleMobileSection={toggleMobileSection}
         />
 
         <AppMainColumn
           buildStamp={buildStamp}
+          categoryLabel={categoryLabel}
           centerDate={centerDate}
           celebration={celebration}
           compactPrimaryMedia={compactPrimaryMedia}
@@ -266,6 +313,7 @@ function App({
           mainTitle={mainTitle}
           mood={mood}
           moodLabel={getMoodLabel(mood, locale)}
+          fikaSuggestion={fikaSuggestion}
           nationalDayPanel={nationalDayPanel}
           onOpenImageCredits={() => setShowImageCredits(true)}
           onOpenReleaseNotes={() => setShowReleaseNotes(true)}
@@ -280,6 +328,7 @@ function App({
           themeDayTitleEnding={themeDayTitleEnding}
           upcomingNotables={upcomingNotables}
           visibleBlurb={blurb}
+          scoreLabel={scoreLabel}
         />
       </div>
 

--- a/fredagskoll-frontend/src/appText.ts
+++ b/fredagskoll-frontend/src/appText.ts
@@ -76,6 +76,8 @@ export const appText: Record<
     title: string;
     lede: string;
     pickDate: string;
+    surpriseAction: string;
+    surpriseHint: string;
     moodLabel: string;
     nameday: string;
     namedayLoading: string;
@@ -142,6 +144,8 @@ export const appText: Record<
     lede:
       'Välj ett datum och låt appen avgöra om dagen förtjänar flaggor, bakverk, högtidston eller bara ett torrt konstaterande av kalenderns begränsningar.',
     pickDate: 'Välj datum',
+    surpriseAction: 'Överraska mig',
+    surpriseHint: 'Hoppa till ett datum som faktiskt verkar värt att fira.',
     moodLabel: 'Ton',
     nameday: 'Dagens namnsdag',
     namedayLoading: 'Laddar namnsdag från öppet API.',
@@ -215,6 +219,8 @@ export const appText: Record<
     lede:
       'Pick a date and let the app decide whether it calls for flags, pastries, ceremonial energy, or just a dry acknowledgement of the calendar’s limitations.',
     pickDate: 'Choose date',
+    surpriseAction: 'Surprise me',
+    surpriseHint: 'Jump to a date that actually seems worth celebrating.',
     moodLabel: 'Tone',
     nameday: "Today's name day",
     namedayLoading: 'Loading name day from the open API.',
@@ -288,6 +294,8 @@ export const appText: Record<
     lede:
       'Escolha uma data e deixe o app decidir se o dia merece bandeiras, doces, solenidade ou apenas um comentário seco sobre as limitações do calendário.',
     pickDate: 'Escolher data',
+    surpriseAction: 'Me surpreenda',
+    surpriseHint: 'Pule para uma data que realmente pareça valer a comemoração.',
     moodLabel: 'Tom',
     nameday: 'Nome do dia',
     namedayLoading: 'Carregando nome do dia pela API aberta.',

--- a/fredagskoll-frontend/src/buildInfo.generated.ts
+++ b/fredagskoll-frontend/src/buildInfo.generated.ts
@@ -1,6 +1,6 @@
 export const buildInfo = {
-  "version": "0.1.31",
-  "gitSha": "ccefb80",
-  "buildRef": "ccefb80",
-  "builtAt": "2026-03-15T20:36:32.939Z"
+  "version": "0.1.32",
+  "gitSha": "bd64d19",
+  "buildRef": "bd64d19",
+  "builtAt": "2026-03-15T21:08:15.608Z"
 } as const;

--- a/fredagskoll-frontend/src/components/AppMainColumn.tsx
+++ b/fredagskoll-frontend/src/components/AppMainColumn.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { MainCelebrationCard } from './MainCelebrationCard';
 import { MainFooterMeta } from './MainFooterMeta';
+import { EngagementPanel } from './EngagementPanel';
 import { Locale } from '../locale';
 import { Mood } from '../mood';
 import { appText } from '../appText';
@@ -8,9 +9,11 @@ import { CelebrationContent } from '../features/celebrations/celebrations';
 import { MobileSectionKey } from '../appTypes';
 import { NationalDayPanel } from '../features/national-days/nationalDays';
 import { UpcomingNotable } from '../features/upcoming/upcomingNotables';
+import { FikaSuggestion } from '../features/engagement/engagement';
 
 type AppMainColumnProps = {
   buildStamp: string;
+  categoryLabel: string | null;
   centerDate: string;
   celebration: CelebrationContent | null;
   compactPrimaryMedia: boolean;
@@ -28,6 +31,7 @@ type AppMainColumnProps = {
   mainTitle: string;
   mood: Mood;
   moodLabel: string;
+  fikaSuggestion: FikaSuggestion;
   nationalDayPanel: NationalDayPanel | null;
   onOpenImageCredits: () => void;
   onOpenReleaseNotes: () => void;
@@ -40,10 +44,12 @@ type AppMainColumnProps = {
   themeDayTitleEnding: string;
   upcomingNotables: UpcomingNotable[];
   visibleBlurb: string;
+  scoreLabel: string;
 };
 
 export function AppMainColumn({
   buildStamp,
+  categoryLabel,
   centerDate,
   celebration,
   compactPrimaryMedia,
@@ -61,6 +67,7 @@ export function AppMainColumn({
   mainTitle,
   mood,
   moodLabel,
+  fikaSuggestion,
   nationalDayPanel,
   onOpenImageCredits,
   onOpenReleaseNotes,
@@ -73,10 +80,12 @@ export function AppMainColumn({
   themeDayTitleEnding,
   upcomingNotables,
   visibleBlurb,
+  scoreLabel,
 }: AppMainColumnProps) {
   return (
     <div className="app-main-column">
       <MainCelebrationCard
+        categoryLabel={categoryLabel}
         centerDate={centerDate}
         celebration={celebration}
         compactPrimaryMedia={compactPrimaryMedia}
@@ -94,6 +103,7 @@ export function AppMainColumn({
         mainTitle={mainTitle}
         mood={mood}
         moodLabel={moodLabel}
+        scoreLabel={scoreLabel}
         nationalDayPanel={nationalDayPanel}
         onReroll={onReroll}
         onStepDate={onStepDate}
@@ -104,6 +114,12 @@ export function AppMainColumn({
         themeDayTitleEnding={themeDayTitleEnding}
         upcomingNotables={upcomingNotables}
         visibleBlurb={visibleBlurb}
+      />
+
+      <EngagementPanel
+        categoryLabel={categoryLabel}
+        fikaSuggestion={fikaSuggestion}
+        scoreLabel={scoreLabel}
       />
 
       <MainFooterMeta

--- a/fredagskoll-frontend/src/components/EngagementPanel.tsx
+++ b/fredagskoll-frontend/src/components/EngagementPanel.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { FikaSuggestion } from '../features/engagement/engagement';
+
+type EngagementPanelProps = {
+  categoryLabel: string | null;
+  scoreLabel: string;
+  fikaSuggestion: FikaSuggestion;
+};
+
+export function EngagementPanel({
+  categoryLabel,
+  fikaSuggestion,
+  scoreLabel,
+}: EngagementPanelProps) {
+  return (
+    <section className="engagement-panel" aria-label={fikaSuggestion.label}>
+      <div className="engagement-metrics" aria-label={scoreLabel}>
+        {categoryLabel ? (
+          <span className="engagement-chip engagement-chip--category">{categoryLabel}</span>
+        ) : null}
+        <span className="engagement-chip engagement-chip--score">{scoreLabel}</span>
+      </div>
+
+      <div className="fika-card">
+        <p className="eyebrow">{fikaSuggestion.label}</p>
+        <p className="fika-item">{fikaSuggestion.item}</p>
+        <p className="fika-score">{`${fikaSuggestion.score}/10`}</p>
+        <p className="fika-note">{fikaSuggestion.note}</p>
+      </div>
+    </section>
+  );
+}

--- a/fredagskoll-frontend/src/components/IntroPanel.tsx
+++ b/fredagskoll-frontend/src/components/IntroPanel.tsx
@@ -41,6 +41,7 @@ type IntroPanelProps = {
   onSelectMood: (mood: Mood) => void;
   onDateChange: (date: string) => void;
   onDateCommit: () => void;
+  onSurpriseDate: () => void;
   onToggleMobileSection: (section: MobileSectionKey) => void;
 };
 
@@ -67,6 +68,7 @@ export function IntroPanel({
   onSelectMood,
   onDateChange,
   onDateCommit,
+  onSurpriseDate,
   onToggleMobileSection,
 }: IntroPanelProps) {
   const text = appText[locale];
@@ -150,6 +152,10 @@ export function IntroPanel({
           <span>{dateLabel}</span>
         </div>
       </div>
+      <button type="button" className="surprise-button" onClick={onSurpriseDate}>
+        {text.surpriseAction}
+      </button>
+      <p className="surprise-hint">{text.surpriseHint}</p>
 
       <label htmlFor="mood-picker" className="picker-label">
         {text.moodLabel}

--- a/fredagskoll-frontend/src/components/MainCelebrationCard.tsx
+++ b/fredagskoll-frontend/src/components/MainCelebrationCard.tsx
@@ -22,6 +22,7 @@ import { formatShortSwedishDate } from '../dateUtils';
 import { Mood } from '../mood';
 
 type MainCelebrationCardProps = {
+  categoryLabel: string | null;
   centerDate: string;
   celebration: CelebrationContent | null;
   compactPrimaryMedia: boolean;
@@ -36,6 +37,7 @@ type MainCelebrationCardProps = {
   mainCardRef: React.RefObject<HTMLElement | null>;
   mainTitle: string;
   mood: Mood;
+  scoreLabel: string;
   nationalDayPanel: NationalDayPanel | null;
   onReroll: () => void;
   onStepDate: (days: number) => void;
@@ -52,6 +54,7 @@ type MainCelebrationCardProps = {
 };
 
 export function MainCelebrationCard({
+  categoryLabel,
   centerDate,
   celebration,
   compactPrimaryMedia,
@@ -69,6 +72,7 @@ export function MainCelebrationCard({
   mainTitle,
   mood,
   moodLabel,
+  scoreLabel,
   nationalDayPanel,
   onReroll,
   onStepDate,
@@ -105,7 +109,11 @@ export function MainCelebrationCard({
 
       <div className="card-kicker-row">
         <p className="eyebrow">{kicker}</p>
-        <span className="mood-pill">{moodLabel}</span>
+        <div className="card-kicker-metrics">
+          {categoryLabel ? <span className="mood-pill mood-pill--category">{categoryLabel}</span> : null}
+          <span className="mood-pill mood-pill--score">{scoreLabel}</span>
+          <span className="mood-pill">{moodLabel}</span>
+        </div>
       </div>
 
       {themeDayDisplayTitle && !celebration ? (

--- a/fredagskoll-frontend/src/features/engagement/engagement.test.ts
+++ b/fredagskoll-frontend/src/features/engagement/engagement.test.ts
@@ -1,0 +1,41 @@
+import {
+  getCategoryLabel,
+  getDailyFikaSuggestion,
+  pickSurpriseDate,
+  scoreEngagementSnapshot,
+} from './engagement';
+
+test('scores a major celebration date higher than an ordinary date', () => {
+  const nationaldagen = scoreEngagementSnapshot(new Date('2026-06-06T12:00:00'), 'public');
+  const ordinaryDay = scoreEngagementSnapshot(new Date('2026-02-18T12:00:00'), 'public');
+
+  expect(nationaldagen.dayType).toBe('nationaldagen');
+  expect(nationaldagen.score).toBeGreaterThan(ordinaryDay.score);
+});
+
+test('picks a celebration-worthy surprise date from the current year pool', () => {
+  const surprise = pickSurpriseDate(new Date('2026-01-10T12:00:00'), 'public', 0.1);
+
+  expect(surprise.score).toBeGreaterThanOrEqual(45);
+  expect(surprise.dayType === 'ordinary' ? surprise.themeDays.length > 0 : true).toBe(true);
+});
+
+test('builds fika suggestions from specific celebrations when possible', () => {
+  const fika = getDailyFikaSuggestion({
+    celebration: 'fettisdag',
+    category: 'food',
+    themeDays: [],
+    locale: 'sv',
+    mood: 'dry',
+    score: 95,
+  });
+
+  expect(fika.item).toMatch(/semla/i);
+  expect(fika.score).toBeGreaterThanOrEqual(9);
+});
+
+test('translates category labels', () => {
+  expect(getCategoryLabel('official', 'sv')).toBe('Officiell');
+  expect(getCategoryLabel('food', 'en')).toBe('Food');
+  expect(getCategoryLabel('team', 'pt-BR')).toBe('Equipe');
+});

--- a/fredagskoll-frontend/src/features/engagement/engagement.ts
+++ b/fredagskoll-frontend/src/features/engagement/engagement.ts
@@ -1,0 +1,288 @@
+import { ContentPack } from '../../contentPack';
+import { addDays, formatForInput } from '../../dateUtils';
+import { DayType, getDayStatus, getOfficialHolidays } from '../../dayLogic';
+import { Locale } from '../../locale';
+import { Mood } from '../../mood';
+import {
+  CelebrationCategory,
+  CelebrationDayType,
+  getCelebrationDefinition,
+} from '../celebrations/celebrationDefinitions';
+import { getThemeDaysForDate } from '../theme-days/temadagar';
+
+export type EngagementSnapshot = {
+  date: Date;
+  dayType: DayType;
+  themeDays: string[];
+  category: CelebrationCategory | null;
+  score: number;
+};
+
+export type FikaSuggestion = {
+  label: string;
+  item: string;
+  score: number;
+  note: string;
+};
+
+const categoryWeight: Record<CelebrationCategory, number> = {
+  official: 24,
+  food: 28,
+  seasonal: 22,
+  observance: 18,
+  team: 14,
+};
+
+const surpriseKeywordWeight: Array<{ pattern: RegExp; weight: number }> = [
+  { pattern: /kanel|semla|våff|vaff|kladdkaka|lakrits|pizza|donut|glass|fika/i, weight: 18 },
+  { pattern: /jul|påsk|pask|valborg|midsommar|lucia|national/i, weight: 16 },
+  { pattern: /star wars|sockorna|fred|bok|museum|radio|hjärta|heart/i, weight: 12 },
+  { pattern: /internationella|world|världs|v[aä]rlds/i, weight: 6 },
+];
+
+const fikaByCelebration: Partial<Record<CelebrationDayType, { item: string; score: number }>> = {
+  allahjartansdag: { item: 'geléhjärtan och kaffe', score: 7 },
+  fettisdag: { item: 'semla', score: 10 },
+  skartorsdag: { item: 'påskgodis och kaffe', score: 7 },
+  langfredag: { item: 'mjuk kaka och lugnt kaffe', score: 5 },
+  paskafton: { item: 'påskgodis och kaffe', score: 9 },
+  paskdagen: { item: 'påskdessert', score: 8 },
+  annandagpask: { item: 'rester och påtår', score: 7 },
+  vaffeldagen: { item: 'våffla', score: 10 },
+  valborg: { item: 'bulle och kvällskaffe', score: 8 },
+  nationaldagen: { item: 'jordgubbstårta eller fika i blågult', score: 8 },
+  midsommarafton: { item: 'jordgubbar och kaffe', score: 10 },
+  kanelbullensdag: { item: 'kanelbulle', score: 10 },
+  kladdkakansdag: { item: 'kladdkaka', score: 10 },
+  surstrommingspremiar: { item: 'efterrätt och ett förlåtande kaffe', score: 6 },
+  lucia: { item: 'lussekatt', score: 9 },
+  julafton: { item: 'julgodis och glöggfika', score: 9 },
+  nyarsafton: { item: 'något sött före bubbel', score: 7 },
+  kottonsdag: { item: 'något grillvänligt till eftermiddagskaffet', score: 5 },
+  fisktorsdag: { item: 'citronkaka eller bryggkaffe med disciplin', score: 4 },
+  marmeladfredag: { item: 'toast med marmelad eller fredagsfika', score: 8 },
+};
+
+function clampScore(score: number): number {
+  return Math.max(1, Math.min(100, Math.round(score)));
+}
+
+function getThemeDayInterestBonus(themeDays: string[]): number {
+  return themeDays.reduce((total, themeDay) => {
+    const matchWeight = surpriseKeywordWeight.reduce((best, entry) => {
+      return entry.pattern.test(themeDay) ? Math.max(best, entry.weight) : best;
+    }, 0);
+
+    return total + matchWeight;
+  }, 0);
+}
+
+export function getCategoryLabel(
+  category: CelebrationCategory | null,
+  locale: Locale
+): string | null {
+  if (!category) {
+    return null;
+  }
+
+  const labels: Record<Locale, Record<CelebrationCategory, string>> = {
+    sv: {
+      official: 'Officiell',
+      food: 'Fika/fest',
+      seasonal: 'Säsong',
+      observance: 'Högtid',
+      team: 'Intern',
+    },
+    en: {
+      official: 'Official',
+      food: 'Food',
+      seasonal: 'Seasonal',
+      observance: 'Observance',
+      team: 'Team',
+    },
+    'pt-BR': {
+      official: 'Oficial',
+      food: 'Comida',
+      seasonal: 'Sazonal',
+      observance: 'Observância',
+      team: 'Equipe',
+    },
+  };
+
+  return labels[locale][category];
+}
+
+export function getEngagementScoreLabel(score: number, locale: Locale): string {
+  if (locale === 'en') {
+    return `Celebration score ${score}/100`;
+  }
+
+  if (locale === 'pt-BR') {
+    return `Pontuação de celebração ${score}/100`;
+  }
+
+  return `Firarpoäng ${score}/100`;
+}
+
+export function scoreEngagementSnapshot(
+  date: Date,
+  contentPack: ContentPack
+): EngagementSnapshot {
+  const dayStatus = getDayStatus(date, contentPack);
+  const themeDays = getThemeDaysForDate(date);
+  const definition =
+    dayStatus.dayType === 'ordinary' ? null : getCelebrationDefinition(dayStatus.dayType);
+  const category = definition?.category ?? null;
+
+  let score = 6;
+
+  if (definition) {
+    score += 42 + Math.round(definition.priority / 4);
+    score += categoryWeight[definition.category];
+  }
+
+  if (themeDays.length > 0) {
+    score += Math.min(3, themeDays.length) * 10;
+    score += getThemeDayInterestBonus(themeDays);
+  }
+
+  if (getOfficialHolidays(date.getFullYear()).some((holiday) => holiday.dateLabel === formatForInput(date))) {
+    score += 10;
+  }
+
+  return {
+    date,
+    dayType: dayStatus.dayType,
+    themeDays,
+    category,
+    score: clampScore(score),
+  };
+}
+
+function pickWeighted<T>(
+  items: T[],
+  getWeight: (item: T) => number,
+  randomValue: number
+): T {
+  const total = items.reduce((sum, item) => sum + getWeight(item), 0);
+  let cursor = randomValue * total;
+
+  for (const item of items) {
+    cursor -= getWeight(item);
+    if (cursor <= 0) {
+      return item;
+    }
+  }
+
+  return items[items.length - 1];
+}
+
+export function pickSurpriseDate(
+  anchorDate: Date,
+  contentPack: ContentPack,
+  randomValue = Math.random()
+): EngagementSnapshot {
+  const yearStart = new Date(anchorDate.getFullYear(), 0, 1);
+  const candidates: EngagementSnapshot[] = [];
+
+  for (let offset = 0; offset < 366; offset += 1) {
+    const current = addDays(yearStart, offset);
+    if (current.getFullYear() !== anchorDate.getFullYear()) {
+      break;
+    }
+
+    const snapshot = scoreEngagementSnapshot(current, contentPack);
+    if (snapshot.score >= 45) {
+      candidates.push(snapshot);
+    }
+  }
+
+  if (candidates.length === 0) {
+    return scoreEngagementSnapshot(anchorDate, contentPack);
+  }
+
+  return pickWeighted(candidates, (candidate) => candidate.score, randomValue);
+}
+
+function containsFoodKeyword(themeDay: string): boolean {
+  return /fika|kanel|kaffe|semla|våff|vaff|kaka|bak|bulle|pizza|donut|glass|ost|choklad|lakrits/i.test(
+    themeDay
+  );
+}
+
+function getFallbackFikaItem(locale: Locale, mood: Mood): string {
+  if (locale === 'en') {
+    return mood === 'formal' ? 'coffee and a modest biscuit' : 'coffee and something sweet';
+  }
+
+  if (locale === 'pt-BR') {
+    return mood === 'formal' ? 'café e um biscoito discreto' : 'café e algo doce';
+  }
+
+  return mood === 'formal' ? 'kaffe och en diskret kaka' : 'kaffe och något sött';
+}
+
+export function getDailyFikaSuggestion(args: {
+  celebration: CelebrationDayType | null;
+  category: CelebrationCategory | null;
+  themeDays: string[];
+  locale: Locale;
+  mood: Mood;
+  score: number;
+}): FikaSuggestion {
+  const { celebration, category, themeDays, locale, mood, score } = args;
+  const celebrationSuggestion = celebration ? fikaByCelebration[celebration] : null;
+  const foodTheme = themeDays.find(containsFoodKeyword) ?? themeDays[0] ?? null;
+
+  const label =
+    locale === 'en'
+      ? "Today's fika excuse"
+      : locale === 'pt-BR'
+        ? 'Desculpa do dia para um fika'
+        : 'Dagens ursäkt att fika';
+
+  if (celebrationSuggestion) {
+    return {
+      label,
+      item: celebrationSuggestion.item,
+      score: Math.max(celebrationSuggestion.score, Math.min(10, Math.round(score / 10))),
+      note:
+        locale === 'en'
+          ? 'The date is already carrying enough ceremony to justify a proper pause.'
+          : locale === 'pt-BR'
+            ? 'A data já carrega cerimônia suficiente para justificar uma pausa decente.'
+            : 'Datumet bär redan tillräckligt mycket ceremoni för att motivera en ordentlig paus.',
+    };
+  }
+
+  if (foodTheme) {
+    return {
+      label,
+      item:
+        locale === 'en'
+          ? `something that fits ${foodTheme.toLowerCase()}`
+          : locale === 'pt-BR'
+            ? `algo que combine com ${foodTheme.toLowerCase()}`
+            : `något som passar till ${foodTheme.toLowerCase()}`,
+      score: Math.max(6, Math.min(9, Math.round(score / 10))),
+      note:
+        locale === 'en'
+          ? 'A food-leaning theme day is close enough to count as a legitimate fika angle.'
+          : locale === 'pt-BR'
+            ? 'Uma data temática puxada para comida já basta para virar um ângulo legítimo de fika.'
+            : 'En matnära temadag är tillräckligt mycket innehåll för att räknas som giltig fika-vinkel.',
+    };
+  }
+
+  return {
+    label,
+    item: getFallbackFikaItem(locale, mood),
+    score: category === 'official' ? 6 : 4,
+    note:
+      locale === 'en'
+        ? 'No pastry emergency is in progress, but a calm fika remains structurally defensible.'
+        : locale === 'pt-BR'
+          ? 'Nenhuma emergência de confeitaria está em curso, mas um fika tranquilo continua defensável.'
+          : 'Ingen akut bakverksfråga pågår, men en lugn fika är fortfarande strukturellt försvarbar.',
+  };
+}

--- a/fredagskoll-frontend/src/hooks/useAppShellState.ts
+++ b/fredagskoll-frontend/src/hooks/useAppShellState.ts
@@ -14,11 +14,11 @@ const initialExpandedSections: Record<MobileSectionKey, boolean> = {
   worldNationalDays: true,
 };
 
-type UseAppChromeArgs = {
+type UseAppShellStateArgs = {
   initialDate: Date;
 };
 
-export function useAppShellState({ initialDate }: UseAppChromeArgs) {
+export function useAppShellState({ initialDate }: UseAppShellStateArgs) {
   const [locale, setLocale] = useState<Locale>(getInitialLocale);
   const [darkMode, setDarkMode] = useState(getInitialDarkMode);
   const [showLanguageMenu, setShowLanguageMenu] = useState(false);
@@ -66,6 +66,25 @@ export function useAppShellState({ initialDate }: UseAppChromeArgs) {
     shouldScrollAfterDateCommitRef.current = isMobileLayout;
   }
 
+  function jumpToDate(
+    nextDate: string,
+    mainCardRef?: RefObject<HTMLElement | null>
+  ): void {
+    setSelectedDate(nextDate);
+    shouldScrollAfterDateCommitRef.current = false;
+
+    if (!isMobileLayout || !mainCardRef || typeof window === 'undefined') {
+      return;
+    }
+
+    window.setTimeout(() => {
+      mainCardRef.current?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'start',
+      });
+    }, 120);
+  }
+
   function handleDateCommit(mainCardRef: RefObject<HTMLElement | null>): void {
     if (
       !isMobileLayout ||
@@ -109,6 +128,7 @@ export function useAppShellState({ initialDate }: UseAppChromeArgs) {
     setShowReleaseNotes,
     handleDateChange,
     handleDateCommit,
+    jumpToDate,
     toggleMobileSection,
   };
 }

--- a/fredagskoll-frontend/src/releaseNotes.ts
+++ b/fredagskoll-frontend/src/releaseNotes.ts
@@ -8,6 +8,19 @@ export type ReleaseNote = {
 
 export const releaseNotes: ReleaseNote[] = [
   {
+    version: '0.1.32',
+    shortSummary: {
+      sv: 'Appen hjälper nu mer aktivt till att hitta bättre dagar att fira.',
+      en: 'The app now helps you find better days to celebrate.',
+      'pt-BR': 'O app agora ajuda melhor a encontrar dias mais interessantes para celebrar.',
+    },
+    summary: {
+      sv: 'Appen har fått ett överraskningsläge för att hoppa till mer firvärda datum, synliga kategorier för olika slags firardagar, en tydligare firarpoäng och en ny liten fika-panel som gör dagens anledning mer lekfull. Tanken är att det ska kännas roligare att utforska kalendern, inte bara slå upp ett datum och gå vidare.',
+      en: 'The app now includes a surprise mode for jumping to more celebration-worthy dates, visible celebration categories, a clearer celebration score, and a small fika panel that makes the daily excuse more playful. The goal is to make exploring the calendar more fun instead of only checking a date and leaving.',
+      'pt-BR': 'O app agora inclui um modo surpresa para pular para datas mais celebráveis, categorias visíveis para os tipos de celebração, uma pontuação mais clara e um pequeno painel de fika que deixa a desculpa do dia mais divertida. A ideia é tornar a exploração do calendário mais prazerosa, em vez de só consultar uma data e ir embora.',
+    },
+  },
+  {
     version: '0.1.31',
     shortSummary: {
       sv: 'Frontendens verktygslåda kör nu på Vite i stället för CRA.',

--- a/fredagskoll-frontend/src/styles/content.css
+++ b/fredagskoll-frontend/src/styles/content.css
@@ -48,6 +48,14 @@
   min-width: 0;
 }
 
+.card-kicker-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: start;
+  flex-wrap: wrap;
+}
+
 .card-date {
   margin: 0;
   text-align: center;

--- a/fredagskoll-frontend/src/styles/layout.css
+++ b/fredagskoll-frontend/src/styles/layout.css
@@ -413,6 +413,116 @@
   max-width: 28ch;
 }
 
+.surprise-button {
+  border: 0;
+  border-radius: var(--mood-chip-radius);
+  background: linear-gradient(135deg, var(--tone-accent), color-mix(in srgb, var(--tone-accent) 62%, white));
+  color: #fff9f1;
+  padding: 0.85rem 1rem;
+  font-size: 0.92rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition:
+    transform 220ms ease,
+    filter 220ms ease,
+    box-shadow 220ms ease;
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.16), var(--mood-outline);
+}
+
+.surprise-button:hover {
+  transform: translateY(-1px);
+  filter: saturate(1.06) brightness(1.02);
+}
+
+.surprise-hint {
+  margin: -0.45rem 0 0;
+  color: var(--muted);
+  font-size: 0.88rem;
+  line-height: 1.38;
+}
+
+.card-kicker-metrics {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.mood-pill--category,
+.mood-pill--score {
+  color: var(--mood-button-text);
+  background: var(--mood-button-bg);
+}
+
+.engagement-panel {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.engagement-metrics {
+  display: flex;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+}
+
+.engagement-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.45rem 0.8rem;
+  border-radius: var(--mood-chip-radius);
+  background: var(--mood-button-bg);
+  color: var(--mood-button-text);
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--tone-accent) 24%, transparent),
+    var(--mood-badge-shadow);
+}
+
+.engagement-chip--score {
+  background: color-mix(in srgb, var(--tone-soft) 82%, rgba(255, 255, 255, 0.32));
+  color: var(--tone-ink-text);
+}
+
+.fika-card {
+  padding: 1.15rem 1.25rem;
+  border-radius: var(--mood-subpanel-radius);
+  background:
+    linear-gradient(135deg, var(--mood-panel-tint), transparent 72%),
+    linear-gradient(90deg, transparent 0 0.8rem, color-mix(in srgb, var(--tone-accent) 9%, transparent) 0.8rem 100%),
+    var(--accent-soft);
+  border: 1px solid color-mix(in srgb, var(--panel-border) 74%, var(--mood-panel-border) 26%);
+  box-shadow: var(--mood-outline);
+  display: grid;
+  gap: 0.4rem;
+}
+
+.fika-item,
+.fika-score,
+.fika-note {
+  margin: 0;
+}
+
+.fika-item {
+  font-size: 1.1rem;
+  font-weight: 800;
+  color: var(--text);
+}
+
+.fika-score {
+  font-size: 0.9rem;
+  font-weight: 800;
+  color: var(--tone-accent-text);
+}
+
+.fika-note {
+  color: var(--muted);
+  line-height: 1.42;
+}
+
 .nameday-card {
   display: grid;
   gap: 0.45rem;

--- a/fredagskoll-frontend/src/styles/responsive.css
+++ b/fredagskoll-frontend/src/styles/responsive.css
@@ -48,9 +48,19 @@
     font-size: 0.88rem;
   }
 
+  .card-kicker-row,
+  .card-kicker-metrics,
+  .engagement-metrics {
+    justify-content: flex-start;
+  }
+
   .theme-toggle {
     padding: 0.68rem 0.85rem;
     font-size: 0.84rem;
+  }
+
+  .surprise-button {
+    width: 100%;
   }
 
   .intro-controls {


### PR DESCRIPTION
## Summary
- add a surprise date action, engagement scoring, category labels, and a fika excuse panel
- expose the new engagement surfaces in the intro panel and main card UI
- document Phase 2 work and bump the frontend to 0.1.32

## Testing
- npm test -- src/features/engagement/engagement.test.ts src/App.test.tsx
- npm run build

Closes #71
Closes #72
Closes #75
Closes #77